### PR TITLE
feat: add pure utility components (mode, options, paths, serialize, redact, log)

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,4 @@
+export function log(message: string): void {
+  if (process.env.SHELL_CASSETTE_LOG === 'silent') return
+  process.stderr.write(`shell-cassette: ${message}\n`)
+}

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -1,0 +1,17 @@
+import type { Mode } from './types.js'
+
+const VALID_MODES: ReadonlySet<Mode> = new Set(['record', 'replay', 'auto', 'passthrough'])
+
+export function resolveMode(
+  envVar: string | undefined,
+  isCI: boolean,
+  scopeDefault: 'auto' | 'passthrough',
+): Mode {
+  if (envVar && VALID_MODES.has(envVar as Mode)) {
+    return envVar as Mode
+  }
+  if (isCI) {
+    return 'replay'
+  }
+  return scopeDefault
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,31 @@
+import { UnsupportedOptionError } from './errors.js'
+
+export function validateOptions(options: Record<string, unknown> | undefined): void {
+  if (!options) return
+
+  if (options.buffer === false) {
+    throw new UnsupportedOptionError(
+      'execa option `buffer: false` (streaming) not supported in v0.1. Planned for v1.0.',
+    )
+  }
+  if (options.ipc === true) {
+    throw new UnsupportedOptionError(
+      'execa option `ipc: true` not supported in v0.1. Planned for v1.0.',
+    )
+  }
+  if (options.inputFile !== undefined && options.inputFile !== null) {
+    throw new UnsupportedOptionError(
+      'execa option `inputFile` not supported in v0.1. Planned for v1.0.',
+    )
+  }
+  if (options.input !== undefined && options.input !== null) {
+    throw new UnsupportedOptionError(
+      'execa option `input` (stdin) not supported in v0.1. Buffered stdin planned for v0.2.',
+    )
+  }
+  if (options.node === true) {
+    throw new UnsupportedOptionError(
+      'execa option `node: true` (execaNode) not supported in v0.1. Planned for v0.2.',
+    )
+  }
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto'
+import path from 'node:path'
+import { CassetteIOError } from './errors.js'
+
+const MAX_NAME_LENGTH = 80
+const HASH_SUFFIX_LENGTH = 6
+const MAX_PATH_LENGTH = 240
+
+function shortHash(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, HASH_SUFFIX_LENGTH)
+}
+
+export function sanitizeName(input: string): string {
+  if (!input) return 'untitled'
+
+  // NFKD normalize, drop combining marks (accents)
+  const normalized = input.normalize('NFKD').replace(/\p{M}/gu, '')
+  // Strip non-ASCII
+  const ascii = normalized.replace(/[^\x20-\x7E]/g, '')
+  // Lowercase, replace non-alphanumeric with dashes, collapse
+  const slug = ascii
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  if (!slug) return 'untitled'
+
+  if (slug.length > MAX_NAME_LENGTH) {
+    const truncated = slug.slice(0, MAX_NAME_LENGTH)
+    return `${truncated}-${shortHash(input)}`
+  }
+
+  return slug
+}
+
+export function cassettePath(
+  testFile: string,
+  describePath: readonly string[],
+  testName: string,
+  cassetteDir: string,
+): string {
+  const dir = path.posix.dirname(testFile)
+  const fileBasename = path.posix.basename(testFile)
+  const sanitizedDescribe = describePath.map(sanitizeName)
+  const sanitizedTest = sanitizeName(testName)
+
+  const fullPath = path.posix.join(
+    dir,
+    cassetteDir,
+    fileBasename,
+    ...sanitizedDescribe,
+    `${sanitizedTest}.json`,
+  )
+
+  if (fullPath.length > MAX_PATH_LENGTH) {
+    throw new CassetteIOError(
+      `cassette path exceeds ${MAX_PATH_LENGTH} chars (Windows MAX_PATH safety): ${fullPath}`,
+      new Error('PathTooLong'),
+    )
+  }
+
+  return fullPath
+}

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,51 @@
+const LONG_VALUE_THRESHOLD = 100
+
+export const CURATED_KEYS = [
+  'TOKEN',
+  'SECRET',
+  'PASSWORD',
+  'PASSWD',
+  'APIKEY',
+  'API_KEY',
+  'CREDENTIAL',
+  'PRIVATE_KEY',
+  'AUTH_TOKEN',
+  'BEARER_TOKEN',
+  'JWT',
+] as const
+
+export type RedactConfig = {
+  redactEnvKeys: string[]
+}
+
+export type RedactResult = {
+  redacted: Record<string, string>
+  redactedKeys: string[]
+  warnings: string[]
+}
+
+export function redactEnv(env: Record<string, string>, config: RedactConfig): RedactResult {
+  const allKeys = [...CURATED_KEYS, ...config.redactEnvKeys]
+  const redacted: Record<string, string> = {}
+  const redactedKeys: string[] = []
+  const warnings: string[] = []
+
+  for (const [key, value] of Object.entries(env)) {
+    const upper = key.toUpperCase()
+    const isSensitive = allKeys.some((k) => upper.includes(k.toUpperCase()))
+
+    if (isSensitive) {
+      redacted[key] = '<redacted>'
+      redactedKeys.push(key)
+    } else {
+      redacted[key] = value
+      if (value.length > LONG_VALUE_THRESHOLD) {
+        warnings.push(
+          `env var ${key} has ${value.length}-char value, not in curated/configured list. Review before commit.`,
+        )
+      }
+    }
+  }
+
+  return { redacted, redactedKeys, warnings }
+}

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,0 +1,83 @@
+import { BinaryOutputError, CassetteCorruptError } from './errors.js'
+import type { CassetteFile, Recording } from './types.js'
+
+const SCHEMA_VERSION = 1
+
+export function serialize(file: CassetteFile): string {
+  validateBeforeSerialize(file)
+  // Build object in canonical key order for stable diffs
+  const ordered = {
+    version: file.version,
+    recordings: file.recordings.map(orderRecording),
+  }
+  return `${JSON.stringify(ordered, null, 2)}\n`
+}
+
+function orderRecording(rec: Recording) {
+  return {
+    call: {
+      command: rec.call.command,
+      args: rec.call.args,
+      cwd: rec.call.cwd,
+      env: rec.call.env,
+      stdin: rec.call.stdin,
+    },
+    result: {
+      stdoutLines: rec.result.stdoutLines,
+      stderrLines: rec.result.stderrLines,
+      exitCode: rec.result.exitCode,
+      signal: rec.result.signal,
+      durationMs: rec.result.durationMs,
+    },
+  }
+}
+
+function validateBeforeSerialize(file: CassetteFile): void {
+  for (const rec of file.recordings) {
+    for (const line of rec.result.stdoutLines) {
+      if (typeof line !== 'string') {
+        throw new BinaryOutputError(
+          `cannot serialize non-string in stdoutLines for ${rec.call.command}; v0.1 supports UTF-8 text only`,
+        )
+      }
+    }
+    for (const line of rec.result.stderrLines) {
+      if (typeof line !== 'string') {
+        throw new BinaryOutputError(
+          `cannot serialize non-string in stderrLines for ${rec.call.command}; v0.1 supports UTF-8 text only`,
+        )
+      }
+    }
+  }
+}
+
+export function deserialize(text: string): CassetteFile {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    throw new CassetteCorruptError(`invalid JSON: ${(e as Error).message}`)
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new CassetteCorruptError('cassette must be a JSON object')
+  }
+
+  const obj = parsed as Record<string, unknown>
+  if (!('version' in obj)) {
+    throw new CassetteCorruptError('cassette missing `version` field')
+  }
+  if (obj.version !== SCHEMA_VERSION) {
+    throw new CassetteCorruptError(
+      `cassette version ${obj.version} unknown; expected ${SCHEMA_VERSION}. Delete and re-record.`,
+    )
+  }
+  if (!Array.isArray(obj.recordings)) {
+    throw new CassetteCorruptError('cassette `recordings` must be an array')
+  }
+
+  return {
+    version: SCHEMA_VERSION,
+    recordings: obj.recordings as Recording[],
+  }
+}

