### PR TITLE
feat: add vitest plugin (lifecycle hooks + path derivation + concurrent guard)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,39 @@
+import { ConcurrencyError } from './errors.js'
+import { cassettePath } from './paths.js'
+
+type VitestSuiteLike = {
+  name: string
+  suite?: VitestSuiteLike
+}
+
+type VitestTaskLike = {
+  name: string
+  file?: { filepath: string }
+  suite?: VitestSuiteLike
+  concurrent?: boolean
+}
+
+export function deriveCassettePathFromTask(task: VitestTaskLike, cassetteDir: string): string {
+  if (task.concurrent === true) {
+    throw new ConcurrencyError(
+      `shell-cassette: vitest plugin cannot safely auto-cassette test.concurrent (module global races under concurrent execution).
+Options:
+  1. Don't use test.concurrent in this file
+  2. Move concurrent tests to a separate test file that doesn't import 'shell-cassette/vitest', and use useCassette(cassettePath, fn) explicitly in each test body.`,
+    )
+  }
+
+  const filepath = task.file?.filepath
+  if (!filepath) {
+    throw new Error('shell-cassette: vitest task missing file.filepath')
+  }
+
+  const describePath: string[] = []
+  let suite = task.suite
+  while (suite) {
+    if (suite.name) describePath.unshift(suite.name)
+    suite = suite.suite
+  }
+
+  return cassettePath(filepath, describePath, task.name, cassetteDir)
+}

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach } from 'vitest'
+import { getConfig } from './config.js'
+import { ConcurrencyError } from './errors.js'
+import { writeCassetteFile } from './io.js'
+import { deriveCassettePathFromTask } from './plugin.js'
+import { serialize } from './serialize.js'
+import {
+  clearActiveCassette,
+  registerSessionPath,
+  setActiveCassette,
+  unregisterSessionPath,
+} from './state.js'
+import type { CassetteSession } from './types.js'
+
+beforeEach((ctx) => {
+  const task = (ctx as { task?: unknown }).task as
+    | Parameters<typeof deriveCassettePathFromTask>[0]
+    | undefined
+  if (!task) return
+
+  const config = getConfig()
+  let cassettePath: string
+  try {
+    cassettePath = deriveCassettePathFromTask(task, config.cassetteDir)
+  } catch (e) {
+    if (e instanceof ConcurrencyError) {
+      throw e
+    }
+    return
+  }
+
+  registerSessionPath(cassettePath, `vitest-plugin:${task.name}`)
+
+  const session: CassetteSession = {
+    name: task.name,
+    path: cassettePath,
+    scopeDefault: 'auto',
+    loadedFile: null,
+    matcher: null,
+    newRecordings: [],
+  }
+  setActiveCassette(session)
+})
+
+afterEach(async () => {
+  const { getActiveCassette } = await import('./state.js')
+  const session = getActiveCassette()
+  if (session && session.newRecordings.length > 0) {
+    const existingRecordings = session.loadedFile?.recordings ?? []
+    const merged = {
+      version: 1 as const,
+      recordings: [...existingRecordings, ...session.newRecordings],
+    }
+    await writeCassetteFile(session.path, serialize(merged))
+  }
+  if (session) {
+    unregisterSessionPath(session.path)
+  }
+  clearActiveCassette()
+})

--- a/tests/plugin/fixtures/basic/package.json
+++ b/tests/plugin/fixtures/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "shell-cassette-plugin-fixture-basic",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/plugin/fixtures/basic/src/sample.test.ts
+++ b/tests/plugin/fixtures/basic/src/sample.test.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest'
+import { execa } from '../../../../../src/execa.js'
+
+test('records node version', async () => {
+  await execa('node', ['--version'])
+})

--- a/tests/plugin/fixtures/basic/vitest.config.ts
+++ b/tests/plugin/fixtures/basic/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['../../../../src/vitest.ts'],
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/tests/plugin/lifecycle.test.ts
+++ b/tests/plugin/lifecycle.test.ts
@@ -1,0 +1,37 @@
+import { readFile, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { execa as childExeca } from 'execa'
+import { describe, expect, test } from 'vitest'
+
+describe('vitest plugin lifecycle (subprocess-driven)', () => {
+  test('plugin records cassettes for tests in fixture project', async () => {
+    const fixtureDir = path.resolve('tests/plugin/fixtures/basic')
+
+    // Run vitest in the fixture dir
+    await childExeca('npx', ['vitest', 'run'], {
+      cwd: fixtureDir,
+      env: {
+        ...process.env,
+        SHELL_CASSETTE_ACK_REDACTION: 'true',
+      },
+      reject: false,
+    })
+
+    // Check that cassette file was written
+    const cassetteFile = path.join(
+      fixtureDir,
+      'src',
+      '__cassettes__',
+      'sample.test.ts',
+      'records-node-version.json',
+    )
+    const content = await readFile(cassetteFile, 'utf8')
+    expect(content).toContain('node')
+
+    // Cleanup the test artifacts
+    await rm(path.join(fixtureDir, 'src', '__cassettes__'), {
+      recursive: true,
+      force: true,
+    })
+  }, 60000) // 60s timeout — vitest subprocess startup is slow on Windows
+})

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+import { deriveCassettePathFromTask } from '../../src/plugin.js'
+
+describe('deriveCassettePathFromTask', () => {
+  test('flat test produces correct path', () => {
+    const task = {
+      name: 'finds branch',
+      file: { filepath: '/repo/src/git.test.ts' },
+      suite: undefined,
+      concurrent: false,
+    }
+    const result = deriveCassettePathFromTask(task as never, '__cassettes__')
+    expect(result).toBe('/repo/src/__cassettes__/git.test.ts/finds-branch.json')
+  })
+
+  test('nested describe produces nested path', () => {
+    const task = {
+      name: 'reads HEAD',
+      file: { filepath: '/repo/src/git.test.ts' },
+      suite: {
+        name: 'inner',
+        suite: {
+          name: 'outer',
+          suite: undefined,
+        },
+      },
+      concurrent: false,
+    }
+    const result = deriveCassettePathFromTask(task as never, '__cassettes__')
+    expect(result).toBe('/repo/src/__cassettes__/git.test.ts/outer/inner/reads-head.json')
+  })
+
+  test('throws ConcurrencyError if task.concurrent is true', () => {
+    const task = {
+      name: 'concurrent test',
+      file: { filepath: '/repo/x.test.ts' },
+      suite: undefined,
+      concurrent: true,
+    }
+    expect(() => deriveCassettePathFromTask(task as never, '__cassettes__')).toThrow(/concurrent/)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
-    exclude: ['tests/dogfood/**', 'node_modules/**', 'dist/**'],
+    exclude: ['tests/dogfood/**', 'tests/plugin/fixtures/**', 'node_modules/**', 'dist/**'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## What Changed

- Vitest plugin internals: `deriveCassettePathFromTask` walks vitest's task suite chain to build the (file, describePath, testName) tuple. Throws ConcurrencyError on `test.concurrent`.
- Vitest plugin (side-effect import) registers hooks on import. `beforeEach` derives the cassette path, registers it, creates a session, sets the module-global active cassette. `afterEach` persists if recordings exist, unregisters, clears.
- Fixture project (`basic/`) with subprocess-driven lifecycle test.
- Vitest config excludes `tests/plugin/fixtures/**` so fixture sample tests are not picked up by the parent run.

## Test Plan

- [x] `npm test` (128/128 passing across 21 test files; 3 new plugin unit tests, 1 subprocess-driven lifecycle test that spawns vitest in fixture project, ~1.4s)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean (44 files)