### PR TITLE
feat: add config layer (loader + defaults + validation)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,50 @@
+import { CassetteConfigError } from './errors.js'
+import { defaultMatcher } from './matcher.js'
+import type { MatcherFn } from './types.js'
+
+export type Config = {
+  matcher: MatcherFn
+  cassetteDir: string
+  redactEnvKeys: string[]
+}
+
+export type PartialConfig = Partial<Config>
+
+export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
+  matcher: defaultMatcher,
+  cassetteDir: '__cassettes__',
+  redactEnvKeys: [] as string[],
+})
+
+export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Config> {
+  return Object.freeze({
+    matcher: input?.matcher ?? DEFAULT_CONFIG.matcher,
+    cassetteDir: input?.cassetteDir ?? DEFAULT_CONFIG.cassetteDir,
+    redactEnvKeys: input?.redactEnvKeys ?? DEFAULT_CONFIG.redactEnvKeys,
+  })
+}
+
+export function validateConfig(input: unknown): asserts input is PartialConfig {
+  if (input === undefined) return
+  if (input === null || typeof input !== 'object') {
+    throw new CassetteConfigError('config must be an object')
+  }
+  const obj = input as Record<string, unknown>
+
+  if ('cassetteDir' in obj && typeof obj.cassetteDir !== 'string') {
+    throw new CassetteConfigError('config.cassetteDir must be a string')
+  }
+  if ('matcher' in obj && typeof obj.matcher !== 'function') {
+    throw new CassetteConfigError('config.matcher must be a function (call, recording) => boolean')
+  }
+  if ('redactEnvKeys' in obj) {
+    if (!Array.isArray(obj.redactEnvKeys)) {
+      throw new CassetteConfigError('config.redactEnvKeys must be an array of strings')
+    }
+    if (!obj.redactEnvKeys.every((k) => typeof k === 'string')) {
+      throw new CassetteConfigError('config.redactEnvKeys items must all be strings')
+    }
+  }
+}
+
+// loadConfig and getConfig defined later in this file (see Task 20)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import { stat } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { CassetteConfigError } from './errors.js'
 import { defaultMatcher } from './matcher.js'
 import type { MatcherFn } from './types.js'
@@ -47,4 +50,45 @@ export function validateConfig(input: unknown): asserts input is PartialConfig {
   }
 }
 
