### PR TITLE
feat: add active cassette state (module global + ALS, priority resolved)

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,45 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { CassetteCollisionError } from './errors.js'
+import type { CassetteSession } from './types.js'
+
+const als = new AsyncLocalStorage<CassetteSession>()
+let moduleGlobalSession: CassetteSession | null = null
+const openSessions = new Map<string, string>()
+
+export function getActiveCassette(): CassetteSession | null {
+  const alsSession = als.getStore()
+  if (alsSession !== undefined) return alsSession
+  return moduleGlobalSession
+}
+
+export function setActiveCassette(session: CassetteSession): void {
+  moduleGlobalSession = session
+}
+
+export function clearActiveCassette(): void {
+  moduleGlobalSession = null
+}
+
+export async function withCassette<T>(session: CassetteSession, fn: () => Promise<T>): Promise<T> {
+  return als.run(session, fn)
+}
+
+export function registerSessionPath(path: string, opener: string): void {
+  const existing = openSessions.get(path)
+  if (existing !== undefined) {
+    throw new CassetteCollisionError(
+      `cassette path ${path} is already open in this process (opened by ${existing}); attempted re-open by ${opener}. Concurrent useCassette calls cannot share a cassette file.`,
+    )
+  }
+  openSessions.set(path, opener)
+}
+
+export function unregisterSessionPath(path: string): void {
+  openSessions.delete(path)
+}
+
+// Test-only reset (NOT exported through index.ts)
+export function _resetForTesting(): void {
+  moduleGlobalSession = null
+  openSessions.clear()
+}

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { CassetteCollisionError } from '../../src/errors.js'
+import {
+  clearActiveCassette,
+  getActiveCassette,
+  registerSessionPath,
+  setActiveCassette,
+  unregisterSessionPath,
+  withCassette,
+} from '../../src/state.js'
+import type { CassetteSession } from '../../src/types.js'
+
+const sessionAt = (path: string): CassetteSession => ({
+  name: `s-${path}`,
+  path,
+  scopeDefault: 'auto',
+  loadedFile: null,
+  matcher: null,
+  newRecordings: [],
+})
+
+afterEach(() => {
+  clearActiveCassette()
+})
+
+describe('module-global active cassette', () => {
+  test('returns null when nothing set', () => {
+    expect(getActiveCassette()).toBeNull()
+  })
+
+  test('returns set value', () => {
+    const s = sessionAt('/tmp/x.json')
+    setActiveCassette(s)
+    expect(getActiveCassette()).toBe(s)
+  })
+
+  test('clear resets to null', () => {
+    setActiveCassette(sessionAt('/tmp/x.json'))
+    clearActiveCassette()
+    expect(getActiveCassette()).toBeNull()
+  })
+})
+
+describe('ALS active cassette via withCassette', () => {
+  test('inside withCassette, returns ALS session', async () => {
+    const s = sessionAt('/tmp/als.json')
+    const result = await withCassette(s, async () => getActiveCassette())
+    expect(result).toBe(s)
+  })
+
+  test('after withCassette returns, ALS session is gone', async () => {
+    await withCassette(sessionAt('/tmp/als.json'), async () => 'done')
+    expect(getActiveCassette()).toBeNull()
+  })
+
+  test('ALS wins over module global', async () => {
+    const moduleSession = sessionAt('/tmp/module.json')
+    const alsSession = sessionAt('/tmp/als.json')
+    setActiveCassette(moduleSession)
+    const inside = await withCassette(alsSession, async () => getActiveCassette())
+    expect(inside).toBe(alsSession)
+    expect(getActiveCassette()).toBe(moduleSession)
+  })
+
+  test('nested withCassette works (inner wins)', async () => {
+    const outer = sessionAt('/tmp/outer.json')
+    const inner = sessionAt('/tmp/inner.json')
+    const result = await withCassette(outer, async () =>
+      withCassette(inner, async () => getActiveCassette()),
+    )
+    expect(result).toBe(inner)
+  })
+})
+
+describe('CassetteCollisionError detection via path map', () => {
+  test('registering same path twice throws', () => {
+    registerSessionPath('/tmp/foo.json', 'opener-a')
+    expect(() => registerSessionPath('/tmp/foo.json', 'opener-b')).toThrow(CassetteCollisionError)
+    unregisterSessionPath('/tmp/foo.json')
+  })
+
+  test('after unregister, can register again', () => {
+    registerSessionPath('/tmp/foo.json', 'opener-a')
+    unregisterSessionPath('/tmp/foo.json')
+    expect(() => registerSessionPath('/tmp/foo.json', 'opener-b')).not.toThrow()
+    unregisterSessionPath('/tmp/foo.json')
+  })
+})

--- a/tests/upstream/als-behavior.test.ts
+++ b/tests/upstream/als-behavior.test.ts
@@ -1,0 +1,40 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { describe, expect, test } from 'vitest'
+
+const als = new AsyncLocalStorage<string>()
+
+describe('vitest ALS behavior (regression guard)', () => {
+  test('als.run wrapping test body works', async () => {
+    await als.run('value-a', async () => {
+      expect(als.getStore()).toBe('value-a')
+      await new Promise((r) => setTimeout(r, 5))
+      expect(als.getStore()).toBe('value-a')
+    })
+  })
+
+  test.concurrent('als.run isolates concurrent test A', async () => {
+    await als.run('concurrent-a', async () => {
+      expect(als.getStore()).toBe('concurrent-a')
+      await new Promise((r) => setTimeout(r, 50))
+      expect(als.getStore()).toBe('concurrent-a')
+    })
+  })
+
+  test.concurrent('als.run isolates concurrent test B', async () => {
+    await als.run('concurrent-b', async () => {
+      expect(als.getStore()).toBe('concurrent-b')
+      await new Promise((r) => setTimeout(r, 50))
+      expect(als.getStore()).toBe('concurrent-b')
+    })
+  })
+
+  test('als.run nesting produces correct lookup', async () => {
+    await als.run('outer', async () => {
+      expect(als.getStore()).toBe('outer')
+      await als.run('inner', async () => {
+        expect(als.getStore()).toBe('inner')
+      })
+      expect(als.getStore()).toBe('outer')
+    })
+  })
+})


### PR DESCRIPTION
## What Changed

- Active cassette state: `getActiveCassette` / `setActiveCassette` / `clearActiveCassette` for module-global writes (vitest plugin path); `withCassette` wraps an async fn in `als.run` scope (useCassette path). ALS reads win over module global. Plus `registerSessionPath` / `unregisterSessionPath` for CassetteCollisionError detection.
- ALS upstream-behavior regression tests: guards against vitest changing ALS semantics. Verifies `als.run` propagates into the test body, isolates concurrent tests, and nests correctly.

## Test Plan

- [x] `npm test` (110/110 passing across 16 test files; 9 new state tests, 4 new ALS regression tests)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean