### PR TITLE
feat: add tinyexec adapter at shell-cassette/tinyexec (with tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node": "^22.19.17",
         "@vitest/coverage-v8": "^4.1.5",
         "execa": "^9.0.0",
+        "tinyexec": "^1.1.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
       },
@@ -21,9 +22,12 @@
       },
       "peerDependencies": {
         "execa": "^9.0.0",
-        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0"
+        "vitest": "^4.0.0"
       },
       "peerDependenciesMeta": {
+        "execa": {
+          "optional": true
+        },
         "vitest": {
           "optional": true
         }
@@ -250,31 +254,6 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,6 +260,31 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -876,9 +901,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,14 @@
       },
       "peerDependencies": {
         "execa": "^9.0.0",
+        "tinyexec": "^1.0.0",
         "vitest": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "execa": {
+          "optional": true
+        },
+        "tinyexec": {
           "optional": true
         },
         "vitest": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/execa.d.ts",
       "default": "./dist/execa.js"
     },
+    "./tinyexec": {
+      "types": "./dist/tinyexec.d.ts",
+      "default": "./dist/tinyexec.js"
+    },
     "./vitest": {
       "types": "./dist/vitest.d.ts",
       "default": "./dist/vitest.js"

--- a/package.json
+++ b/package.json
@@ -73,10 +73,14 @@
   },
   "peerDependencies": {
     "execa": "^9.0.0",
+    "tinyexec": "^1.0.0",
     "vitest": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "execa": {
+      "optional": true
+    },
+    "tinyexec": {
       "optional": true
     },
     "vitest": {
@@ -88,6 +92,7 @@
     "@types/node": "^22.19.17",
     "@vitest/coverage-v8": "^4.1.5",
     "execa": "^9.0.0",
+    "tinyexec": "^1.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }

--- a/src/options-tinyexec.ts
+++ b/src/options-tinyexec.ts
@@ -1,0 +1,17 @@
+import { UnsupportedOptionError } from './errors.js'
+
+export function validateOptions(options: Record<string, unknown> | undefined): void {
+  if (!options) return
+
+  if (options.persist === true) {
+    throw new UnsupportedOptionError(
+      'tinyexec option `persist: true` not supported. Subprocesses outliving the host process cannot be replayed. Tracked in backlog.',
+    )
+  }
+
+  if (options.stdin !== undefined && options.stdin !== null && typeof options.stdin !== 'string') {
+    throw new UnsupportedOptionError(
+      'tinyexec option `stdin` as Result (pipe chaining) not supported. Pass a string for buffered stdin. Tracked in backlog.',
+    )
+  }
+}

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -49,6 +49,10 @@ function captureResult(raw: unknown): CassetteResult {
   // tinyexec.stdout/stderr is always a string per its type contract; the [''] fallback
   // exists only for defensive narrowing on `unknown` raw input (e.g., a thrown error
   // shape that happens to lack stdout/stderr fields).
+  //
+  // tinyexec exposes only `killed: boolean`, not the actual signal name (SIGINT,
+  // SIGKILL, etc.). We unconditionally record SIGTERM on kill; the real signal is
+  // lost. Tracked in backlog: "preserve exact signal for tinyexec recording".
   return {
     stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
     stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -7,11 +7,15 @@ import { type RunnerHooks, runWrapped } from './wrapper.js'
 
 export type { Options, Result } from 'tinyexec'
 
-export function x(file: string, args?: readonly string[], options?: Options): Promise<TinyResult> {
-  return runWrapped(file, args ?? [], options ?? ({} as Options), tinyexecHooks)
+export function x(
+  file: string,
+  args?: readonly string[],
+  options?: Partial<Options>,
+): Promise<TinyResult> {
+  return runWrapped(file, args ?? [], options ?? {}, tinyexecHooks)
 }
 
-const tinyexecHooks: RunnerHooks<Options, TinyResult> = {
+const tinyexecHooks: RunnerHooks<Partial<Options>, TinyResult> = {
   validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
   buildCall,
   realCall: (file, args, options) =>
@@ -20,7 +24,7 @@ const tinyexecHooks: RunnerHooks<Options, TinyResult> = {
   synthesize,
 }
 
-function buildCall(file: string, args: readonly string[], options: Options): Call {
+function buildCall(file: string, args: readonly string[], options: Partial<Options>): Call {
   const nodeOptions = (options as { nodeOptions?: { cwd?: string; env?: NodeJS.ProcessEnv } })
     .nodeOptions
   return {
@@ -50,7 +54,7 @@ function captureResult(raw: unknown): CassetteResult {
   }
 }
 
-function synthesize(rec: Recording, options: Options): TinyResult {
+function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
   const killed = rec.result.signal !== null

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -1,0 +1,91 @@
+import type { Options, Result as TinyResult } from 'tinyexec'
+import { x as realX } from 'tinyexec'
+import { UnsupportedOptionError } from './errors.js'
+import { validateOptions } from './options-tinyexec.js'
+import type { Call, Result as CassetteResult, Recording } from './types.js'
+import { type RunnerHooks, runWrapped } from './wrapper.js'
+
+export type { Options, Result } from 'tinyexec'
+
+export function x(file: string, args?: readonly string[], options?: Options): Promise<TinyResult> {
+  return runWrapped(file, args ?? [], options ?? ({} as Options), tinyexecHooks)
+}
+
+const tinyexecHooks: RunnerHooks<Options, TinyResult> = {
+  validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
+  buildCall,
+  realCall: (file, args, options) =>
+    realX(file, [...args], options) as unknown as Promise<TinyResult>,
+  captureResult,
+  synthesize,
+}
+
+function buildCall(file: string, args: readonly string[], options: Options): Call {
+  const nodeOptions = (options as { nodeOptions?: { cwd?: string; env?: NodeJS.ProcessEnv } })
+    .nodeOptions
+  return {
+    command: file,
+    args: [...args],
+    cwd: nodeOptions?.cwd ?? null,
+    env: (nodeOptions?.env as Record<string, string> | undefined) ?? {},
+    stdin: null,
+  }
+}
+
+function captureResult(raw: unknown): CassetteResult {
+  const r = raw as {
+    stdout?: string
+    stderr?: string
+    exitCode?: number
+    killed?: boolean
+    aborted?: boolean
+  }
+  return {
+    stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
+    stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],
+    allLines: null,
+    exitCode: r.exitCode ?? 0,
+    signal: r.killed === true ? 'SIGTERM' : null,
+    durationMs: 0,
+  }
+}
+
+function synthesize(rec: Recording, options: Options): TinyResult {
+  const stdout = rec.result.stdoutLines.join('\n')
+  const stderr = rec.result.stderrLines.join('\n')
+  const killed = rec.result.signal !== null
+
+  const result = {
+    stdout,
+    stderr,
+    exitCode: rec.result.exitCode,
+    pid: -1,
+    aborted: false,
+    killed,
+    process: null,
+    pipe: () => {
+      throw new UnsupportedOptionError(
+        'tinyexec result.pipe() not supported on replay (no live subprocess). Tracked in backlog.',
+      )
+    },
+    kill: () => {
+      // no-op on replay; subprocess never spawned
+    },
+    [Symbol.asyncIterator]: () => {
+      throw new UnsupportedOptionError(
+        'tinyexec async iteration `for await (line of result)` not supported on replay. Tracked in backlog.',
+      )
+    },
+  }
+
+  if ((options as { throwOnError?: boolean }).throwOnError === true && rec.result.exitCode !== 0) {
+    throw Object.assign(
+      new Error(
+        `Process exited with non-zero code: ${rec.result.exitCode} (command: ${rec.call.command})`,
+      ),
+      result,
+    )
+  }
+
+  return result as unknown as TinyResult
+}

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -18,6 +18,8 @@ export function x(
 const tinyexecHooks: RunnerHooks<Partial<Options>, TinyResult> = {
   validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
   buildCall,
+  // tinyexec's Result is structurally a PromiseLike & OutputApi, not Promise<Result>;
+  // double-cast through unknown is needed to satisfy the hook's Promise<ResultShape> signature
   realCall: (file, args, options) =>
     realX(file, [...args], options) as unknown as Promise<TinyResult>,
   captureResult,
@@ -44,6 +46,9 @@ function captureResult(raw: unknown): CassetteResult {
     killed?: boolean
     aborted?: boolean
   }
+  // tinyexec.stdout/stderr is always a string per its type contract; the [''] fallback
+  // exists only for defensive narrowing on `unknown` raw input (e.g., a thrown error
+  // shape that happens to lack stdout/stderr fields).
   return {
     stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
     stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],
@@ -91,5 +96,9 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
     )
   }
 
+  // The synthesized object lacks tinyexec's full structural shape (no `then`/`spawn`
+  // fields from ExecProcess; `process` is null instead of ChildProcess | undefined).
+  // Documented replay limit: code reading these fields synchronously before await,
+  // or calling sync-only ProcessApi methods, must use real execution.
   return result as unknown as TinyResult
 }

--- a/tests/e2e/tinyexec-record-replay.test.ts
+++ b/tests/e2e/tinyexec-record-replay.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { _resetForTesting } from '../../src/state.js'
+import { x } from '../../src/tinyexec.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+let tmp: string
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-e2e-'))
+  _resetForTesting()
+  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+  delete process.env.SHELL_CASSETTE_MODE
+  delete process.env.CI
+})
+
+afterEach(async () => {
+  _resetForTesting()
+  await rm(tmp, { recursive: true, force: true })
+  delete process.env.SHELL_CASSETTE_ACK_REDACTION
+})
+
+describe('tinyexec e2e', () => {
+  test('record then replay round-trip on node --version', async () => {
+    const cassettePath = path.join(tmp, 'node-version.json')
+
+    let recordedStdout = ''
+    await useCassette(cassettePath, async () => {
+      const r = await x('node', ['--version'])
+      recordedStdout = r.stdout
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toMatch(/^v\d+\.\d+\.\d+/)
+    })
+
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    await useCassette(cassettePath, async () => {
+      const r = await x('node', ['--version'])
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toBe(recordedStdout)
+    })
+  })
+
+  test('record then replay handles non-zero exit (no throw by default)', async () => {
+    const cassettePath = path.join(tmp, 'node-fail.json')
+
+    await useCassette(cassettePath, async () => {
+      const r = await x('node', ['-e', 'process.exit(1)'])
+      expect(r.exitCode).toBe(1)
+      // tinyexec default: does NOT throw on non-zero
+    })
+
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    await useCassette(cassettePath, async () => {
+      const r = await x('node', ['-e', 'process.exit(1)'])
+      expect(r.exitCode).toBe(1)
+    })
+  })
+
+  test('throwOnError throws on replay when exit code is non-zero', async () => {
+    const cassettePath = path.join(tmp, 'node-fail-throw.json')
+
+    await useCassette(cassettePath, async () => {
+      // Record run with throwOnError - real tinyexec throws
+      await expect(
+        x('node', ['-e', 'process.exit(1)'], { throwOnError: true }),
+      ).rejects.toBeDefined()
+    })
+
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    await useCassette(cassettePath, async () => {
+      // Replay run with throwOnError - synthesized error
+      await expect(x('node', ['-e', 'process.exit(1)'], { throwOnError: true })).rejects.toThrow(
+        /non-zero code: 1/,
+      )
+    })
+  })
+
+  test('record stdout with newlines, replay preserves them', async () => {
+    const cassettePath = path.join(tmp, 'node-multiline.json')
+
+    let recordedStdout = ''
+    await useCassette(cassettePath, async () => {
+      const r = await x('node', ['-e', 'console.log("a"); console.log("b"); console.log("c")'])
+      // tinyexec preserves trailing newline from `console.log("c")`
+      expect(r.stdout).toBe('a\nb\nc\n')
+      expect(r.exitCode).toBe(0)
+      recordedStdout = r.stdout
+    })
+
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    await useCassette(cassettePath, async () => {
+      const r = await x('node', ['-e', 'console.log("a"); console.log("b"); console.log("c")'])
+      expect(r.stdout).toBe(recordedStdout)
+    })
+  })
+})

--- a/tests/error-path/tinyexec-errors.test.ts
+++ b/tests/error-path/tinyexec-errors.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import {
+  AckRequiredError,
+  ReplayMissError,
+  ShellCassetteError,
+  UnsupportedOptionError,
+} from '../../src/errors.js'
+import { MatcherState } from '../../src/matcher.js'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { CassetteSession } from '../../src/types.js'
+
+vi.mock('tinyexec', () => ({
+  x: vi.fn(),
+}))
+
+const { x: realXMock } = await import('tinyexec')
+const { x } = await import('../../src/tinyexec.js')
+
+const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
+  const base: CassetteSession = {
+    name: 'test',
+    path: '/tmp/test.json',
+    scopeDefault: 'auto',
+    loadedFile: { version: 1, recordings: [] },
+    matcher: null,
+    newRecordings: [],
+    ...overrides,
+  }
+  // Mirror wrapper.ts lazy-load invariant
+  if (base.loadedFile !== null && base.matcher === null) {
+    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
+  }
+  return base
+}
+
+beforeEach(() => {
+  _resetForTesting()
+  vi.mocked(realXMock).mockReset()
+  delete process.env.SHELL_CASSETTE_MODE
+  delete process.env.SHELL_CASSETTE_ACK_REDACTION
+  delete process.env.CI
+})
+
+afterEach(() => {
+  _resetForTesting()
+  clearActiveCassette()
+})
+
+describe('tinyexec error paths', () => {
+  test('UnsupportedOptionError on persist:true', async () => {
+    await expect(x('echo', [], { persist: true })).rejects.toBeInstanceOf(UnsupportedOptionError)
+  })
+
+  test('UnsupportedOptionError inherits from ShellCassetteError', async () => {
+    try {
+      await x('echo', [], { persist: true })
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShellCassetteError)
+    }
+  })
+
+  test('UnsupportedOptionError message contains option name and backlog reference', async () => {
+    try {
+      await x('echo', [], { persist: true })
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect((e as Error).message).toContain('persist')
+      expect((e as Error).message).toContain('backlog')
+    }
+  })
+
+  test('AckRequiredError on record without ack env var', async () => {
+    setActiveCassette(makeSession({ loadedFile: null }))
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+
+    await expect(x('echo', ['hi'])).rejects.toBeInstanceOf(AckRequiredError)
+    expect(realXMock).not.toHaveBeenCalled()
+  })
+
+  test('ReplayMissError when cassette empty in replay mode', async () => {
+    setActiveCassette(makeSession({ loadedFile: { version: 1, recordings: [] } }))
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    await expect(x('echo', ['unrecorded'])).rejects.toBeInstanceOf(ReplayMissError)
+  })
+
+  test('ReplayMissError message includes the call signature', async () => {
+    setActiveCassette(makeSession({ loadedFile: { version: 1, recordings: [] } }))
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    try {
+      await x('git', ['status', '--porcelain'])
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ReplayMissError)
+      expect((e as Error).message).toContain('git status --porcelain')
+      expect((e as Error).message).toContain('To re-record')
+    }
+  })
+})

--- a/tests/error-path/tinyexec-errors.test.ts
+++ b/tests/error-path/tinyexec-errors.test.ts
@@ -1,14 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { DEFAULT_CONFIG } from '../../src/config.js'
 import {
   AckRequiredError,
   ReplayMissError,
   ShellCassetteError,
   UnsupportedOptionError,
 } from '../../src/errors.js'
-import { MatcherState } from '../../src/matcher.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { CassetteSession } from '../../src/types.js'
+import { makeSession } from '../helpers/session.js'
 
 vi.mock('tinyexec', () => ({
   x: vi.fn(),
@@ -16,23 +14,6 @@ vi.mock('tinyexec', () => ({
 
 const { x: realXMock } = await import('tinyexec')
 const { x } = await import('../../src/tinyexec.js')
-
-const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
-  const base: CassetteSession = {
-    name: 'test',
-    path: '/tmp/test.json',
-    scopeDefault: 'auto',
-    loadedFile: { version: 1, recordings: [] },
-    matcher: null,
-    newRecordings: [],
-    ...overrides,
-  }
-  // Mirror wrapper.ts lazy-load invariant
-  if (base.loadedFile !== null && base.matcher === null) {
-    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
-  }
-  return base
-}
 
 beforeEach(() => {
   _resetForTesting()

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import { MatcherState } from '../../src/matcher.js'
+import type { CassetteSession } from '../../src/types.js'
+
+// Mirror wrapper.ts lazy-load invariant: the wrapper only initializes
+// session.matcher on the lazy-load path (when loadedFile is null on first
+// call). Tests that pre-populate loadedFile must also pre-populate matcher,
+// or ensureMatcher() throws "internal bug" on the first call. Tracked under
+// issue #26 (CassetteSession type permits unreachable states).
+export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
+  const base: CassetteSession = {
+    name: 'test',
+    path: '/tmp/test.json',
+    scopeDefault: 'auto',
+    loadedFile: { version: 1, recordings: [] },
+    matcher: null,
+    newRecordings: [],
+    ...overrides,
+  }
+  if (base.loadedFile !== null && base.matcher === null) {
+    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
+  }
+  return base
+}

--- a/tests/integration/wrapper-tinyexec.test.ts
+++ b/tests/integration/wrapper-tinyexec.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { serialize } from '../../src/serialize.js'
 import { _resetForTesting, clearActiveCassette } from '../../src/state.js'
 import { useCassette } from '../../src/use-cassette.js'
 
@@ -57,7 +58,7 @@ describe('tinyexec integration', () => {
   test('replay reads cassette file and synthesizes result', async () => {
     const cassettePath = path.join(tmp, 'test.json')
 
-    const cassetteJson = JSON.stringify({
+    const cassetteJson = serialize({
       version: 1,
       recordings: [
         {
@@ -106,7 +107,7 @@ describe('tinyexec integration', () => {
   test('lazy write: cassette only written when newRecordings has entries', async () => {
     const cassettePath = path.join(tmp, 'replay-only.json')
 
-    const cassetteJson = JSON.stringify({
+    const cassetteJson = serialize({
       version: 1,
       recordings: [
         {

--- a/tests/integration/wrapper-tinyexec.test.ts
+++ b/tests/integration/wrapper-tinyexec.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { _resetForTesting, clearActiveCassette } from '../../src/state.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+vi.mock('tinyexec', () => ({
+  x: vi.fn(),
+}))
+
+const { x: realXMock } = await import('tinyexec')
+const { x } = await import('../../src/tinyexec.js')
+
+let tmp: string
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
+  _resetForTesting()
+  vi.mocked(realXMock).mockReset()
+  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+  delete process.env.SHELL_CASSETTE_MODE
+  delete process.env.CI
+})
+
+afterEach(async () => {
+  _resetForTesting()
+  clearActiveCassette()
+  await rm(tmp, { recursive: true, force: true })
+  delete process.env.SHELL_CASSETTE_ACK_REDACTION
+})
+
+describe('tinyexec integration', () => {
+  test('record creates cassette file with new recording', async () => {
+    vi.mocked(realXMock).mockResolvedValueOnce({
+      stdout: 'recorded-output',
+      stderr: '',
+      exitCode: 0,
+      pid: 1,
+      aborted: false,
+      killed: false,
+    } as never)
+
+    const cassettePath = path.join(tmp, 'test.json')
+    await useCassette(cassettePath, async () => {
+      await x('echo', ['recorded-output'])
+    })
+
+    const content = await readFile(cassettePath, 'utf8')
+    const parsed = JSON.parse(content)
+    expect(parsed.version).toBe(1)
+    expect(parsed.recordings).toHaveLength(1)
+    expect(parsed.recordings[0].call.command).toBe('echo')
+    expect(parsed.recordings[0].result.stdoutLines).toEqual(['recorded-output'])
+  })
+
+  test('replay reads cassette file and synthesizes result', async () => {
+    const cassettePath = path.join(tmp, 'test.json')
+
+    const cassetteJson = JSON.stringify({
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'echo', args: ['canned'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['canned'],
+            stderrLines: [''],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+          },
+        },
+      ],
+    })
+    await writeFile(cassettePath, cassetteJson, 'utf8')
+
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    let received: { stdout: string; exitCode: number } | null = null
+    await useCassette(cassettePath, async () => {
+      const r = (await x('echo', ['canned'])) as unknown as {
+        stdout: string
+        exitCode: number
+      }
+      received = r
+    })
+
+    expect(realXMock).not.toHaveBeenCalled()
+    expect(received).not.toBeNull()
+    expect((received as unknown as { stdout: string }).stdout).toBe('canned')
+    expect((received as unknown as { exitCode: number }).exitCode).toBe(0)
+  })
+
+  test('lazy load: cassette file not read when no x() call happens', async () => {
+    const cassettePath = path.join(tmp, 'never-loaded.json')
+
+    await useCassette(cassettePath, async () => {
+      // no x() calls in scope
+    })
+
+    // Cassette file should not exist (no recordings to write)
+    await expect(stat(cassettePath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  test('lazy write: cassette only written when newRecordings has entries', async () => {
+    const cassettePath = path.join(tmp, 'replay-only.json')
+
+    const cassetteJson = JSON.stringify({
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['hi'],
+            stderrLines: [''],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+          },
+        },
+      ],
+    })
+    await writeFile(cassettePath, cassetteJson, 'utf8')
+
+    const beforeStat = await stat(cassettePath)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    await useCassette(cassettePath, async () => {
+      await x('echo', ['hi']) // matches recording, no new write
+    })
+
+    const afterStat = await stat(cassettePath)
+    expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs)
+  })
+})

--- a/tests/unit/options-tinyexec.test.ts
+++ b/tests/unit/options-tinyexec.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { UnsupportedOptionError } from '../../src/errors.js'
+import { validateOptions } from '../../src/options-tinyexec.js'
+
+describe('validateOptions (tinyexec)', () => {
+  test('accepts undefined options', () => {
+    expect(() => validateOptions(undefined)).not.toThrow()
+  })
+
+  test('accepts empty options', () => {
+    expect(() => validateOptions({})).not.toThrow()
+  })
+
+  test('throws UnsupportedOptionError for persist:true', () => {
+    expect(() => validateOptions({ persist: true })).toThrow(UnsupportedOptionError)
+  })
+
+  test('error message for persist:true mentions persist and backlog', () => {
+    try {
+      validateOptions({ persist: true })
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect((e as Error).message).toContain('persist')
+      expect((e as Error).message).toContain('backlog')
+    }
+  })
+
+  test('accepts persist:false', () => {
+    expect(() => validateOptions({ persist: false })).not.toThrow()
+  })
+
+  test('throws UnsupportedOptionError for stdin as object (Result piping)', () => {
+    const fakeResult = { stdout: 'foo', stderr: '', exitCode: 0 }
+    expect(() => validateOptions({ stdin: fakeResult })).toThrow(UnsupportedOptionError)
+  })
+
+  test('error message for stdin-as-object mentions stdin and string', () => {
+    try {
+      validateOptions({ stdin: { stdout: 'x' } })
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect((e as Error).message).toContain('stdin')
+      expect((e as Error).message).toContain('string')
+    }
+  })
+
+  test('accepts stdin as string', () => {
+    expect(() => validateOptions({ stdin: 'hello' })).not.toThrow()
+  })
+
+  test('accepts stdin as undefined', () => {
+    expect(() => validateOptions({ stdin: undefined })).not.toThrow()
+  })
+
+  test('accepts stdin as null', () => {
+    expect(() => validateOptions({ stdin: null })).not.toThrow()
+  })
+
+  test('accepts signal, timeout, nodeOptions, throwOnError together', () => {
+    const aborter = new AbortController()
+    expect(() =>
+      validateOptions({
+        signal: aborter.signal,
+        timeout: 5000,
+        nodeOptions: { cwd: '/tmp' },
+        throwOnError: true,
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts unknown future options without throwing', () => {
+    // Forward-compat: tinyexec may add options we don't know about; we accept them.
+    expect(() => validateOptions({ someUnknownFutureOption: true })).not.toThrow()
+  })
+})

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { DEFAULT_CONFIG } from '../../src/config.js'
-import { MatcherState } from '../../src/matcher.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { CassetteSession, Recording } from '../../src/types.js'
+import type { Recording } from '../../src/types.js'
+import { makeSession } from '../helpers/session.js'
 
 vi.mock('tinyexec', () => ({
   x: vi.fn(),
@@ -10,24 +9,6 @@ vi.mock('tinyexec', () => ({
 
 const { x: realXMock } = await import('tinyexec')
 const { x } = await import('../../src/tinyexec.js')
-
-const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
-  const base: CassetteSession = {
-    name: 'test',
-    path: '/tmp/test.json',
-    scopeDefault: 'auto',
-    loadedFile: { version: 1, recordings: [] },
-    matcher: null,
-    newRecordings: [],
-    ...overrides,
-  }
-  // Mirror wrapper.ts lazy-load invariant: if loadedFile is set, matcher must
-  // also be set. (Wrapper only inits matcher on the lazy-load path.)
-  if (base.loadedFile !== null && base.matcher === null) {
-    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
-  }
-  return base
-}
 
 describe('tinyexec adapter', () => {
   beforeEach(() => {

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import { MatcherState } from '../../src/matcher.js'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { CassetteSession, Recording } from '../../src/types.js'
+
+vi.mock('tinyexec', () => ({
+  x: vi.fn(),
+}))
+
+const { x: realXMock } = await import('tinyexec')
+const { x } = await import('../../src/tinyexec.js')
+
+const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
+  const base: CassetteSession = {
+    name: 'test',
+    path: '/tmp/test.json',
+    scopeDefault: 'auto',
+    loadedFile: { version: 1, recordings: [] },
+    matcher: null,
+    newRecordings: [],
+    ...overrides,
+  }
+  // Mirror wrapper.ts lazy-load invariant: if loadedFile is set, matcher must
+  // also be set. (Wrapper only inits matcher on the lazy-load path.)
+  if (base.loadedFile !== null && base.matcher === null) {
+    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
+  }
+  return base
+}
+
+describe('tinyexec adapter', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    vi.mocked(realXMock).mockReset()
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+  })
+
+  test('passthrough calls real tinyexec when no cassette', async () => {
+    vi.mocked(realXMock).mockResolvedValueOnce({
+      stdout: 'hello',
+      stderr: '',
+      exitCode: 0,
+      pid: 123,
+      aborted: false,
+      killed: false,
+    } as never)
+
+    const result = await x('echo', ['hello'])
+    expect(realXMock).toHaveBeenCalledWith('echo', ['hello'], {})
+    expect(result.stdout).toBe('hello')
+  })
+
+  test('buildCall extracts cwd and env from nodeOptions', async () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    const session = makeSession({ loadedFile: null })
+    setActiveCassette(session)
+
+    vi.mocked(realXMock).mockResolvedValueOnce({
+      stdout: 'ok',
+      stderr: '',
+      exitCode: 0,
+      pid: 1,
+      aborted: false,
+      killed: false,
+    } as never)
+
+    await x('git', ['status'], {
+      nodeOptions: { cwd: '/repo', env: { GIT_TERMINAL_PROMPT: '0' } },
+    })
+
+    expect(session.newRecordings[0]?.call.cwd).toBe('/repo')
+    expect(session.newRecordings[0]?.call.env).toEqual({ GIT_TERMINAL_PROMPT: '0' })
+  })
+
+  test('captureResult maps stdout/stderr to line arrays', async () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    const session = makeSession({ loadedFile: null })
+    setActiveCassette(session)
+
+    vi.mocked(realXMock).mockResolvedValueOnce({
+      stdout: 'a\nb',
+      stderr: 'err',
+      exitCode: 0,
+      pid: 1,
+      aborted: false,
+      killed: false,
+    } as never)
+
+    await x('node', ['-e', 'console.log("a"); console.log("b"); console.error("err")'])
+
+    expect(session.newRecordings[0]?.result.stdoutLines).toEqual(['a', 'b'])
+    expect(session.newRecordings[0]?.result.stderrLines).toEqual(['err'])
+    expect(session.newRecordings[0]?.result.allLines).toBeNull()
+  })
+
+  test('captureResult maps killed=true to signal=SIGTERM', async () => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    const session = makeSession({ loadedFile: null })
+    setActiveCassette(session)
+
+    vi.mocked(realXMock).mockResolvedValueOnce({
+      stdout: '',
+      stderr: '',
+      exitCode: 143,
+      pid: 1,
+      aborted: false,
+      killed: true,
+    } as never)
+
+    await x('sleep', ['10'])
+    expect(session.newRecordings[0]?.result.signal).toBe('SIGTERM')
+  })
+
+  test('synthesize returns tinyexec-shaped result on replay', async () => {
+    const recording: Recording = {
+      call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['hi'],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const result = await x('echo', ['hi'])
+
+    expect(result.stdout).toBe('hi')
+    expect(result.stderr).toBe('')
+    expect(result.exitCode).toBe(0)
+    expect(result.killed).toBe(false)
+    expect(result.aborted).toBe(false)
+    expect(realXMock).not.toHaveBeenCalled()
+  })
+
+  test('synthesize honors throwOnError when exit code is non-zero', async () => {
+    const recording: Recording = {
+      call: { command: 'false', args: [], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: [''],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 1,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    await expect(x('false', [], { throwOnError: true })).rejects.toThrow(/non-zero code: 1/)
+  })
+
+  test('synthesize does NOT throw on non-zero by default (inverse of execa)', async () => {
+    const recording: Recording = {
+      call: { command: 'false', args: [], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: [''],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 1,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const result = await x('false', [])
+    expect(result.exitCode).toBe(1)
+  })
+
+  test('synthesize result.process is null on replay', async () => {
+    const recording: Recording = {
+      call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['hi'],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const result = (await x('echo', ['hi'])) as unknown as { process: unknown }
+    expect(result.process).toBeNull()
+  })
+
+  test('synthesize result.pipe() throws UnsupportedOptionError', async () => {
+    const recording: Recording = {
+      call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['hi'],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const result = (await x('echo', ['hi'])) as unknown as { pipe: () => void }
+    expect(() => result.pipe()).toThrow(/pipe.*not supported/i)
+  })
+
+  test('synthesize async iteration throws UnsupportedOptionError', async () => {
+    const recording: Recording = {
+      call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['hi'],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const result = await x('echo', ['hi'])
+    expect(() => {
+      const it = (result as { [Symbol.asyncIterator]: () => unknown })[Symbol.asyncIterator]()
+      return it
+    }).toThrow(/async iteration.*not supported/i)
+  })
+})

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { DEFAULT_CONFIG } from '../../src/config.js'
 import { AckRequiredError, ReplayMissError, UnsupportedOptionError } from '../../src/errors.js'
-import { MatcherState } from '../../src/matcher.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { CassetteSession, Recording } from '../../src/types.js'
+import type { Recording } from '../../src/types.js'
 import { type RunnerHooks, runWrapped } from '../../src/wrapper.js'
+import { makeSession } from '../helpers/session.js'
 
 type FakeOpts = { fake?: true }
 type FakeResult = { stdout: string; exitCode: number }
@@ -37,25 +36,6 @@ const baseHooks = (
     exitCode: rec.result.exitCode,
   }),
 })
-
-const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
-  const base: CassetteSession = {
-    name: 'test',
-    path: '/tmp/test.json',
-    scopeDefault: 'auto',
-    loadedFile: { version: 1, recordings: [] },
-    matcher: null,
-    newRecordings: [],
-    ...overrides,
-  }
-  // wrapper.ts only initializes the matcher when loadedFile is null on first
-  // call. When tests pre-populate loadedFile, also pre-populate the matcher
-  // to mirror what the wrapper would do on its lazy-load path.
-  if (base.loadedFile !== null && base.matcher === null) {
-    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
-  }
-  return base
-}
 
 describe('runWrapped (envelope)', () => {
   beforeEach(() => {

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import { AckRequiredError, ReplayMissError, UnsupportedOptionError } from '../../src/errors.js'
+import { MatcherState } from '../../src/matcher.js'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { CassetteSession, Recording } from '../../src/types.js'
+import { type RunnerHooks, runWrapped } from '../../src/wrapper.js'
+
+type FakeOpts = { fake?: true }
+type FakeResult = { stdout: string; exitCode: number }
+
+const baseHooks = (
+  realCall: (file: string, args: readonly string[], options: FakeOpts) => Promise<FakeResult>,
+): RunnerHooks<FakeOpts, FakeResult> => ({
+  validate: () => {},
+  buildCall: (file, args) => ({
+    command: file,
+    args: [...args],
+    cwd: null,
+    env: {},
+    stdin: null,
+  }),
+  realCall,
+  captureResult: (raw) => {
+    const r = raw as FakeResult
+    return {
+      stdoutLines: r.stdout.split('\n'),
+      stderrLines: [''],
+      allLines: null,
+      exitCode: r.exitCode,
+      signal: null,
+      durationMs: 0,
+    }
+  },
+  synthesize: (rec) => ({
+    stdout: rec.result.stdoutLines.join('\n'),
+    exitCode: rec.result.exitCode,
+  }),
+})
+
+const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
+  const base: CassetteSession = {
+    name: 'test',
+    path: '/tmp/test.json',
+    scopeDefault: 'auto',
+    loadedFile: { version: 1, recordings: [] },
+    matcher: null,
+    newRecordings: [],
+    ...overrides,
+  }
+  // wrapper.ts only initializes the matcher when loadedFile is null on first
+  // call. When tests pre-populate loadedFile, also pre-populate the matcher
+  // to mirror what the wrapper would do on its lazy-load path.
+  if (base.loadedFile !== null && base.matcher === null) {
+    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
+  }
+  return base
+}
+
+describe('runWrapped (envelope)', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+  })
+
+  test('passthrough when no active cassette', async () => {
+    const realCall = vi.fn(async () => ({ stdout: 'hello', exitCode: 0 }))
+    const result = await runWrapped('echo', ['hello'], {}, baseHooks(realCall))
+    expect(realCall).toHaveBeenCalledOnce()
+    expect(result).toEqual({ stdout: 'hello', exitCode: 0 })
+  })
+
+  test('validate is called even when no active cassette', async () => {
+    const validate = vi.fn(() => {
+      throw new UnsupportedOptionError('test')
+    })
+    const realCall = vi.fn()
+    const hooks: RunnerHooks<FakeOpts, FakeResult> = {
+      ...baseHooks(realCall as never),
+      validate,
+    }
+    await expect(runWrapped('echo', [], {}, hooks)).rejects.toBeInstanceOf(UnsupportedOptionError)
+    expect(validate).toHaveBeenCalledOnce()
+    expect(realCall).not.toHaveBeenCalled()
+  })
+
+  test('record path requires ack gate', async () => {
+    const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
+    setActiveCassette(session)
+    const realCall = vi.fn(async () => ({ stdout: 'x', exitCode: 0 }))
+    await expect(runWrapped('echo', [], {}, baseHooks(realCall))).rejects.toBeInstanceOf(
+      AckRequiredError,
+    )
+    expect(realCall).not.toHaveBeenCalled()
+    clearActiveCassette()
+  })
+
+  test('replay path returns synthesized result on match', async () => {
+    const recording: Recording = {
+      call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['hi', ''],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const realCall = vi.fn()
+    const result = await runWrapped('echo', ['hi'], {}, baseHooks(realCall as never))
+    expect(realCall).not.toHaveBeenCalled()
+    expect(result).toEqual({ stdout: 'hi\n', exitCode: 0 })
+    clearActiveCassette()
+  })
+
+  test('replay path throws ReplayMissError when no match', async () => {
+    const session = makeSession({
+      loadedFile: { version: 1, recordings: [] },
+    })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+
+    const realCall = vi.fn()
+    await expect(
+      runWrapped('echo', ['hi'], {}, baseHooks(realCall as never)),
+    ).rejects.toBeInstanceOf(ReplayMissError)
+    clearActiveCassette()
+  })
+
+  test('record path captures result and returns it', async () => {
+    const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    const realCall = vi.fn(async () => ({ stdout: 'recorded', exitCode: 0 }))
+
+    const result = await runWrapped('echo', ['recorded'], {}, baseHooks(realCall))
+
+    expect(result).toEqual({ stdout: 'recorded', exitCode: 0 })
+    expect(session.newRecordings).toHaveLength(1)
+    expect(session.newRecordings[0]?.result.stdoutLines).toEqual(['recorded'])
+    clearActiveCassette()
+  })
+
+  test('record path captures error and re-throws', async () => {
+    const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+
+    const fakeError = Object.assign(new Error('subprocess failed'), {
+      stdout: 'partial',
+      exitCode: 1,
+    })
+    const realCall = vi.fn(async () => {
+      throw fakeError
+    })
+
+    await expect(runWrapped('echo', [], {}, baseHooks(realCall))).rejects.toBe(fakeError)
+    expect(session.newRecordings).toHaveLength(1)
+    expect(session.newRecordings[0]?.result.exitCode).toBe(1)
+    clearActiveCassette()
+  })
+})


### PR DESCRIPTION
## What Changed

Additive change (no breaking impact). Adds the tinyexec adapter at `shell-cassette/tinyexec` plus full test coverage.

```ts
import { x } from 'shell-cassette/tinyexec'

const r = await x('git', ['status'])
console.log(r.stdout)
```

Both `execa` and `tinyexec` peer deps are optional. Install only what you use.

### Source

- `src/options-tinyexec.ts` (17 lines): option validator. Rejects `persist:true` (subprocesses outliving host process can't be replayed) and `stdin` as Result (pipe chaining requires live process). Accepts everything else.
- `src/tinyexec.ts` (104 lines): thin adapter wiring tinyexec hooks into the shared `runWrapped` envelope. Honors `throwOnError` on replay (inverse of execa's `reject` default; tinyexec doesn't throw by default on non-zero exit).
- `package.json`: adds tinyexec to dev/peer deps with `optional: true`, plus the `./tinyexec` exports entry.

### Tests

| File | LOC | Tests | Purpose |
|---|---:|---:|---|
| `tests/unit/options-tinyexec.test.ts` | 77 | 12 | Validator: accepted shapes, rejection paths, error messages |
| `tests/unit/wrapper.test.ts` | 176 | 7 | Envelope behavior with synthetic hooks (runner-agnostic) |
| `tests/unit/tinyexec-adapter.test.ts` | 261 | 10 | buildCall, captureResult, synthesize behavior with mocked tinyexec |
| `tests/integration/wrapper-tinyexec.test.ts` | 137 | 4 | Real fs (temp dirs) + mocked tinyexec; record creates cassette, replay reads cassette, lazy load, lazy write |
| `tests/e2e/tinyexec-record-replay.test.ts` | 98 | 4 | Real tinyexec spawning real `node`; round-trip on `node --version`, non-zero exit, throwOnError, multi-line stdout |
| `tests/error-path/tinyexec-errors.test.ts` | 102 | 6 | UnsupportedOptionError on persist:true, ShellCassetteError inheritance, AckRequiredError, ReplayMissError variants |

Test count: 109 -> 136 (post-extract) -> 179 (this PR). +43 new tests.

## Documented replay limits (tinyexec)

- `result.process` is `null` (no live `ChildProcess` to expose).
- `result.pipe()` throws `UnsupportedOptionError`.
- `result.kill()` is a no-op.
- `for await (line of result)` async iteration throws `UnsupportedOptionError`.
- Synchronous reads of `pid`, `killed`, `aborted` before `await` are not honored (the wrapper returns `Promise<TinyResult>`, not the tinyexec ProcessPromise shape).
- `signal` mapping is lossy: tinyexec exposes only `killed: boolean`, not the actual signal name. We unconditionally record `'SIGTERM'` on kill. Tracked in backlog.

## Notes

- The first version used `Options` (tinyexec's required-fields interface) in the public function signature. tinyexec's `Options` declares all six fields as required; tinyexec itself wraps the call site in `Partial<Options>` for ergonomics. Without `Partial<>`, common usage like `x('node', ['-v'], { throwOnError: true })` fails typecheck with TS2345. Verified empirically and fixed.
- tinyexec preserves trailing newlines from stdout (e.g., `console.log('c')` produces `'a\nb\nc\n'`, not `'a\nb\nc'`). The line-array round-trip handles this correctly.

## Related Issues

Issue #26: `ensureMatcher` type smell, tracked separately; affects test scaffolding (added comment with details).

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (28 files / 179 tests / all green)
- [x] `npm run test:coverage` (88.28% statements / 83.87% branches; above 80/75 thresholds)
- [x] `npm run build` clean
- [x] All sub-paths resolve correctly (`shell-cassette`, `shell-cassette/execa`, `shell-cassette/tinyexec`, `shell-cassette/vitest`, `shell-cassette/errors`, `shell-cassette/config`)
- [x] Public API typechecks under user call patterns (verified empirically with synthetic user file)