### PR TITLE
docs: add README and verify build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,130 @@
 # shell-cassette
-Polly.js, but for shell commands.
+
+> Polly.js, but for shell commands. Record subprocess calls once, replay them deterministically forever.
+
+## Why
+
+Testing code that spawns subprocesses today means picking between three bad options: hit the real binary (slow, flaky, environment-dependent), hand-roll mocks (tedious, drifts from reality), or skip testing the boundary (where bugs come from).
+
+shell-cassette records subprocess calls once and replays them deterministically. Your tests go from minutes to seconds without losing fidelity to real subprocess behavior.
+
+## Installation
+
+```bash
+npm install --save-dev shell-cassette execa
+```
+
+## Quick start
+
+```ts
+// vitest.setup.ts
+import 'shell-cassette/vitest'
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts']
+  }
+})
+```
+
+```ts
+// my-test.test.ts
+import { test, expect } from 'vitest'
+import { execa } from 'shell-cassette'
+
+test('finds current branch', async () => {
+  const { stdout } = await execa('git', ['branch', '--show-current'])
+  expect(stdout).toBe('main')
+})
+```
+
+First run (record):
+
+```bash
+SHELL_CASSETTE_ACK_REDACTION=true npm test
+```
+
+Subsequent runs (auto-replay):
+
+```bash
+npm test
+```
+
+CI:
+
+```bash
+npm test  # CI=true forces replay-strict
+```
+
+## Recording mode
+
+| Mode | Behavior |
+|---|---|
+| `passthrough` (default outside cassette scope) | Calls real execa, no recording |
+| `auto` (default inside cassette scope) | Replays if recording exists, records if not (auto-additive) |
+| `record` | Always records (overwrites unmatched recordings) |
+| `replay` | Replays only; throws on missing |
+
+Set via `SHELL_CASSETTE_MODE=record|replay|passthrough`. `CI=true` forces `replay`.
+
+## Security: redaction
+
+shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`.
+
+By default, env var values are redacted when KEY contains:
+`TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `APIKEY`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`, `AUTH_TOKEN`, `BEARER_TOKEN`, `JWT`.
+
+shell-cassette does NOT redact:
+
+- stdout/stderr content
+- command args
+- env vars with non-curated names (e.g., `STRIPE_KEY`, `OPENAI_KEY`)
+- paths in cwd
+
+**Always review cassettes before committing.**
+
+## Configuration
+
+Optional `shell-cassette.config.{js,mjs}`:
+
+```js
+// shell-cassette.config.js
+export default {
+  cassetteDir: '__cassettes__',         // default
+  redactEnvKeys: ['STRIPE_KEY'],        // adds to curated list
+  matcher: (call, rec) => /* custom */, // default: command + deep-equal args
+}
+```
+
+## Explicit cassette scope
+
+For non-vitest contexts or `test.concurrent`:
+
+```ts
+import { useCassette, execa } from 'shell-cassette'
+
+test.concurrent('parallel test', async () => {
+  await useCassette('./cassettes/parallel.json', async () => {
+    await execa('git', ['status'])
+  })
+})
+```
+
+## What v0.1 doesn't do (yet)
+
+- Multiple subprocess libraries (tinyexec, nano-spawn) — v0.2
+- Streaming output (`buffer: false`) — v1.0
+- IPC channels (`ipc: true`) — v1.0
+- stdin support — v0.2 (buffered) / v1.0 (file)
+- Bun.spawn / Deno.Command / native child_process — v1.0
+- CLI tools (`shell-cassette show`, `prune`, etc.) — v0.2
+- Stdout/stderr/args content redaction — v0.2
+
+## License
+
+MIT — see `LICENSE`.


### PR DESCRIPTION
## What Changed

- README documents usage, modes, security guarantees, and configuration.
- Build verified: `tsc` produces clean `dist/` with all `.d.ts`, `.js`, `.map` files; smoke import `import('./dist/index.js')` exports `execa` and `useCassette`.
- All 137 tests passing across 23 test files; biome clean (47 files); tsc clean.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` 137/137 passing
- [x] `npm run build` produces clean `dist/`
- [ ] Tag v0.1.0 (deferred to manual verification per user instruction)