### PR TITLE
feat: add ack gate (live env var read, one-way per call)

### DIFF
--- a/src/ack.ts
+++ b/src/ack.ts
@@ -1,0 +1,25 @@
+import { AckRequiredError } from './errors.js'
+
+const HELP_TEXT = `refusing to record without redaction acknowledgment.
+
+shell-cassette v0.1 redacts env var values when KEY matches:
+  TOKEN, SECRET, PASSWORD, PASSWD, APIKEY, API_KEY, CREDENTIAL,
+  PRIVATE_KEY, AUTH_TOKEN, BEARER_TOKEN, JWT
+(extensible via shell-cassette.config.{js,mjs} \`redactEnvKeys\`)
+
+It does NOT redact:
+  - stdout / stderr content
+  - command args (e.g., --token=xyz)
+  - env vars with non-curated names (e.g., STRIPE_KEY, OPENAI_KEY,
+    DATABASE_URL) unless added via config
+  - paths in cwd
+
+ALWAYS review cassettes before committing.
+
+To proceed: set SHELL_CASSETTE_ACK_REDACTION=true.`
+
+export function requireAckGate(): void {
+  if (process.env.SHELL_CASSETTE_ACK_REDACTION !== 'true') {
+    throw new AckRequiredError(HELP_TEXT)
+  }
+}

--- a/tests/security/ack-gate.test.ts
+++ b/tests/security/ack-gate.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { requireAckGate } from '../../src/ack.js'
+import { AckRequiredError } from '../../src/errors.js'
+
+const originalEnv = process.env.SHELL_CASSETTE_ACK_REDACTION
+
+beforeEach(() => {
+  // biome-ignore lint/performance/noDelete: env var must be unset, not stringified to "undefined"
+  delete process.env.SHELL_CASSETTE_ACK_REDACTION
+})
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    // biome-ignore lint/performance/noDelete: env var must be unset, not stringified to "undefined"
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+  } else {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = originalEnv
+  }
+})
+
+describe('requireAckGate', () => {
+  test('throws AckRequiredError when env var unset', () => {
+    expect(() => requireAckGate()).toThrow(AckRequiredError)
+  })
+
+  test('throws when env var is empty string', () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = ''
+    expect(() => requireAckGate()).toThrow(AckRequiredError)
+  })
+
+  test('throws when env var is "false"', () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'false'
+    expect(() => requireAckGate()).toThrow(AckRequiredError)
+  })
+
+  test('passes when env var is "true"', () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    expect(() => requireAckGate()).not.toThrow()
+  })
+
+  test('error message describes redaction scope and how to ack', () => {
+    try {
+      requireAckGate()
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain('SHELL_CASSETTE_ACK_REDACTION')
+      expect(msg).toContain('TOKEN')
+      expect(msg).toContain('stdout')
+    }
+  })
+
+  test('one-shot toggle: env on then off → next call throws', () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    expect(() => requireAckGate()).not.toThrow()
+    // biome-ignore lint/performance/noDelete: env var must be unset, not stringified to "undefined"
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    expect(() => requireAckGate()).toThrow(AckRequiredError)
+  })
+})


### PR DESCRIPTION
## What Changed

- `requireAckGate()` reads `SHELL_CASSETTE_ACK_REDACTION` on every call (no caching) and throws `AckRequiredError` with help text describing what is redacted (the curated 11 keys), what is NOT (stdout, stderr, args, non-curated env, paths), and how to ack.

## Test Plan

- [x] `npm test` (116/116 passing across 17 test files; 6 new ack gate tests in `tests/security/`)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean