### PR TITLE
feat!: move execa adapter to shell-cassette/execa sub-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export default defineConfig({
 ```ts
 // my-test.test.ts
 import { test, expect } from 'vitest'
-import { execa } from 'shell-cassette'
+import { execa } from 'shell-cassette/execa'
 
 test('finds current branch', async () => {
   const { stdout } = await execa('git', ['branch', '--show-current'])
@@ -121,7 +121,8 @@ export default {
 For non-vitest contexts or `test.concurrent`:
 
 ```ts
-import { useCassette, execa } from 'shell-cassette'
+import { useCassette } from 'shell-cassette'
+import { execa } from 'shell-cassette/execa'
 
 test.concurrent('parallel test', async () => {
   await useCassette('./cassettes/parallel.json', async () => {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./execa": {
+      "types": "./dist/execa.d.ts",
+      "default": "./dist/execa.js"
+    },
     "./vitest": {
       "types": "./dist/vitest.d.ts",
       "default": "./dist/vitest.js"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
     "vitest": "^4.0.0"
   },
   "peerDependenciesMeta": {
+    "execa": {
+      "optional": true
+    },
     "vitest": {
       "optional": true
     }

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -30,8 +30,8 @@ function buildCall(file: string, args: readonly string[], options: Options): Cal
   }
 }
 
-function captureResult(execaResult: unknown): Result {
-  const r = execaResult as {
+function captureResult(raw: unknown): Result {
+  const r = raw as {
     stdout?: string | string[]
     stderr?: string | string[]
     all?: string | string[]

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -14,13 +14,13 @@ export function execa(
 
 const execaHooks: RunnerHooks<Options, unknown> = {
   validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
-  buildCall: (file, args, options) => buildCallExeca(file, args, options),
+  buildCall,
   realCall: (file, args, options) => realExeca(file, args, options) as unknown as Promise<unknown>,
-  captureResult: (raw) => captureResultExeca(raw),
-  synthesize: (rec, options) => synthesizeExeca(rec, options),
+  captureResult,
+  synthesize,
 }
 
-function buildCallExeca(file: string, args: readonly string[], options: Options): Call {
+function buildCall(file: string, args: readonly string[], options: Options): Call {
   return {
     command: file,
     args: [...args],
@@ -30,7 +30,7 @@ function buildCallExeca(file: string, args: readonly string[], options: Options)
   }
 }
 
-function captureResultExeca(execaResult: unknown): Result {
+function captureResult(execaResult: unknown): Result {
   const r = execaResult as {
     stdout?: string | string[]
     stderr?: string | string[]
@@ -55,7 +55,7 @@ function toLines(input: string | string[] | undefined): string[] {
   return input.split('\n')
 }
 
-function synthesizeExeca(rec: Recording, options: Options): unknown {
+function synthesize(rec: Recording, options: Options): unknown {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
   const all =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export { execa } from './execa.js'
 export type {
   Call,
   CassetteFile,

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -12,7 +12,7 @@ export type RunnerHooks<Opts, ResultShape> = {
   validate: (options: Opts | undefined) => void
   buildCall: (file: string, args: readonly string[], options: Opts) => Call
   realCall: (file: string, args: readonly string[], options: Opts) => Promise<ResultShape>
-  captureResult: (raw: ResultShape | unknown) => Result
+  captureResult: (raw: unknown) => Result
   synthesize: (rec: Recording, options: Opts) => ResultShape
 }
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -83,7 +83,7 @@ export async function runWrapped<Opts, ResultShape>(
 
 function captureAndRecord<Opts, ResultShape>(
   call: Call,
-  raw: ResultShape | unknown,
+  raw: unknown,
   hooks: RunnerHooks<Opts, ResultShape>,
   session: CassetteSession,
   config: Config,

--- a/tests/unit/options-execa.test.ts
+++ b/tests/unit/options-execa.test.ts
@@ -36,7 +36,7 @@ describe('validateOptions', () => {
     expect(() => validateOptions({ node: true })).toThrow(UnsupportedOptionError)
   })
 
-  test('error message includes the option name and target version', () => {
+  test('error message includes the option name and backlog reference', () => {
     try {
       validateOptions({ ipc: true })
     } catch (e) {


### PR DESCRIPTION
## What Changed

Breaking change. Migration is one line per import site:

```diff
- import { execa } from 'shell-cassette'
+ import { execa } from 'shell-cassette/execa'
```

Per SemVer 0.x, minor versions can ship breaking changes.

- `execa` adapter moves from the main `shell-cassette` entry to the `shell-cassette/execa` sub-path. Mirrors the existing pattern for `shell-cassette/{vitest,errors,config}`.
- Core `shell-cassette` entry shrinks to `useCassette` and shared types only. No adapter is privileged at the main entry.
- Both `execa` and `vitest` peer deps are now optional via `peerDependenciesMeta`. Users importing only `useCassette` no longer see unmet-peer warnings for execa.

### Cleanups bundled

- Drop redundant `ResultShape | unknown` from `RunnerHooks.captureResult` type signature (and the parallel internal `captureAndRecord` helper for consistency).
- Rename test `'includes the option name and target version'` to `'includes the option name and backlog reference'` (assertion was updated to check `'Tracked in backlog'`).
- Drop `Execa` suffix from private functions in `src/execa.ts`; simplify hook bundle to property shorthand.

## Why

Sets up the tinyexec adapter to land symmetrically. Adding nano-spawn / child_process / Bun / Deno later follows the same sub-path pattern with no further architectural change.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (22 files / 136 tests / all green)
- [x] `npm run build` clean
- [x] Smoke check: `import('./dist/execa.js')` exposes `execa` (function)
- [x] Smoke check: `import('./dist/index.js')` exposes only `useCassette`
- [x] `dist/index.js` does NOT transitively import from `'execa'` (verified: only `dist/execa.js` and `dist/execa.d.ts` reference it)

## Notes

The README still has two stale `import { execa } from 'shell-cassette'` references (lines 50 and 124). README updates are deferred to a later docs PR. Flagging here so the reviewer of the eventual docs PR knows to verify those specific lines.