--- a/tests/fixtures/cassettes/malformed.json
+++ b/tests/fixtures/cassettes/malformed.json
@@ -1,0 +1,1 @@
+{ this is not valid JSON

--- a/tests/fixtures/cassettes/no-version.json
+++ b/tests/fixtures/cassettes/no-version.json
@@ -1,0 +1,3 @@
+{
+  "recordings": []
+}

--- a/tests/fixtures/cassettes/unknown-version.json
+++ b/tests/fixtures/cassettes/unknown-version.json
@@ -1,0 +1,4 @@
+{
+  "version": 999,
+  "recordings": []
+}

--- a/tests/fixtures/cassettes/valid-v1-empty.json
+++ b/tests/fixtures/cassettes/valid-v1-empty.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "recordings": []
+}

--- a/tests/fixtures/cassettes/valid-v1-single.json
+++ b/tests/fixtures/cassettes/valid-v1-single.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "recordings": [
+    {
+      "call": {
+        "command": "git",
+        "args": ["status", "--porcelain"],
+        "cwd": "/tmp/repo",
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": ["M src/foo.ts", "?? src/bar.ts", ""],
+        "stderrLines": [""],
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 142
+      }
+    }
+  ]
+}

--- a/tests/unit/log.test.ts
+++ b/tests/unit/log.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { log } from '../../src/log.js'
+
+describe('log', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  const originalEnv = process.env.SHELL_CASSETTE_LOG
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+    if (originalEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: env var must be unset, not stringified to "undefined"
+      delete process.env.SHELL_CASSETTE_LOG
+    } else {
+      process.env.SHELL_CASSETTE_LOG = originalEnv
+    }
+  })
+
+  test('writes to stderr with shell-cassette: prefix', () => {
+    // biome-ignore lint/performance/noDelete: env var must be unset, not stringified to "undefined"
+    delete process.env.SHELL_CASSETTE_LOG
+    log('hello world')
+    expect(stderrSpy).toHaveBeenCalledOnce()
+    const call = stderrSpy.mock.calls[0]?.[0] as string
+    expect(call).toMatch(/^shell-cassette: hello world\n$/)
+  })
+
+  test('SHELL_CASSETTE_LOG=silent suppresses output', () => {
+    process.env.SHELL_CASSETTE_LOG = 'silent'
+    log('should not appear')
+    expect(stderrSpy).not.toHaveBeenCalled()
+  })
+
+  test('any value other than silent emits normally', () => {
+    process.env.SHELL_CASSETTE_LOG = 'verbose'
+    log('shown')
+    expect(stderrSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/mode.test.ts
+++ b/tests/unit/mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { resolveMode } from '../../src/mode.js'
+
+describe('resolveMode', () => {
+  test('returns scopeDefault when no env vars set', () => {
+    expect(resolveMode(undefined, false, 'auto')).toBe('auto')
+    expect(resolveMode(undefined, false, 'passthrough')).toBe('passthrough')
+  })
+
+  test('SHELL_CASSETTE_MODE env var wins over everything', () => {
+    expect(resolveMode('record', true, 'auto')).toBe('record')
+    expect(resolveMode('replay', false, 'auto')).toBe('replay')
+    expect(resolveMode('passthrough', true, 'auto')).toBe('passthrough')
+    expect(resolveMode('auto', true, 'passthrough')).toBe('auto')
+  })
+
+  test('CI=true forces replay-strict when no env override', () => {
+    expect(resolveMode(undefined, true, 'auto')).toBe('replay')
+    expect(resolveMode(undefined, true, 'passthrough')).toBe('replay')
+  })
+
+  test('invalid env var values fall through to next priority', () => {
+    expect(resolveMode('invalid-mode', false, 'auto')).toBe('auto')
+    expect(resolveMode('', false, 'auto')).toBe('auto')
+    expect(resolveMode('invalid-mode', true, 'auto')).toBe('replay')
+  })
+})

--- a/tests/unit/options.test.ts
+++ b/tests/unit/options.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+import { UnsupportedOptionError } from '../../src/errors.js'
+import { validateOptions } from '../../src/options.js'
+
+describe('validateOptions', () => {
+  test('passes for empty options', () => {
+    expect(() => validateOptions({})).not.toThrow()
+    expect(() => validateOptions(undefined)).not.toThrow()
+  })
+
+  test('passes for supported options', () => {
+    expect(() => validateOptions({ cwd: '/tmp', env: {} })).not.toThrow()
+    expect(() => validateOptions({ reject: true })).not.toThrow()
+    expect(() => validateOptions({ lines: true })).not.toThrow()
+    expect(() => validateOptions({ timeout: 5000 })).not.toThrow()
+  })
+
+  test('throws on buffer:false', () => {
+    expect(() => validateOptions({ buffer: false })).toThrow(UnsupportedOptionError)
+    expect(() => validateOptions({ buffer: false })).toThrow(/buffer/)
+  })
+
+  test('throws on ipc:true', () => {
+    expect(() => validateOptions({ ipc: true })).toThrow(UnsupportedOptionError)
+  })
+
+  test('throws on inputFile', () => {
+    expect(() => validateOptions({ inputFile: '/tmp/x' })).toThrow(UnsupportedOptionError)
+  })
+
+  test('throws on input (stdin)', () => {
+    expect(() => validateOptions({ input: 'data' })).toThrow(UnsupportedOptionError)
+  })
+
+  test('throws on node:true (execaNode)', () => {
+    expect(() => validateOptions({ node: true })).toThrow(UnsupportedOptionError)
+  })
+
+  test('error message includes the option name and target version', () => {
+    try {
+      validateOptions({ ipc: true })
+    } catch (e) {
+      expect((e as Error).message).toContain('ipc')
+      expect((e as Error).message).toContain('v1.0')
+    }
+  })
+})

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { CassetteIOError } from '../../src/errors.js'
+import { cassettePath, sanitizeName } from '../../src/paths.js'
+
+describe('sanitizeName', () => {
+  test('preserves simple names', () => {
+    expect(sanitizeName('finds-current-branch')).toBe('finds-current-branch')
+  })
+
+  test('lowercases and kebab-cases spaces', () => {
+    expect(sanitizeName('Finds Current Branch')).toBe('finds-current-branch')
+  })
+
+  test('strips non-ASCII via NFKD normalize', () => {
+    // "café" → "cafe" via NFKD
+    expect(sanitizeName('Visits café')).toBe('visits-cafe')
+  })
+
+  test('replaces special characters with dashes', () => {
+    expect(sanitizeName('handles "quoted" strings & special!')).toBe(
+      'handles-quoted-strings-special',
+    )
+  })
+
+  test('collapses consecutive dashes', () => {
+    expect(sanitizeName('--foo--bar--')).toBe('foo-bar')
+  })
+
+  test('truncates to 80 chars with hash suffix', () => {
+    const long = 'a'.repeat(100)
+    const result = sanitizeName(long)
+    expect(result.length).toBeLessThanOrEqual(80 + 7) // 80 + '-' + 6-char hash
+    expect(result).toMatch(/^a+-[a-f0-9]{6}$/)
+  })
+
+  test('different long inputs yield different hash suffixes', () => {
+    const a = sanitizeName('a'.repeat(100))
+    const b = sanitizeName('b'.repeat(100))
+    expect(a).not.toBe(b)
+  })
+
+  test('handles empty string with placeholder', () => {
+    expect(sanitizeName('')).toBe('untitled')
+  })
+})
+
+describe('cassettePath', () => {
+  test('builds path next to test file in __cassettes__/', () => {
+    const result = cassettePath('/repo/src/foo.test.ts', [], 'my test', '__cassettes__')
+    expect(result).toBe('/repo/src/__cassettes__/foo.test.ts/my-test.json')
+  })
+
+  test('includes describe path as nested directories', () => {
+    const result = cassettePath(
+      '/repo/src/foo.test.ts',
+      ['outer', 'inner'],
+      'leaf',
+      '__cassettes__',
+    )
+    expect(result).toBe('/repo/src/__cassettes__/foo.test.ts/outer/inner/leaf.json')
+  })
+
+  test('sanitizes describe and test name segments', () => {
+    const result = cassettePath(
+      '/repo/src/foo.test.ts',
+      ['Has Spaces'],
+      'My Test!',
+      '__cassettes__',
+    )
+    expect(result).toBe('/repo/src/__cassettes__/foo.test.ts/has-spaces/my-test.json')
+  })
+
+  test('throws CassetteIOError if total path > 240 chars (Windows safe)', () => {
+    const longTestPath = `/repo/${'a'.repeat(300)}/foo.test.ts`
+    expect(() => cassettePath(longTestPath, [], 'test', '__cassettes__')).toThrow(CassetteIOError)
+  })
+})

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest'
+import { CURATED_KEYS, redactEnv } from '../../src/redact.js'
+
+const defaultConfig = { redactEnvKeys: [] as string[] }
+
+describe('redactEnv (curated list)', () => {
+  test('redacts TOKEN, SECRET, PASSWORD, JWT keys', () => {
+    const env = {
+      MY_TOKEN: 'abc',
+      USER_SECRET: 'def',
+      DB_PASSWORD: 'ghi',
+      JWT_KEY: 'jkl',
+      SAFE_VAR: 'public',
+    }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.redacted.MY_TOKEN).toBe('<redacted>')
+    expect(result.redacted.USER_SECRET).toBe('<redacted>')
+    expect(result.redacted.DB_PASSWORD).toBe('<redacted>')
+    expect(result.redacted.JWT_KEY).toBe('<redacted>')
+    expect(result.redacted.SAFE_VAR).toBe('public')
+    expect(result.redactedKeys).toEqual(
+      expect.arrayContaining(['MY_TOKEN', 'USER_SECRET', 'DB_PASSWORD', 'JWT_KEY']),
+    )
+  })
+
+  test('case-insensitive substring match', () => {
+    const env = { my_token_value: 'abc', SeCrEt: 'def' }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.redacted.my_token_value).toBe('<redacted>')
+    expect(result.redacted.SeCrEt).toBe('<redacted>')
+  })
+
+  test('does not redact PUBLIC_KEY (curated has PRIVATE_KEY only)', () => {
+    const env = { PUBLIC_KEY: 'pubdata', PRIVATE_KEY: 'privdata' }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.redacted.PUBLIC_KEY).toBe('pubdata')
+    expect(result.redacted.PRIVATE_KEY).toBe('<redacted>')
+  })
+
+  test('does not redact bare KEY-suffix names like STRIPE_KEY (documented gap)', () => {
+    const env = { STRIPE_KEY: 'sk_live_xyz', OPENAI_KEY: 'sk-abc' }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.redacted.STRIPE_KEY).toBe('sk_live_xyz')
+    expect(result.redacted.OPENAI_KEY).toBe('sk-abc')
+  })
+})
+
+describe('redactEnv (user-extended via config)', () => {
+  test('config.redactEnvKeys adds to curated list', () => {
+    const env = { STRIPE_KEY: 'sk_live_xyz', NORMAL: 'safe' }
+    const result = redactEnv(env, { redactEnvKeys: ['STRIPE_KEY'] })
+    expect(result.redacted.STRIPE_KEY).toBe('<redacted>')
+    expect(result.redacted.NORMAL).toBe('safe')
+  })
+
+  test('config keys are case-insensitive substring like curated', () => {
+    const env = { my_stripe_key: 'sk', X: 'safe' }
+    const result = redactEnv(env, { redactEnvKeys: ['STRIPE'] })
+    expect(result.redacted.my_stripe_key).toBe('<redacted>')
+  })
+
+  test('curated still applies when user adds extras', () => {
+    const env = { TOKEN: 'a', STRIPE_KEY: 'b' }
+    const result = redactEnv(env, { redactEnvKeys: ['STRIPE'] })
+    expect(result.redacted.TOKEN).toBe('<redacted>')
+    expect(result.redacted.STRIPE_KEY).toBe('<redacted>')
+  })
+})
+
+describe('redactEnv (length warnings)', () => {
+  test('emits warning for unredacted env value > 100 chars', () => {
+    const env = { LONG_VAR: 'a'.repeat(150) }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.warnings.length).toBe(1)
+    expect(result.warnings[0]).toContain('LONG_VAR')
+    expect(result.warnings[0]).toContain('150')
+  })
+
+  test('no warning at exactly 100 chars', () => {
+    const env = { VAR: 'a'.repeat(100) }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.warnings.length).toBe(0)
+  })
+
+  test('warning at 101 chars', () => {
+    const env = { VAR: 'a'.repeat(101) }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.warnings.length).toBe(1)
+  })
+
+  test('no warning for redacted long values', () => {
+    const env = { GH_TOKEN: 'a'.repeat(150) }
+    const result = redactEnv(env, defaultConfig)
+    expect(result.warnings.length).toBe(0)
+  })
+})
+
+describe('CURATED_KEYS exposed for testing/inspection', () => {
+  test('contains expected items', () => {
+    const expected = [
+      'TOKEN',
+      'SECRET',
+      'PASSWORD',
+      'PASSWD',
+      'APIKEY',
+      'API_KEY',
+      'CREDENTIAL',
+      'PRIVATE_KEY',
+      'AUTH_TOKEN',
+      'BEARER_TOKEN',
+      'JWT',
+    ]
+    for (const key of expected) {
+      expect(CURATED_KEYS).toContain(key)
+    }
+  })
+})

