### PR TITLE
test: add tinyexec dogfood with committed cassettes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,8 @@ jobs:
       - name: test
         run: npm test
 
+      - name: test:dogfood
+        run: npm run test:dogfood
+
       - name: build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:dogfood": "vitest run --config vitest.dogfood.config.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",

--- a/tests/dogfood/tinyexec/__cassettes__/dogfood.test.ts/shell-cassette-tinyexec-dogfood/replays-multi-line-stdout-preserving-trailing-newline.json
+++ b/tests/dogfood/tinyexec/__cassettes__/dogfood.test.ts/shell-cassette-tinyexec-dogfood/replays-multi-line-stdout-preserving-trailing-newline.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "recordings": [
+    {
+      "call": {
+        "command": "node",
+        "args": [
+          "-e",
+          "console.log(\"line1\"); console.log(\"line2\")"
+        ],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": [
+          "line1",
+          "line2",
+          ""
+        ],
+        "stderrLines": [
+          ""
+        ],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 0
+      }
+    }
+  ]
+}

--- a/tests/dogfood/tinyexec/__cassettes__/dogfood.test.ts/shell-cassette-tinyexec-dogfood/replays-node-version-output-from-cassette.json
+++ b/tests/dogfood/tinyexec/__cassettes__/dogfood.test.ts/shell-cassette-tinyexec-dogfood/replays-node-version-output-from-cassette.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "recordings": [
+    {
+      "call": {
+        "command": "node",
+        "args": [
+          "--version"
+        ],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": [
+          "v23.11.0\r",
+          ""
+        ],
+        "stderrLines": [
+          ""
+        ],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 0
+      }
+    }
+  ]
+}

--- a/tests/dogfood/tinyexec/__cassettes__/dogfood.test.ts/shell-cassette-tinyexec-dogfood/replays-non-zero-exit-without-throwing-by-default.json
+++ b/tests/dogfood/tinyexec/__cassettes__/dogfood.test.ts/shell-cassette-tinyexec-dogfood/replays-non-zero-exit-without-throwing-by-default.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "recordings": [
+    {
+      "call": {
+        "command": "node",
+        "args": [
+          "-e",
+          "process.exit(2)"
+        ],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": [
+          ""
+        ],
+        "stderrLines": [
+          ""
+        ],
+        "allLines": null,
+        "exitCode": 2,
+        "signal": null,
+        "durationMs": 0
+      }
+    }
+  ]
+}

--- a/tests/dogfood/tinyexec/dogfood.test.ts
+++ b/tests/dogfood/tinyexec/dogfood.test.ts
@@ -6,14 +6,19 @@
 //
 // CI replay-strict: set CI=true (forces replay; record paths throw).
 
-import '../../../src/vitest.js'
 import { describe, expect, test } from 'vitest'
