### PR TITLE
refactor: extract shared wrapper envelope

### DIFF
--- a/src/execa.ts
+++ b/src/execa.ts
@@ -1,6 +1,6 @@
 import type { Options, ResultPromise } from 'execa'
 import { execa as realExeca } from 'execa'
-import { validateOptions } from './options.js'
+import { validateOptions } from './options-execa.js'
 import type { Call, Recording, Result } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
 

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -1,94 +1,26 @@
 import type { Options, ResultPromise } from 'execa'
 import { execa as realExeca } from 'execa'
-import { requireAckGate } from './ack.js'
-import { type Config, getConfig } from './config.js'
-import { ReplayMissError } from './errors.js'
-import { loadCassette } from './loader.js'
-import { MatcherState } from './matcher.js'
-import { resolveMode } from './mode.js'
 import { validateOptions } from './options.js'
-import { record } from './recorder.js'
-import { getActiveCassette } from './state.js'
-import type { Call, CassetteSession, MatcherStateLike, Recording, Result } from './types.js'
+import type { Call, Recording, Result } from './types.js'
+import { type RunnerHooks, runWrapped } from './wrapper.js'
 
 export function execa(
   file: string,
   args?: readonly string[],
   options?: Options,
 ): ResultPromise<Options> {
-  return runExeca(file, args ?? [], options ?? {}) as ResultPromise<Options>
+  return runWrapped(file, args ?? [], options ?? {}, execaHooks) as ResultPromise<Options>
 }
 
-async function runExeca(file: string, args: readonly string[], options: Options): Promise<unknown> {
-  validateOptions(options as Record<string, unknown>)
-
-  const session = getActiveCassette()
-  if (session === null) {
-    return realExeca(file, args, options)
-  }
-
-  // Lazy load cassette + build matcher on first call in scope
-  const config = getConfig()
-  if (session.loadedFile === null) {
-    session.loadedFile = await loadCassette(session.path)
-    session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], config.matcher)
-  }
-
-  const mode = resolveMode(
-    process.env.SHELL_CASSETTE_MODE,
-    Boolean(process.env.CI),
-    session.scopeDefault,
-  )
-
-  if (mode === 'passthrough') {
-    return realExeca(file, args, options)
-  }
-
-  const call = buildCall(file, args, options)
-  const matcher = ensureMatcher(session.matcher)
-
-  if (mode === 'replay') {
-    if (session.loadedFile === null) {
-      throw new ReplayMissError(
-        `no cassette at ${session.path}; run with SHELL_CASSETTE_MODE=record to create.`,
-      )
-    }
-    const recording = matcher.findMatch(call)
-    if (recording === null) {
-      throw buildReplayMissError(call, session)
-    }
-    return synthesize(recording, options)
-  }
-
-  if (mode === 'auto') {
-    const recording = matcher.findMatch(call)
-    if (recording !== null) {
-      return synthesize(recording, options)
-    }
-    // fall through to record path (auto-additive)
-  }
-
-  // mode is 'record' OR auto-with-no-match
-  requireAckGate()
-  try {
-    const result = await realExeca(file, args, options)
-    captureRecording(call, result, session, config)
-    return result
-  } catch (err) {
-    // execa errors propagate; capture failure first
-    captureRecording(call, err, session, config)
-    throw err
-  }
+const execaHooks: RunnerHooks<Options, unknown> = {
+  validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
+  buildCall: (file, args, options) => buildCallExeca(file, args, options),
+  realCall: (file, args, options) => realExeca(file, args, options) as unknown as Promise<unknown>,
+  captureResult: (raw) => captureResultExeca(raw),
+  synthesize: (rec, options) => synthesizeExeca(rec, options),
 }
 