--- a/tests/unit/serialize.test.ts
+++ b/tests/unit/serialize.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, test } from 'vitest'
+import { BinaryOutputError, CassetteCorruptError } from '../../src/errors.js'
+import { deserialize, serialize } from '../../src/serialize.js'
+import type { CassetteFile } from '../../src/types.js'
+
+const fixture = (name: string) => readFileSync(`tests/fixtures/cassettes/${name}.json`, 'utf8')
+
+describe('deserialize', () => {
+  test('parses valid v1 empty cassette', () => {
+    const result = deserialize(fixture('valid-v1-empty'))
+    expect(result.version).toBe(1)
+    expect(result.recordings).toEqual([])
+  })
+
+  test('parses valid v1 single recording', () => {
+    const result = deserialize(fixture('valid-v1-single'))
+    expect(result.recordings).toHaveLength(1)
+    expect(result.recordings[0]?.call.command).toBe('git')
+    expect(result.recordings[0]?.result.exitCode).toBe(0)
+  })
+
+  test('throws CassetteCorruptError on missing version', () => {
+    expect(() => deserialize(fixture('no-version'))).toThrow(CassetteCorruptError)
+  })
+
+  test('throws CassetteCorruptError on unknown version', () => {
+    expect(() => deserialize(fixture('unknown-version'))).toThrow(CassetteCorruptError)
+  })
+
+  test('throws CassetteCorruptError on malformed JSON', () => {
+    expect(() => deserialize(fixture('malformed'))).toThrow(CassetteCorruptError)
+  })
+})
+
+describe('serialize', () => {
+  test('round-trip for single recording', () => {
+    const file: CassetteFile = {
+      version: 1,
+      recordings: [
+        {
+          call: {
+            command: 'echo',
+            args: ['hello'],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+          result: {
+            stdoutLines: ['hello', ''],
+            stderrLines: [''],
+            exitCode: 0,
+            signal: null,
+            durationMs: 5,
+          },
+        },
+      ],
+    }
+    const json = serialize(file)
+    const round = deserialize(json)
+    expect(round).toEqual(file)
+  })
+
+  test('output uses 2-space indent and canonical key order', () => {
+    const file: CassetteFile = {
+      version: 1,
+      recordings: [],
+    }
+    const json = serialize(file)
+    expect(json.startsWith('{\n  "version": 1')).toBe(true)
+  })
+
+  test('preserves trailing newline via empty string at end of stdoutLines', () => {
+    const file: CassetteFile = {
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['line1', 'line2', ''],
+            stderrLines: [''],
+            exitCode: 0,
+            signal: null,
+            durationMs: 1,
+          },
+        },
+      ],
+    }
+    const round = deserialize(serialize(file))
+    expect(round.recordings[0]?.result.stdoutLines).toEqual(['line1', 'line2', ''])
+  })
+
+  test('throws BinaryOutputError if attempting to serialize non-string in stdoutLines', () => {
+    const bad = {
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [Buffer.from([0xff, 0xfe]) as unknown as string],
+            stderrLines: [''],
+            exitCode: 0,
+            signal: null,
+            durationMs: 1,
+          },
+        },
+      ],
+    } as CassetteFile
+    expect(() => serialize(bad)).toThrow(BinaryOutputError)
+  })
+})