+// Side-effect import: registers the vitest auto-cassette plugin's beforeEach/
+// afterEach hooks. Must be imported (the load order vs `vitest` doesn't matter
+// since both register effects synchronously before any test runs).
+import '../../../src/vitest.js'
 import { x } from '../../../src/tinyexec.js'
 
 describe('shell-cassette tinyexec dogfood', () => {
   test('replays node version output from cassette', async () => {
     const r = await x('node', ['--version'])
     expect(r.exitCode).toBe(0)
+    // Regex-anchored prefix only; tolerates trailing \r\n on Windows-recorded
+    // cassettes and the cassette's actual node version (whoever recorded last).
     expect(r.stdout).toMatch(/^v\d+\.\d+\.\d+/)
   })
 

--- a/tests/dogfood/tinyexec/dogfood.test.ts
+++ b/tests/dogfood/tinyexec/dogfood.test.ts
@@ -1,0 +1,33 @@
+// Dogfood: shell-cassette tests itself with the vitest auto-cassette plugin.
+// Cassettes are committed under __cassettes__/ so CI replays from disk.
+//
+// Local re-record: delete the cassette files, then
+//   SHELL_CASSETTE_ACK_REDACTION=true npm run test:dogfood
+//
+// CI replay-strict: set CI=true (forces replay; record paths throw).
+
+import '../../../src/vitest.js'
+import { describe, expect, test } from 'vitest'
+import { x } from '../../../src/tinyexec.js'
+
+describe('shell-cassette tinyexec dogfood', () => {
+  test('replays node version output from cassette', async () => {
+    const r = await x('node', ['--version'])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toMatch(/^v\d+\.\d+\.\d+/)
+  })
+
+  test('replays multi-line stdout preserving trailing newline', async () => {
+    const r = await x('node', ['-e', 'console.log("line1"); console.log("line2")'])
+    expect(r.exitCode).toBe(0)
+    // tinyexec preserves trailing newlines from console.log. Tolerate \r on
+    // Windows-recorded cassettes (Node's stdout path varies by output kind).
+    expect(r.stdout).toMatch(/^line1\r?\nline2\r?\n$/)
+  })
+
+  test('replays non-zero exit without throwing by default', async () => {
+    const r = await x('node', ['-e', 'process.exit(2)'])
+    expect(r.exitCode).toBe(2)
+    // tinyexec's default does NOT throw on non-zero exit
+  })
+})

--- a/vitest.dogfood.config.ts
+++ b/vitest.dogfood.config.ts
@@ -10,6 +10,5 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['tests/dogfood/**/*.test.ts'],
-    exclude: ['node_modules/**', 'dist/**'],
   },
 })

--- a/vitest.dogfood.config.ts
+++ b/vitest.dogfood.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+// Dogfood tests run separately from the regular suite because they import
+// `src/vitest.ts` which registers global beforeEach/afterEach hooks. Those
+// hooks try to derive a cassette path for every test in the run and would
+// interfere with regular unit/integration tests that don't expect to be
+// auto-cassetted.
+//
+// Run with `npm run test:dogfood`. CI runs both this and the regular suite.
+export default defineConfig({
+  test: {
+    include: ['tests/dogfood/**/*.test.ts'],
+    exclude: ['node_modules/**', 'dist/**'],
+  },
+})


### PR DESCRIPTION
## What Changed

- `vitest.dogfood.config.ts`: separate vitest config because importing `src/vitest.ts` registers global beforeEach/afterEach hooks that interfere with the regular suite.
- `tests/dogfood/tinyexec/dogfood.test.ts`: three tests using the auto-cassette plugin.
- Three committed cassette JSON files under `__cassettes__/`.
- New npm script: `test:dogfood`.
- CI workflow updated to run `test:dogfood` after the regular test step.

## Why

Self-tests the tinyexec adapter via the vitest auto-cassette plugin. Cassettes are committed under `tests/dogfood/tinyexec/__cassettes__/` so CI exercises the replay-from-disk path on every run. v0.2 dogfoods only tinyexec because that's the new adapter being introduced.

## Three dogfood tests

| Test | Asserts |
|---|---|
| `replays node version output from cassette` | `exitCode === 0`, `stdout` matches `/^v\d+\.\d+\.\d+/` |
| `replays multi-line stdout preserving trailing newline` | `exitCode === 0`, stdout matches regex tolerant of `\r?\n` |
| `replays non-zero exit without throwing by default` | `exitCode === 2` (verifies tinyexec's default no-throw behavior) |

## Notes

Cross-platform line endings: cassettes recorded on Windows. The `node --version` cassette captured `\r` in stdout (Node's `--version` path on Windows preserves CRLF). The multi-line cassette captured clean LF (`console.log` path differs on the same Node, same machine, different output kind). Both assertions are line-ending tolerant. CI on Ubuntu and Windows replays the same cassette content; tests pass on both.

Local re-record:

```bash
rm -rf tests/dogfood/tinyexec/__cassettes__/
SHELL_CASSETTE_ACK_REDACTION=true npm run test:dogfood
```

CI replay-strict:

```bash
CI=true npm run test:dogfood
```

This forces replay mode; any new record attempt throws.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (28 files / 179 tests / all green; regular suite, dogfood excluded)
- [x] `npm run test:dogfood` (1 file / 3 tests / all green)
- [x] `CI=true npm run test:dogfood` passes (replay-strict mode)
- [x] `npm run build` clean