-function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
-  if (matcher === null) {
-    throw new Error('shell-cassette: matcher was not initialized before use (internal bug)')
-  }
-  return matcher
-}
-
-function buildCall(file: string, args: readonly string[], options: Options): Call {
+function buildCallExeca(file: string, args: readonly string[], options: Options): Call {
   return {
     command: file,
     args: [...args],
@@ -98,12 +30,7 @@ function buildCall(file: string, args: readonly string[], options: Options): Cal
   }
 }
 
-function captureRecording(
-  call: Call,
-  execaResult: unknown,
-  session: CassetteSession,
-  config: Config,
-): void {
+function captureResultExeca(execaResult: unknown): Result {
   const r = execaResult as {
     stdout?: string | string[]
     stderr?: string | string[]
@@ -112,7 +39,7 @@ function captureRecording(
     signal?: string | null
     durationMs?: number
   }
-  const result: Result = {
+  return {
     stdoutLines: toLines(r.stdout),
     stderrLines: toLines(r.stderr),
     allLines: r.all === undefined ? null : toLines(r.all),
@@ -120,7 +47,6 @@ function captureRecording(
     signal: r.signal ?? null,
     durationMs: r.durationMs ?? 0,
   }
-  record(call, result, session, config)
 }
 
 function toLines(input: string | string[] | undefined): string[] {
@@ -129,7 +55,7 @@ function toLines(input: string | string[] | undefined): string[] {
   return input.split('\n')
 }
 
-function synthesize(rec: Recording, options: Options): unknown {
+function synthesizeExeca(rec: Recording, options: Options): unknown {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
   const all =
@@ -149,7 +75,6 @@ function synthesize(rec: Recording, options: Options): unknown {
     ...(all !== undefined && { all }),
   }
 
-  // If reject is true (default) and exit !== 0, throw an Error shaped like ExecaError
   if (options.reject !== false && rec.result.exitCode !== 0) {
     const err = Object.assign(
       new Error(`Command failed with exit code ${rec.result.exitCode}: ${result.command}`),
@@ -160,20 +85,4 @@ function synthesize(rec: Recording, options: Options): unknown {
   }
 
   return result
-}
-
-function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
-  const recordedCalls = session.loadedFile?.recordings
-    .map((r) => `${r.call.command} ${r.call.args.join(' ')}`)
-    .join('\n  - ')
-  return new ReplayMissError(
-    `no matching recording for \`${call.command} ${call.args.join(' ')}\`
-  cassette: ${session.path}
-  matcher:  default (command + deep-equal args)
-
-Recorded calls in this cassette:
-  - ${recordedCalls ?? '(none)'}
-
-To re-record: delete the cassette file and run tests again.`,
-  )
 }

--- a/src/options-execa.ts
+++ b/src/options-execa.ts
@@ -5,27 +5,23 @@ export function validateOptions(options: Record<string, unknown> | undefined): v
 
   if (options.buffer === false) {
     throw new UnsupportedOptionError(
-      'execa option `buffer: false` (streaming) not supported in v0.1. Planned for v1.0.',
+      'execa option `buffer: false` (streaming) not supported. Tracked in backlog.',
     )
   }
   if (options.ipc === true) {
-    throw new UnsupportedOptionError(
-      'execa option `ipc: true` not supported in v0.1. Planned for v1.0.',
-    )
+    throw new UnsupportedOptionError('execa option `ipc: true` not supported. Tracked in backlog.')
   }
   if (options.inputFile !== undefined && options.inputFile !== null) {
-    throw new UnsupportedOptionError(
-      'execa option `inputFile` not supported in v0.1. Planned for v1.0.',
-    )
+    throw new UnsupportedOptionError('execa option `inputFile` not supported. Tracked in backlog.')
   }
   if (options.input !== undefined && options.input !== null) {
     throw new UnsupportedOptionError(
-      'execa option `input` (stdin) not supported in v0.1. Buffered stdin planned for v0.2.',
+      'execa option `input` (stdin) not supported. Buffered stdin tracked in backlog.',
     )
   }
   if (options.node === true) {
     throw new UnsupportedOptionError(
-      'execa option `node: true` (execaNode) not supported in v0.1. Planned for v0.2.',
+      'execa option `node: true` (execaNode) not supported. Tracked in backlog.',
     )
   }
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,0 +1,116 @@
+import { requireAckGate } from './ack.js'
+import { type Config, getConfig } from './config.js'
+import { ReplayMissError } from './errors.js'
+import { loadCassette } from './loader.js'
+import { MatcherState } from './matcher.js'
+import { resolveMode } from './mode.js'
+import { record } from './recorder.js'
+import { getActiveCassette } from './state.js'
+import type { Call, CassetteSession, MatcherStateLike, Recording, Result } from './types.js'
+
+export type RunnerHooks<Opts, ResultShape> = {
+  validate: (options: Opts | undefined) => void
+  buildCall: (file: string, args: readonly string[], options: Opts) => Call
+  realCall: (file: string, args: readonly string[], options: Opts) => Promise<ResultShape>
+  captureResult: (raw: ResultShape | unknown) => Result
+  synthesize: (rec: Recording, options: Opts) => ResultShape
+}
+
+export async function runWrapped<Opts, ResultShape>(
+  file: string,
+  args: readonly string[],
+  options: Opts,
+  hooks: RunnerHooks<Opts, ResultShape>,
+): Promise<ResultShape> {
+  hooks.validate(options)
+
+  const session = getActiveCassette()
+  if (session === null) {
+    return hooks.realCall(file, args, options)
+  }
+
+  const config = getConfig()
+  if (session.loadedFile === null) {
+    session.loadedFile = await loadCassette(session.path)
+    session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], config.matcher)
+  }
+
+  const mode = resolveMode(
+    process.env.SHELL_CASSETTE_MODE,
+    Boolean(process.env.CI),
+    session.scopeDefault,
+  )
+
+  if (mode === 'passthrough') {
+    return hooks.realCall(file, args, options)
+  }
+
+  const call = hooks.buildCall(file, args, options)
+  const matcher = ensureMatcher(session.matcher)
+
+  if (mode === 'replay') {
+    if (session.loadedFile === null) {
+      throw new ReplayMissError(
+        `no cassette at ${session.path}; run with SHELL_CASSETTE_MODE=record to create.`,
+      )
+    }
+    const recording = matcher.findMatch(call)
+    if (recording === null) {
+      throw buildReplayMissError(call, session)
+    }
+    return hooks.synthesize(recording, options)
+  }
+
+  if (mode === 'auto') {
+    const recording = matcher.findMatch(call)
+    if (recording !== null) {
+      return hooks.synthesize(recording, options)
+    }
+    // fall through to record path (auto-additive)
+  }
+
+  // mode is 'record' OR auto-with-no-match
+  requireAckGate()
+  try {
+    const result = await hooks.realCall(file, args, options)
+    captureAndRecord(call, result, hooks, session, config)
+    return result
+  } catch (err) {
+    captureAndRecord(call, err, hooks, session, config)
+    throw err
+  }
+}
+
+function captureAndRecord<Opts, ResultShape>(
+  call: Call,
+  raw: ResultShape | unknown,
+  hooks: RunnerHooks<Opts, ResultShape>,
+  session: CassetteSession,
+  config: Config,
+): void {
+  const result = hooks.captureResult(raw)
+  record(call, result, session, config)
+}
+
+function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
+  if (matcher === null) {
+    throw new Error('shell-cassette: matcher was not initialized before use (internal bug)')
+  }
+  return matcher
+}
+
+function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
+  const recordedCalls = session.loadedFile?.recordings
+    .map((r) => `${r.call.command} ${r.call.args.join(' ')}`)
+    .join('\n  - ')
+  return new ReplayMissError(
+    `no matching recording for \`${call.command} ${call.args.join(' ')}\`
+  cassette: ${session.path}
+  matcher:  default (command + deep-equal args)
+
+Recorded calls in this cassette:
+  - ${recordedCalls ?? '(none)'}
+
+To re-record: delete the cassette file and run tests again.`,
+  )
+}

--- a/tests/unit/options-execa.test.ts
+++ b/tests/unit/options-execa.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { UnsupportedOptionError } from '../../src/errors.js'
-import { validateOptions } from '../../src/options.js'
+import { validateOptions } from '../../src/options-execa.js'
 
 describe('validateOptions', () => {
   test('passes for empty options', () => {
@@ -41,7 +41,7 @@ describe('validateOptions', () => {
       validateOptions({ ipc: true })
     } catch (e) {
       expect((e as Error).message).toContain('ipc')
-      expect((e as Error).message).toContain('v1.0')
+      expect((e as Error).message).toContain('Tracked in backlog')
     }
   })
 })


### PR DESCRIPTION
## What Changed

- Extracts runner-agnostic envelope from `src/execa.ts` into a new `src/wrapper.ts` (cassette lookup, mode resolution, ack gate, matcher init, record/replay branching).
- Slims `src/execa.ts` from 179 LOC to ~88 LOC; it now wires execa-specific bits (validate, buildCall, realCall, captureResult, synthesize) into `runWrapped` via an internal `RunnerHooks<Opts, ResultShape>` type.
- Renames `src/options.ts` to `src/options-execa.ts` and refreshes user-facing error messages to reference the backlog instead of stale "Planned for v0.2 / v1.0" claims.

No behavior change. All 136 tests pass.

## Why

Prep for the tinyexec adapter, which will share `wrapper.ts` and add a sibling `src/options-tinyexec.ts`.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (22 files, 136 tests, all green)
- [x] `npm run build` clean
- [x] Coverage aggregate 86.03% line / 79.78% branch (above 80/75 thresholds)
- [x] No public API change verified by reading commit diff