### PR DESCRIPTION
## What Changed

- `resolveMode(envVar, isCI, scopeDefault)` validates SHELL_CASSETTE_MODE values; falls through invalid env vars to next priority.
- Execa option validator throws UnsupportedOptionError for `buffer:false`, `ipc:true`, `inputFile`, `input`, `node:true`. Allows `lines:true`.
- Cassette path resolver: `sanitizeName` (NFKD to ASCII via `\p{M}`, kebab-case, 80-char + hash); `cassettePath` uses path.posix; throws CassetteIOError on >240-char paths (Windows MAX_PATH safety).
- Cassette serializer/deserializer with canonical key order, JSON line-array format, version-1 validation, BinaryOutputError on non-strings. Includes 5 fixture cassettes (valid empty/single, no-version, unknown-version, malformed).
- Env redactor: 11 curated keys (TOKEN, SECRET, PASSWORD, etc.), case-insensitive substring match, user-extensible via `config.redactEnvKeys`. Logs warnings on values >100 chars not in any list.
- Logger: single `log()` function, stderr-only, prefix `shell-cassette:`, silent flag suppresses output.

## Test Plan

- [x] `npm test` (56/56 passing across 8 test files)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean
- [x] All components are pure functions (no side effects on hot path)
- [x] Cross-platform paths via path.posix