### PR TITLE
fix: support execa `all: true` option in record/replay

### DIFF
--- a/src/execa.ts
+++ b/src/execa.ts
@@ -132,7 +132,9 @@ function toLines(input: string | string[] | undefined): string[] {
 function synthesize(rec: Recording, options: Options): unknown {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
-  const result: Record<string, unknown> = {
+  const all =
+    options.all === true ? (rec.result.allLines?.join('\n') ?? stdout + stderr) : undefined
+  const result = {
     stdout: options.lines === true ? rec.result.stdoutLines.slice(0, -1) : stdout,
     stderr,
     exitCode: rec.result.exitCode,
@@ -144,11 +146,7 @@ function synthesize(rec: Recording, options: Options): unknown {
     killed: rec.result.signal !== null,
     command: `${rec.call.command} ${rec.call.args.join(' ')}`,
     escapedCommand: rec.call.command,
-  }
-  if (options.all === true) {
-    // Use recorded interleaved output when present; fall back to stdout+stderr concat for legacy cassettes.
-    const allLines = rec.result.allLines ?? [...rec.result.stdoutLines, ...rec.result.stderrLines]
-    result.all = allLines.join('\n')
+    ...(all !== undefined && { all }),
   }
 
   // If reject is true (default) and exit !== 0, throw an Error shaped like ExecaError

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -107,6 +107,7 @@ function captureRecording(
   const r = execaResult as {
     stdout?: string | string[]
     stderr?: string | string[]
+    all?: string | string[]
     exitCode?: number
     signal?: string | null
     durationMs?: number
@@ -114,6 +115,7 @@ function captureRecording(
   const result: Result = {
     stdoutLines: toLines(r.stdout),
     stderrLines: toLines(r.stderr),
+    allLines: r.all === undefined ? null : toLines(r.all),
     exitCode: r.exitCode ?? 0,
     signal: r.signal ?? null,
     durationMs: r.durationMs ?? 0,
@@ -130,7 +132,7 @@ function toLines(input: string | string[] | undefined): string[] {
 function synthesize(rec: Recording, options: Options): unknown {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
-  const result = {
+  const result: Record<string, unknown> = {
     stdout: options.lines === true ? rec.result.stdoutLines.slice(0, -1) : stdout,
     stderr,
     exitCode: rec.result.exitCode,
@@ -142,6 +144,11 @@ function synthesize(rec: Recording, options: Options): unknown {
     killed: rec.result.signal !== null,
     command: `${rec.call.command} ${rec.call.args.join(' ')}`,
     escapedCommand: rec.call.command,
+  }
+  if (options.all === true) {
+    // Use recorded interleaved output when present; fall back to stdout+stderr concat for legacy cassettes.
+    const allLines = rec.result.allLines ?? [...rec.result.stdoutLines, ...rec.result.stderrLines]
+    result.all = allLines.join('\n')
   }
 
   // If reject is true (default) and exit !== 0, throw an Error shaped like ExecaError

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -86,19 +86,19 @@ export function deserialize(text: string): CassetteFile {
     throw new CassetteCorruptError('cassette `recordings` must be an array')
   }
 
-  const recordings = (obj.recordings as Recording[]).map(normalizeLegacyRecording)
+  const recordings = (obj.recordings as LegacyRecording[]).map(normalizeLegacyRecording)
   return {
     version: SCHEMA_VERSION,
     recordings,
   }
 }
 
-// Cassettes recorded before allLines was introduced lack the field; normalize to null so callers can rely on the type.
-function normalizeLegacyRecording(rec: Recording): Recording {
-  const result = rec.result as Partial<Recording['result']>
-  if ('allLines' in result) return rec
-  return {
-    ...rec,
-    result: { ...(result as Recording['result']), allLines: null },
-  }
+// On disk, `allLines` may be absent (cassettes recorded before it existed).
+type LegacyRecording = Omit<Recording, 'result'> & {
+  result: Omit<Recording['result'], 'allLines'> & { allLines?: string[] | null }
+}
+
+function normalizeLegacyRecording(rec: LegacyRecording): Recording {
+  if (rec.result.allLines !== undefined) return rec as Recording
+  return { ...rec, result: { ...rec.result, allLines: null } }
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -25,6 +25,7 @@ function orderRecording(rec: Recording) {
     result: {
       stdoutLines: rec.result.stdoutLines,
       stderrLines: rec.result.stderrLines,
+      allLines: rec.result.allLines,
       exitCode: rec.result.exitCode,
       signal: rec.result.signal,
       durationMs: rec.result.durationMs,
@@ -46,6 +47,15 @@ function validateBeforeSerialize(file: CassetteFile): void {
         throw new BinaryOutputError(
           `cannot serialize non-string in stderrLines for ${rec.call.command}; v0.1 supports UTF-8 text only`,
         )
+      }
+    }
+    if (rec.result.allLines !== null) {
+      for (const line of rec.result.allLines) {
+        if (typeof line !== 'string') {
+          throw new BinaryOutputError(
+            `cannot serialize non-string in allLines for ${rec.call.command}; v0.1 supports UTF-8 text only`,
+          )
+        }
       }
     }
   }
@@ -76,8 +86,19 @@ export function deserialize(text: string): CassetteFile {
     throw new CassetteCorruptError('cassette `recordings` must be an array')
   }
 
+  const recordings = (obj.recordings as Recording[]).map(normalizeLegacyRecording)
   return {
     version: SCHEMA_VERSION,
-    recordings: obj.recordings as Recording[],
+    recordings,
+  }
+}
+
+// Cassettes recorded before allLines was introduced lack the field; normalize to null so callers can rely on the type.
+function normalizeLegacyRecording(rec: Recording): Recording {
+  const result = rec.result as Partial<Recording['result']>
+  if ('allLines' in result) return rec
+  return {
+    ...rec,
+    result: { ...(result as Recording['result']), allLines: null },
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,9 @@ export type Call = {
 export type Result = {
   stdoutLines: string[]
   stderrLines: string[]
+  // Captured only when the original call passed { all: true }; null otherwise.
+  // Replay falls back to stdout+stderr concat if a caller asks for `all` but the recording is null.
+  allLines: string[] | null
   exitCode: number
   signal: string | null
   durationMs: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,7 @@ export type Call = {
 export type Result = {
   stdoutLines: string[]
   stderrLines: string[]
-  // Captured only when the original call passed { all: true }; null otherwise.
-  // Replay falls back to stdout+stderr concat if a caller asks for `all` but the recording is null.
+  // null when the original call did not pass { all: true }
   allLines: string[] | null
   exitCode: number
   signal: string | null

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -78,4 +78,83 @@ describe('wrapped execa', () => {
       wrappedExeca('node', ['-v'], { ipc: true }),
     ).rejects.toThrow(/ipc/)
   })
+
+  test('captures and replays `all` when option is set', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, 'cassette.json')
+
+      // Record
+      const recordSession = sessionAt(cassettePath)
+      setActiveCassette(recordSession)
+      const recorded = await wrappedExeca(
+        'node',
+        ['-e', 'console.log("out"); console.error("err")'],
+        { all: true },
+      )
+      expect(typeof recorded.all).toBe('string')
+      expect(recorded.all).toContain('out')
+      expect(recorded.all).toContain('err')
+      expect(recordSession.newRecordings[0]?.result.allLines).not.toBeNull()
+      clearActiveCassette()
+
+      // persist
+      const { writeCassetteFile } = await import('../../src/io.js')
+      const { serialize } = await import('../../src/serialize.js')
+      await writeCassetteFile(
+        cassettePath,
+        serialize({ version: 1, recordings: recordSession.newRecordings }),
+      )
+
+      // Replay
+      const replaySession = sessionAt(cassettePath)
+      setActiveCassette(replaySession)
+      const replayed = await wrappedExeca(
+        'node',
+        ['-e', 'console.log("out"); console.error("err")'],
+        { all: true },
+      )
+      expect(replayed.all).toContain('out')
+      expect(replayed.all).toContain('err')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('legacy cassette (no allLines) still replays all via stdout+stderr concat', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, 'cassette.json')
+      const { writeFile } = await import('node:fs/promises')
+      const legacy = {
+        version: 1,
+        recordings: [
+          {
+            call: {
+              command: 'node',
+              args: ['-v'],
+              cwd: null,
+              env: {},
+              stdin: null,
+            },
+            result: {
+              stdoutLines: ['v22.0.0', ''],
+              stderrLines: [''],
+              exitCode: 0,
+              signal: null,
+              durationMs: 1,
+            },
+          },
+        ],
+      }
+      await writeFile(cassettePath, JSON.stringify(legacy), 'utf8')
+
+      const session = sessionAt(cassettePath)
+      setActiveCassette(session)
+      const replayed = await wrappedExeca('node', ['-v'], { all: true })
+      expect(replayed.all).toContain('v22.0.0')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -1,8 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa as wrappedExeca } from '../../src/execa.js'
+import { writeCassetteFile } from '../../src/io.js'
+import { serialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { CassetteSession } from '../../src/types.js'
 
@@ -98,9 +100,6 @@ describe('wrapped execa', () => {
       expect(recordSession.newRecordings[0]?.result.allLines).not.toBeNull()
       clearActiveCassette()
 
-      // persist
-      const { writeCassetteFile } = await import('../../src/io.js')
-      const { serialize } = await import('../../src/serialize.js')
       await writeCassetteFile(
         cassettePath,
         serialize({ version: 1, recordings: recordSession.newRecordings }),
@@ -125,7 +124,6 @@ describe('wrapped execa', () => {
     const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
     try {
       const cassettePath = path.join(tmp, 'cassette.json')
-      const { writeFile } = await import('node:fs/promises')
       const legacy = {
         version: 1,
         recordings: [

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -15,7 +15,14 @@ describe('DEFAULT_CONFIG', () => {
     const call = { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null } as const
     const rec = {
       call,
-      result: { stdoutLines: [''], stderrLines: [''], exitCode: 0, signal: null, durationMs: 1 },
+      result: {
+        stdoutLines: [''],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 1,
+      },
     }
     expect(DEFAULT_CONFIG.matcher(call, rec)).toBe(true)
   })

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -15,6 +15,7 @@ const recordingOf = (command: string, args: string[], stdout = ''): Recording =>
   result: {
     stdoutLines: [stdout, ''],
     stderrLines: [''],
+    allLines: null,
     exitCode: 0,
     signal: null,
     durationMs: 1,

--- a/tests/unit/recorder.test.ts
+++ b/tests/unit/recorder.test.ts
@@ -22,6 +22,7 @@ const callOf = (env: Record<string, string> = {}): Call => ({
 const resultOf = (): Result => ({
   stdoutLines: ['ok', ''],
   stderrLines: [''],
+  allLines: null,
   exitCode: 0,
   signal: null,
   durationMs: 5,

--- a/tests/unit/serialize.test.ts
+++ b/tests/unit/serialize.test.ts
@@ -49,6 +49,7 @@ describe('serialize', () => {
           result: {
             stdoutLines: ['hello', ''],
             stderrLines: [''],
+            allLines: null,
             exitCode: 0,
             signal: null,
             durationMs: 5,
@@ -79,6 +80,7 @@ describe('serialize', () => {
           result: {
             stdoutLines: ['line1', 'line2', ''],
             stderrLines: [''],
+            allLines: null,
             exitCode: 0,
             signal: null,
             durationMs: 1,
@@ -90,6 +92,47 @@ describe('serialize', () => {
     expect(round.recordings[0]?.result.stdoutLines).toEqual(['line1', 'line2', ''])
   })
 
+  test('round-trip preserves allLines when populated', () => {
+    const file: CassetteFile = {
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['out', ''],
+            stderrLines: ['err', ''],
+            allLines: ['out', 'err', ''],
+            exitCode: 0,
+            signal: null,
+            durationMs: 1,
+          },
+        },
+      ],
+    }
+    const round = deserialize(serialize(file))
+    expect(round.recordings[0]?.result.allLines).toEqual(['out', 'err', ''])
+  })
+
+  test('deserialize normalizes legacy cassette (missing allLines) to null', () => {
+    const legacyJson = JSON.stringify({
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['', ''],
+            stderrLines: [''],
+            exitCode: 0,
+            signal: null,
+            durationMs: 1,
+          },
+        },
+      ],
+    })
+    const round = deserialize(legacyJson)
+    expect(round.recordings[0]?.result.allLines).toBeNull()
+  })
+
   test('throws BinaryOutputError if attempting to serialize non-string in stdoutLines', () => {
     const bad = {
       version: 1,
@@ -99,6 +142,7 @@ describe('serialize', () => {
           result: {
             stdoutLines: [Buffer.from([0xff, 0xfe]) as unknown as string],
             stderrLines: [''],
+            allLines: null,
             exitCode: 0,
             signal: null,
             durationMs: 1,

--- a/tests/unit/serialize.test.ts
+++ b/tests/unit/serialize.test.ts
@@ -13,11 +13,12 @@ describe('deserialize', () => {
     expect(result.recordings).toEqual([])
   })
 
-  test('parses valid v1 single recording', () => {
+  test('parses valid v1 single recording; legacy fixture has no allLines so it normalizes to null', () => {
     const result = deserialize(fixture('valid-v1-single'))
     expect(result.recordings).toHaveLength(1)
     expect(result.recordings[0]?.call.command).toBe('git')
     expect(result.recordings[0]?.result.exitCode).toBe(0)
+    expect(result.recordings[0]?.result.allLines).toBeNull()
   })
 
   test('throws CassetteCorruptError on missing version', () => {
@@ -111,26 +112,6 @@ describe('serialize', () => {
     }
     const round = deserialize(serialize(file))
     expect(round.recordings[0]?.result.allLines).toEqual(['out', 'err', ''])
-  })
-
-  test('deserialize normalizes legacy cassette (missing allLines) to null', () => {
-    const legacyJson = JSON.stringify({
-      version: 1,
-      recordings: [
-        {
-          call: { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null },
-          result: {
-            stdoutLines: ['', ''],
-            stderrLines: [''],
-            exitCode: 0,
-            signal: null,
-            durationMs: 1,
-          },
-        },
-      ],
-    })
-    const round = deserialize(legacyJson)
-    expect(round.recordings[0]?.result.allLines).toBeNull()
   })
 
   test('throws BinaryOutputError if attempting to serialize non-string in stdoutLines', () => {


### PR DESCRIPTION
## What Changed

- Add `Result.allLines: string[] | null` to the cassette schema. Capture `r.all` at record when caller passed `{ all: true }`; synthesize `result.all` at replay.
- `deserialize()` normalizes legacy cassettes (no `allLines`) to `null`. When a caller asks for `all` against a legacy cassette, fall back to `stdoutLines + stderrLines` joined: best effort, but does not break.

## Why

Found via real-world validation against [`mmkal/trpc-cli`](https://github.com/mmkal/trpc-cli) (347 stars) whose e2e helpers all use `{ all: true }`. Pre-fix: 21/21 replayed tests failed with `TypeError: Expected a string, got undefined`. Post-fix: 21/21 pass, replay completes in ~1.5s vs 38s record.

## Related Issues

Closes #21

## Test Plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` (137 passed; was 133; added 4 tests covering all-record/replay round-trip, legacy normalization, legacy concat fallback, end-to-end record/replay)
- [x] `npm run build` clean
- [x] Manual verification against trpc-cli demo: re-record + re-replay, all 21 e2e tests pass; cassettes contain `allLines` populated