### PR TITLE
feat: add main index entry (public API exports)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,11 @@
+export { execa } from './execa.js'
+export { useCassette } from './use-cassette.js'
+export type {
+  Call,
+  Recording,
+  Result,
+  CassetteFile,
+  CassetteSession,
+  Mode,
+  MatcherFn,
+} from './types.js'


### PR DESCRIPTION
## What Changed

- Runtime exports: `execa` (wrapped), `useCassette` (explicit API).
- Type exports: `Call`, `Recording`, `Result`, `CassetteFile`, `CassetteSession`, `Mode`, `MatcherFn`.

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check .` clean (45 files)
- [x] All 128 existing tests still pass