### PR TITLE
feat: add useCassette explicit API with ALS scope and lazy write in finally

### DIFF
--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -1,0 +1,46 @@
+import path from 'node:path'
+import { writeCassetteFile } from './io.js'
+import { serialize } from './serialize.js'
+import {
+  registerSessionPath,
+  unregisterSessionPath,
+  withCassette as withCassetteScope,
+} from './state.js'
+import type { CassetteFile, CassetteSession } from './types.js'
+
+export async function useCassette<T>(cassettePath: string, fn: () => Promise<T>): Promise<T> {
+  const absolutePath = path.resolve(cassettePath)
+  registerSessionPath(absolutePath, `useCassette(${cassettePath})`)
+  try {
+    const session: CassetteSession = {
+      name: path.basename(cassettePath),
+      path: absolutePath,
+      scopeDefault: 'auto',
+      loadedFile: null,
+      matcher: null,
+      newRecordings: [],
+    }
+
+    return await withCassetteScope(session, async () => {
+      try {
+        return await fn()
+      } finally {
+        await persistSession(session)
+      }
+    })
+  } finally {
+    unregisterSessionPath(absolutePath)
+  }
+}
+
+async function persistSession(session: CassetteSession): Promise<void> {
+  if (session.newRecordings.length === 0) return
+
+  const existingRecordings = session.loadedFile?.recordings ?? []
+  const merged: CassetteFile = {
+    version: 1,
+    recordings: [...existingRecordings, ...session.newRecordings],
+  }
+  const json = serialize(merged)
+  await writeCassetteFile(session.path, json)
+}

--- a/tests/integration/use-cassette.test.ts
+++ b/tests/integration/use-cassette.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+
+beforeEach(() => {
+  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+})
+
+afterEach(() => {
+  if (originalAck === undefined) {
+    // biome-ignore lint/performance/noDelete: env var must be unset, not stringified to "undefined"
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+  } else {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = originalAck
+  }
+})
+
+describe('useCassette', () => {
+  test('records execa calls and writes cassette at scope end', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, '__cassettes__', 'test.json')
+
+      await useCassette(cassettePath, async () => {
+        await execa('node', ['-e', 'console.log("hi")'])
+      })
+
+      const content = await readFile(cassettePath, 'utf8')
+      const parsed = JSON.parse(content)
+      expect(parsed.version).toBe(1)
+      expect(parsed.recordings).toHaveLength(1)
+      expect(parsed.recordings[0].call.command).toBe('node')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('does not write cassette if no execa calls happened', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, '__cassettes__', 'empty.json')
+      await useCassette(cassettePath, async () => {
+        // no execa calls
+      })
+      await expect(readFile(cassettePath, 'utf8')).rejects.toThrow()
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('writes cassette even if callback throws', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, '__cassettes__', 'partial.json')
+      await expect(
+        useCassette(cassettePath, async () => {
+          await execa('node', ['-e', 'console.log("recorded before throw")'])
+          throw new Error('test failure')
+        }),
+      ).rejects.toThrow('test failure')
+
+      const content = await readFile(cassettePath, 'utf8')
+      const parsed = JSON.parse(content)
+      expect(parsed.recordings).toHaveLength(1)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('replays from existing cassette in subsequent calls', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, '__cassettes__', 'replay.json')
+
+      // First run: record
+      await useCassette(cassettePath, async () => {
+        await execa('node', ['-e', 'console.log("recorded")'])
+      })
+
+      // Second run: should replay (no real subprocess)
+      await useCassette(cassettePath, async () => {
+        const result = await execa('node', ['-e', 'console.log("recorded")'])
+        expect(result.stdout).toContain('recorded')
+      })
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## What Changed

- Explicit `useCassette(path, fn)` API for non-vitest contexts and concurrent test cases.
- Opens an ALS scope via `state.ts` `withCassette`. Writes the cassette in a finally block so it persists on throw.
- Auto-additive merge of existing + new recordings.
- Collision detection via `registerSessionPath`.

## Test Plan

- [x] `npm test` (124/124 passing across 19 test files; 4 new useCassette integration tests including throw-during-callback case)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean (38 files)