-// loadConfig and getConfig defined later in this file (see Task 20)
+const CONFIG_FILENAMES = ['shell-cassette.config.js', 'shell-cassette.config.mjs']
+
+async function findConfigFile(startDir: string): Promise<string | null> {
+  let current = path.resolve(startDir)
+  while (true) {
+    for (const name of CONFIG_FILENAMES) {
+      const candidate = path.join(current, name)
+      try {
+        await stat(candidate)
+        return candidate
+      } catch {
+        // not found; continue
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+}
+
+export async function loadConfigFromDir(startDir: string): Promise<Readonly<Config>> {
+  const filePath = await findConfigFile(startDir)
+  if (filePath === null) return DEFAULT_CONFIG
+
+  let imported: { default?: unknown } | unknown
+  try {
+    imported = await import(pathToFileURL(filePath).href)
+  } catch (e) {
+    throw new CassetteConfigError(`failed to load config at ${filePath}: ${(e as Error).message}`)
+  }
+
+  const exported = (imported as { default?: unknown }).default ?? imported
+  validateConfig(exported)
+  return mergeWithDefaults(exported as PartialConfig)
+}
+
+// Top-level await: loaded once at module init
+const _cachedConfig = await loadConfigFromDir(process.cwd())
+
+export function getConfig(): Readonly<Config> {
+  return _cachedConfig
+}

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { loadConfigFromDir } from '../../src/config.js'
+import { CassetteConfigError } from '../../src/errors.js'
+
+describe('loadConfigFromDir', () => {
+  let tmp: string
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test('returns default config when no file found', async () => {
+    const config = await loadConfigFromDir(tmp)
+    expect(config.cassetteDir).toBe('__cassettes__')
+  })
+
+  test('loads .js config file', async () => {
+    await writeFile(
+      path.join(tmp, 'shell-cassette.config.js'),
+      `export default { cassetteDir: 'custom-cassettes' }`,
+    )
+    const config = await loadConfigFromDir(tmp)
+    expect(config.cassetteDir).toBe('custom-cassettes')
+  })
+
+  test('loads .mjs config file', async () => {
+    await writeFile(
+      path.join(tmp, 'shell-cassette.config.mjs'),
+      `export default { redactEnvKeys: ['STRIPE_KEY'] }`,
+    )
+    const config = await loadConfigFromDir(tmp)
+    expect(config.redactEnvKeys).toEqual(['STRIPE_KEY'])
+  })
+
+  test('throws CassetteConfigError on syntax error in config', async () => {
+    await writeFile(
+      path.join(tmp, 'shell-cassette.config.js'),
+      'export default { syntax error here',
+    )
+    await expect(loadConfigFromDir(tmp)).rejects.toThrow(CassetteConfigError)
+  })
+
+  test('throws CassetteConfigError on invalid config shape', async () => {
+    await writeFile(
+      path.join(tmp, 'shell-cassette.config.js'),
+      'export default { cassetteDir: 42 }',
+    )
+    await expect(loadConfigFromDir(tmp)).rejects.toThrow(CassetteConfigError)
+  })
+
+  test('walks up parent directories looking for config', async () => {
+    const subdir = path.join(tmp, 'a', 'b')
+    await mkdir(subdir, { recursive: true })
+    await writeFile(
+      path.join(tmp, 'shell-cassette.config.js'),
+      `export default { cassetteDir: 'parent-cassettes' }`,
+    )
+    const config = await loadConfigFromDir(subdir)
+    expect(config.cassetteDir).toBe('parent-cassettes')
+  })
+})

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest'
+import { DEFAULT_CONFIG, mergeWithDefaults, validateConfig } from '../../src/config.js'
+import { CassetteConfigError } from '../../src/errors.js'
+
+describe('DEFAULT_CONFIG', () => {
+  test('has cassetteDir = __cassettes__', () => {
+    expect(DEFAULT_CONFIG.cassetteDir).toBe('__cassettes__')
+  })
+
+  test('has empty redactEnvKeys', () => {
+    expect(DEFAULT_CONFIG.redactEnvKeys).toEqual([])
+  })
+
+  test('default matcher matches command + args', () => {
+    const call = { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null } as const
+    const rec = {
+      call,
+      result: { stdoutLines: [''], stderrLines: [''], exitCode: 0, signal: null, durationMs: 1 },
+    }
+    expect(DEFAULT_CONFIG.matcher(call, rec)).toBe(true)
+  })
+})
+
+describe('mergeWithDefaults', () => {
+  test('returns defaults when input is undefined', () => {
+    const result = mergeWithDefaults(undefined)
+    expect(result).toEqual(DEFAULT_CONFIG)
+  })
+
+  test('returns defaults when input is empty', () => {
+    const result = mergeWithDefaults({})
+    expect(result.cassetteDir).toBe(DEFAULT_CONFIG.cassetteDir)
+  })
+
+  test('overrides cassetteDir', () => {
+    const result = mergeWithDefaults({ cassetteDir: 'cassettes' })
+    expect(result.cassetteDir).toBe('cassettes')
+  })
+
+  test('overrides redactEnvKeys', () => {
+    const result = mergeWithDefaults({ redactEnvKeys: ['STRIPE_KEY'] })
+    expect(result.redactEnvKeys).toEqual(['STRIPE_KEY'])
+  })
+
+  test('result is frozen', () => {
+    const result = mergeWithDefaults({})
+    expect(Object.isFrozen(result)).toBe(true)
+  })
+})
+
+describe('validateConfig', () => {
+  test('passes for empty input', () => {
+    expect(() => validateConfig({})).not.toThrow()
+  })
+
+  test('throws CassetteConfigError on non-object', () => {
+    expect(() => validateConfig(null)).toThrow(CassetteConfigError)
+    expect(() => validateConfig('string')).toThrow(CassetteConfigError)
+    expect(() => validateConfig(42)).toThrow(CassetteConfigError)
+  })
+
+  test('throws if cassetteDir is not string', () => {
+    expect(() => validateConfig({ cassetteDir: 42 })).toThrow(CassetteConfigError)
+  })
+
+  test('throws if redactEnvKeys is not array of strings', () => {
+    expect(() => validateConfig({ redactEnvKeys: 'foo' })).toThrow(CassetteConfigError)
+    expect(() => validateConfig({ redactEnvKeys: [1, 2] })).toThrow(CassetteConfigError)
+  })
+
+  test('throws if matcher is not function', () => {
+    expect(() => validateConfig({ matcher: 'foo' })).toThrow(CassetteConfigError)
+  })
+})


### PR DESCRIPTION
## What Changed

- Config types, defaults, and validation: `Config` type, `DEFAULT_CONFIG` (frozen), `mergeWithDefaults`, `validateConfig` with TypeScript `asserts` declaration. Throws CassetteConfigError on invalid shape.
- Config file loader with top-level await: `loadConfigFromDir` walks up from cwd looking for `shell-cassette.config.{js,mjs}`; dynamic-imports via `pathToFileURL`; merges with defaults; freezes; cached for the process lifetime via top-level await.

## Why

Top-level await at module init means `import 'shell-cassette'` resolves the config once. `getConfig()` afterwards is synchronous, which is required for the wrapper layer's synchronous design. Supported in Node 14.8+; we target 18+.

## Test Plan

- [x] `npm test` (97/97 passing across 14 test files)
- [x] `npx tsc --noEmit` clean (top-level await compiles fine)
- [x] `npx biome check .` clean (29 files)