### PR TITLE
feat: add core types and 9 typed error classes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,7 +38,10 @@ export class CassetteCollisionError extends ShellCassetteError {
 export class CassetteIOError extends ShellCassetteError {
   static override code = 'CASSETTE_IO'
 
-  constructor(message: string, public override readonly cause: Error) {
+  constructor(
+    message: string,
+    public override readonly cause: Error,
+  ) {
     super(message)
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,48 @@
+export class ShellCassetteError extends Error {
+  static code = 'CASSETTE_GENERIC'
+
+  constructor(message: string) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
+export class AckRequiredError extends ShellCassetteError {
+  static override code = 'CASSETTE_ACK_REQUIRED'
+}
+
+export class UnsupportedOptionError extends ShellCassetteError {
+  static override code = 'CASSETTE_UNSUPPORTED_OPTION'
+}
+
+export class ReplayMissError extends ShellCassetteError {
+  static override code = 'CASSETTE_REPLAY_MISS'
+}
+
+export class ConcurrencyError extends ShellCassetteError {
+  static override code = 'CASSETTE_CONCURRENT'
+}
+
+export class BinaryOutputError extends ShellCassetteError {
+  static override code = 'CASSETTE_BINARY_OUTPUT'
+}
+
+export class CassetteCorruptError extends ShellCassetteError {
+  static override code = 'CASSETTE_CORRUPT'
+}
+
+export class CassetteCollisionError extends ShellCassetteError {
+  static override code = 'CASSETTE_COLLISION'
+}
+
+export class CassetteIOError extends ShellCassetteError {
+  static override code = 'CASSETTE_IO'
+
+  constructor(message: string, public override readonly cause: Error) {
+    super(message)
+  }
+}
+
+export class CassetteConfigError extends ShellCassetteError {
+  static override code = 'CASSETTE_CONFIG'
+}

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -1,0 +1,12 @@
+export function cleanStack(stack: string | undefined): string {
+  if (!stack) return ''
+  const lines = stack.split('\n')
+  const filtered = lines.filter((line) => !line.includes('/shell-cassette/'))
+  return filtered.join('\n')
+}
+
+export function cleanErrorStack(error: Error): void {
+  if (error.stack) {
+    error.stack = cleanStack(error.stack)
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type Call = {
   args: readonly string[]
   cwd: string | null
   env: Record<string, string>
-  stdin: null  // v0.1: stdin not supported
+  stdin: null // v0.1: stdin not supported
 }
 
 export type Result = {
@@ -33,7 +33,7 @@ export type CassetteSession = {
   path: string
   scopeDefault: 'auto' | 'passthrough'
   loadedFile: CassetteFile | null
-  matcher: MatcherStateLike | null  // built lazily; defined in matcher.ts
+  matcher: MatcherStateLike | null // built lazily; defined in matcher.ts
   newRecordings: Recording[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,43 @@
+export type Mode = 'record' | 'replay' | 'auto' | 'passthrough'
+
+export type Call = {
+  command: string
+  args: readonly string[]
+  cwd: string | null
+  env: Record<string, string>
+  stdin: null  // v0.1: stdin not supported
+}
+
+export type Result = {
+  stdoutLines: string[]
+  stderrLines: string[]
+  exitCode: number
+  signal: string | null
+  durationMs: number
+}
+
+export type Recording = {
+  call: Call
+  result: Result
+}
+
+export type CassetteFile = {
+  version: 1
+  recordings: Recording[]
+}
+
+export type MatcherFn = (call: Call, recording: Recording) => boolean
+
+export type CassetteSession = {
+  name: string
+  path: string
+  scopeDefault: 'auto' | 'passthrough'
+  loadedFile: CassetteFile | null
+  matcher: MatcherStateLike | null  // built lazily; defined in matcher.ts
+  newRecordings: Recording[]
+}
+
+// Forward-declared interface; implemented in matcher.ts
+export interface MatcherStateLike {
+  findMatch(call: Call): Recording | null
+}

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from 'vitest'
 import {
-  ShellCassetteError,
   AckRequiredError,
-  UnsupportedOptionError,
-  ReplayMissError,
-  ConcurrencyError,
   BinaryOutputError,
-  CassetteCorruptError,
   CassetteCollisionError,
-  CassetteIOError,
   CassetteConfigError,
+  CassetteCorruptError,
+  CassetteIOError,
+  ConcurrencyError,
+  ReplayMissError,
+  ShellCassetteError,
+  UnsupportedOptionError,
 } from '../../src/errors.js'
 
 describe('error classes', () => {

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import {
+  ShellCassetteError,
+  AckRequiredError,
+  UnsupportedOptionError,
+  ReplayMissError,
+  ConcurrencyError,
+  BinaryOutputError,
+  CassetteCorruptError,
+  CassetteCollisionError,
+  CassetteIOError,
+  CassetteConfigError,
+} from '../../src/errors.js'
+
+describe('error classes', () => {
+  test('all errors inherit from ShellCassetteError', () => {
+    expect(new AckRequiredError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new UnsupportedOptionError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new ReplayMissError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new ConcurrencyError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new BinaryOutputError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new CassetteCorruptError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new CassetteCollisionError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new CassetteIOError('msg', new Error('cause'))).toBeInstanceOf(ShellCassetteError)
+    expect(new CassetteConfigError('msg')).toBeInstanceOf(ShellCassetteError)
+  })
+
+  test('all errors have stable code strings', () => {
+    expect(AckRequiredError.code).toBe('CASSETTE_ACK_REQUIRED')
+    expect(UnsupportedOptionError.code).toBe('CASSETTE_UNSUPPORTED_OPTION')
+    expect(ReplayMissError.code).toBe('CASSETTE_REPLAY_MISS')
+    expect(ConcurrencyError.code).toBe('CASSETTE_CONCURRENT')
+    expect(BinaryOutputError.code).toBe('CASSETTE_BINARY_OUTPUT')
+    expect(CassetteCorruptError.code).toBe('CASSETTE_CORRUPT')
+    expect(CassetteCollisionError.code).toBe('CASSETTE_COLLISION')
+    expect(CassetteIOError.code).toBe('CASSETTE_IO')
+    expect(CassetteConfigError.code).toBe('CASSETTE_CONFIG')
+  })
+
+  test('CassetteIOError preserves cause', () => {
+    const cause = new Error('disk full')
+    const err = new CassetteIOError('failed to write', cause)
+    expect(err.cause).toBe(cause)
+  })
+
+  test('all errors have name matching class name', () => {
+    expect(new AckRequiredError('').name).toBe('AckRequiredError')
+    expect(new ReplayMissError('').name).toBe('ReplayMissError')
+  })
+})

--- a/tests/unit/stack.test.ts
+++ b/tests/unit/stack.test.ts
@@ -15,7 +15,7 @@ describe('cleanStack', () => {
   })
 
   test('returns input unchanged if no shell-cassette frames', () => {
-    const input = `Error: boom\n    at fn (/path/to/file.ts:5:10)`
+    const input = 'Error: boom\n    at fn (/path/to/file.ts:5:10)'
     expect(cleanStack(input)).toBe(input)
   })
 

--- a/tests/unit/stack.test.ts
+++ b/tests/unit/stack.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { cleanStack } from '../../src/stack.js'
+
+describe('cleanStack', () => {
+  test('removes lines containing /shell-cassette/', () => {
+    const input = `Error: boom
+    at userFn (/Users/me/app/test.ts:5:10)
+    at Object.<anonymous> (/Users/me/app/node_modules/shell-cassette/dist/execa.js:42:8)
+    at runTest (/Users/me/app/test.ts:10:3)`
+
+    const output = cleanStack(input)
+    expect(output).toContain('userFn')
+    expect(output).toContain('runTest')
+    expect(output).not.toContain('shell-cassette')
+  })
+
+  test('returns input unchanged if no shell-cassette frames', () => {
+    const input = `Error: boom\n    at fn (/path/to/file.ts:5:10)`
+    expect(cleanStack(input)).toBe(input)
+  })
+
+  test('returns empty string for empty input', () => {
+    expect(cleanStack('')).toBe('')
+  })
+
+  test('handles undefined gracefully', () => {
+    expect(cleanStack(undefined)).toBe('')
+  })
+})


### PR DESCRIPTION
## What Changed

- Define core types: Mode union, Call, Result, Recording, CassetteFile, CassetteSession, MatcherFn, MatcherStateLike (forward-declared interface).
- Add 9 error classes inheriting from ShellCassetteError: AckRequired, UnsupportedOption, ReplayMiss, Concurrency, BinaryOutput, CassetteCorrupt, CassetteCollision, CassetteIO, CassetteConfig. Each has a `static code` for programmatic handling. CassetteIOError preserves `cause` for native fs errors.
- Add stack trace cleanup helper: `cleanStack(string|undefined): string` filters /shell-cassette/ frames; `cleanErrorStack(Error): void` mutates an error's stack property.
- Add .gitattributes for cross-platform LF enforcement and apply biome formatting (import sorting, single-quote literals, multi-line constructor signatures).

## Test Plan

- [x] `npm test` (8/8 passing: errors 4, stack 4)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean
- [x] All 9 error classes inherit ShellCassetteError, correct static code
- [x] CassetteIOError uses `override` modifier on `cause` (ES2022 base Error has cause field; strict mode requires explicit override)