### PR TITLE
docs: README rewrite, per-adapter docs, CHANGELOG, and visible-safety improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,47 @@ jobs:
 
       - name: build
         run: npm run build
+
+  # Smoke test on the published tarball. Catches dist/ shape, exports map,
+  # and peer-dep resolution issues that in-repo tests miss because they
+  # resolve through src/. This would have caught the v0.2 deps.inline
+  # gap before publish.
+  tarball-smoke:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: pack
+        run: npm pack
+
+      - name: smoke test the tarball in a fresh project
+        run: |
+          set -e
+          mkdir -p /tmp/sc-smoke
+          cd /tmp/sc-smoke
+          npm init -y > /dev/null
+          # Install the tarball plus required peer deps for the adapters
+          # we exercise. tinyexec is enough for the smoke check.
+          npm install --silent "$GITHUB_WORKSPACE"/shell-cassette-*.tgz tinyexec
+          # Verify each public sub-path resolves at runtime.
+          node --input-type=module -e "
+            import { useCassette } from 'shell-cassette'
+            import { x } from 'shell-cassette/tinyexec'
+            import { ShellCassetteError } from 'shell-cassette/errors'
+            console.log('useCassette:', typeof useCassette)
+            console.log('tinyexec.x:', typeof x)
+            console.log('ShellCassetteError:', typeof ShellCassetteError)
+            if (typeof useCassette !== 'function') process.exit(1)
+            if (typeof x !== 'function') process.exit(1)
+            if (typeof ShellCassetteError !== 'function') process.exit(1)
+          "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to shell-cassette are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project uses [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-04-26
+
+### BREAKING CHANGES
+
+- `execa` adapter moved from main `shell-cassette` entry to a `shell-cassette/execa` sub-path. v0.1's `import { execa } from 'shell-cassette'` no longer works. Migration:
+  ```diff
+  - import { execa } from 'shell-cassette'
+  + import { execa } from 'shell-cassette/execa'
+  ```
+- Both `execa` and `tinyexec` peer deps are now optional. Install only the runner(s) you actually use.
+
+### Added
+
+- **`shell-cassette/tinyexec` adapter**: drop-in replacement for tinyexec's `x` function. Same record/replay semantics as the execa adapter.
+- **End-of-run redaction summary**: vitest plugin and `useCassette` emit a grouped summary at scope end listing all redactions and warnings, with `⚠️` markers. Designed to be hard to miss in vitest's noisy output.
+- **Cassette `_warning` field**: every cassette JSON now includes a top-level `_warning` field with a "review before commit" reminder. Catches the case where users pipe stderr to `/dev/null` in CI but still commit cassettes.
+- **README sections**: tinyexec adapter overview, "Common gotchas" pointer to troubleshooting docs, "Real-world results" with cac and eslint-import-resolver-typescript benchmarks.
+- **`docs/` directory** with per-adapter and per-feature guides:
+  - `docs/execa.md`
+  - `docs/tinyexec.md`
+  - `docs/vitest-plugin.md`
+  - `docs/troubleshooting.md`
+- **JSDoc on `src/vitest.ts`** documenting the `deps.inline` requirement at module top.
+
+### Changed
+
+- Internal: extracted shared wrapper envelope (`src/wrapper.ts`) from `src/execa.ts`. Adapters now share a runner-agnostic envelope and pass runner-specific behavior via internal hooks (`RunnerHooks`, not exported).
+- Core `shell-cassette` entry shrinks to `useCassette` and shared types.
+- Long-value warning text rewritten to mention the key-only-matching limitation explicitly, so users know what they're being warned about.
+- README rewrite: leads with reproducible-CI-failures framing instead of speed. Adapter content moved to `docs/` for cleaner separation.
+
+### Notes
+
+- Cassette schema is unchanged at `version: 1`. Existing v0.1 cassettes load and replay correctly under v0.2's execa adapter. Cassettes recorded by v0.2 are loadable by v0.1 (additive only). The new `_warning` field is unknown to v0.1's deserializer, which ignores it.
+- **vitest 3.x and 4.x users must add `'shell-cassette'` to `test.server.deps.inline`**. See `docs/troubleshooting.md`.
+- **tinyexec adapter limitations**: `result.process` is `null` on replay, `result.pipe()` and `for await (line of result)` throw `UnsupportedOptionError`, `result.kill()` is a no-op, sync field reads before await return undefined. See `docs/tinyexec.md`.
+- **Known issue [#29](https://github.com/slgoodrich/shell-cassette/issues/29)**: AbortSignal/cancellation state (`isCanceled` for execa, `aborted` for tinyexec) is lost on replay. Cassette schema doesn't preserve it. Fix planned for v0.3+.
+- **Known issue [#33](https://github.com/slgoodrich/shell-cassette/issues/33)**: `AckRequiredError` thrown on matcher miss in auto mode is misleading; will be augmented with matcher-miss context in v0.3.
+- **Known issue [#34](https://github.com/slgoodrich/shell-cassette/issues/34)**: `durationMs` is recorded as `0` for tinyexec captures and may be `0` for execa. Will be properly measured in v0.3.
+
+## [0.1.0] - 2026-04-25
+
+Initial release.
+
+### Added
+
+- Drop-in execa wrapper with record/replay
+- vitest auto-cassette plugin
+- Explicit `useCassette` API for non-vitest contexts
+- Curated env-key redaction (TOKEN, SECRET, PASSWORD, etc.)
+- Ack gate (`SHELL_CASSETTE_ACK_REDACTION=true`) required before recording
+- Long-value warnings for env values over 100 chars not in curated list
+- JSON cassette format with line-array stdout/stderr encoding
+- Atomic cassette writes (temp file + rename)
+- Optional `shell-cassette.config.{js,mjs}` for matcher and redaction overrides
+- Nine typed error classes (`AckRequiredError`, `UnsupportedOptionError`, `ReplayMissError`, `ConcurrencyError`, `BinaryOutputError`, `CassetteCorruptError`, `CassetteCollisionError`, `CassetteIOError`, `CassetteConfigError`)
+- ESM-only, Node 18+

--- a/README.md
+++ b/README.md
@@ -9,27 +9,51 @@
 
 ## Why
 
-Testing code that spawns subprocesses today means picking between three bad options: hit the real binary (slow, flaky, environment-dependent), hand-roll mocks (tedious, drifts from reality), or skip testing the boundary (where bugs come from).
+Tests that shell out are flaky in subtle ways. `git log` returns different output every commit. CI runs `npm publish --dry-run` against a registry that occasionally times out. `gh` and `aws` calls don't work on a plane. The CLI you're wrapping isn't installed on the CI image.
 
-shell-cassette records subprocess calls once and replays them deterministically. Your tests go from minutes to seconds without losing fidelity to real subprocess behavior.
+shell-cassette records subprocess calls once and replays them deterministically. The output is whatever the real subprocess produced when you recorded - frozen, committed to your repo, replayed on every test run thereafter.
 
-## Installation
+What this unlocks:
+
+- **Reproducible CI failures.** A test fails in CI; replay the exact recorded subprocess outputs locally. Debug the real failure, not "what would have happened with my git version on my OS."
+- **Determinism.** Tests stop depending on system state, network, or upstream services.
+- **Offline development.** Tests work on a plane, in a coffee shop, when GitHub is down.
+- **Failure-path testing.** Hand-edit a cassette to set `exitCode: 137` and watch your error handling run, every time.
+- **Speed, as a side effect.** [88x faster on cac](https://github.com/slgoodrich/shell-cassette#real-world-results), 373x on heavier suites, by replacing real subprocess spawns with cassette reads.
+
+## Migrating from v0.1
+
+If you're upgrading from v0.1, the execa adapter moved to a sub-path:
+
+```diff
+- import { execa } from 'shell-cassette'
++ import { execa } from 'shell-cassette/execa'
+```
+
+Both `execa` and the new `tinyexec` peer dep are now optional - install only what you use. (This callout will be removed in v0.3.)
+
+## Install
 
 ```bash
 npm install --save-dev shell-cassette
 ```
 
-Peer dependencies:
+Then install whichever runner peer dep you use:
 
-- `execa` ^9 — required
-- `vitest` ^4 — optional (only needed if you use the vitest plugin)
+```bash
+npm install execa       # for shell-cassette/execa
+# or
+npm install tinyexec    # for shell-cassette/tinyexec
+```
 
-Install whichever you don't already have.
+`vitest` is also an optional peer dep, only needed if you use the auto-cassette plugin.
 
 ## Quick start
 
+Three pieces: setup file, vitest config, and your test.
+
 ```ts
-// vitest.setup.ts
+// tests/sc-setup.ts
 import 'shell-cassette/vitest'
 ```
 
@@ -39,8 +63,13 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    setupFiles: ['./vitest.setup.ts']
-  }
+    setupFiles: ['./tests/sc-setup.ts'],
+    server: {
+      deps: {
+        inline: ['shell-cassette'],   // required for vitest 3.x and 4.x
+      },
+    },
+  },
 })
 ```
 
@@ -61,7 +90,7 @@ First run (record):
 SHELL_CASSETTE_ACK_REDACTION=true npm test
 ```
 
-Subsequent runs (auto-replay):
+Subsequent runs (replay automatically):
 
 ```bash
 npm test
@@ -73,52 +102,26 @@ CI:
 npm test  # CI=true forces replay-strict
 ```
 
-By default, cassettes land next to the test file at `__cassettes__/<test-file>/<test-name>.json`. Commit them — they're how replay works on the next run and in CI.
+Cassettes land at `__cassettes__/<test-file>/<test-name>.json` - commit them.
 
-## Recording mode
+## Adapters
 
-| Mode | Behavior |
-|---|---|
-| `passthrough` (default outside cassette scope) | Calls real execa, no recording |
-| `auto` (default inside cassette scope) | Replays if recording exists, records if not (auto-additive) |
-| `record` | Always records (overwrites unmatched recordings) |
-| `replay` | Replays only; throws on missing |
+shell-cassette ships drop-in replacements for two subprocess libraries:
 
-Set via `SHELL_CASSETTE_MODE=record|replay|passthrough`. `CI=true` forces `replay`.
+- **[execa](docs/execa.md)** (`shell-cassette/execa`)
+- **[tinyexec](docs/tinyexec.md)** (`shell-cassette/tinyexec`)
 
-## Security: redaction
+Each adapter has its own page covering supported options, replay limits, and any quirks.
 
-shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`.
+If you use both, install both peer deps. shell-cassette's main entry exports only `useCassette` (the explicit-scope API) and shared types - adapters live on sub-paths.
 
-By default, env var values are redacted when KEY contains:
-`TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `APIKEY`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`, `AUTH_TOKEN`, `BEARER_TOKEN`, `JWT`.
+## Auto-cassette via the vitest plugin
 
-shell-cassette does NOT redact:
-
-- stdout/stderr content
-- command args
-- env vars with non-curated names (e.g., `STRIPE_KEY`, `OPENAI_KEY`)
-- paths in cwd
-
-**Always review cassettes before committing.**
-
-## Configuration
-
-Optional `shell-cassette.config.{js,mjs}`:
-
-```js
-// shell-cassette.config.js
-export default {
-  cassetteDir: '__cassettes__',         // default
-  redactEnvKeys: ['STRIPE_KEY'],        // adds to curated list
-  // Custom matcher: match on command only, ignore args (default matches command + deep-equal args).
-  matcher: (call, rec) => call.command === rec.call.command,
-}
-```
+The setup snippet above hooks `shell-cassette/vitest`'s auto-cassette plugin into your test runner. One cassette per test, derived from the test's name. See the [vitest plugin guide](docs/vitest-plugin.md) for compatibility notes (`deps.inline` requirement, `vi.mock` interactions, `test.concurrent` handling).
 
 ## Explicit cassette scope
 
-For non-vitest contexts or `test.concurrent`:
+For non-vitest contexts, or `test.concurrent`, or whenever you want fine-grained control:
 
 ```ts
 import { useCassette } from 'shell-cassette'
@@ -131,16 +134,99 @@ test.concurrent('parallel test', async () => {
 })
 ```
 
-## What v0.1 doesn't do (yet)
+Each `useCassette` call opens a scope; subprocess calls inside record/replay against the named cassette. AsyncLocalStorage isolates concurrent scopes correctly.
 
-- Multiple subprocess libraries (tinyexec, nano-spawn) — v0.2
-- Streaming output (`buffer: false`) — v1.0
-- IPC channels (`ipc: true`) — v1.0
-- stdin support — v0.2 (buffered) / v1.0 (file)
-- Bun.spawn / Deno.Command / native child_process — v1.0
-- CLI tools (`shell-cassette show`, `prune`, etc.) — v0.2
-- Stdout/stderr/args content redaction — v0.2
+## Recording mode
+
+| Mode | Behavior |
+|---|---|
+| `passthrough` (default outside a cassette scope) | Calls real subprocess, no recording |
+| `auto` (default inside a scope) | Replays if recording exists, records if not |
+| `record` | Always records (overwrites unmatched recordings) |
+| `replay` | Replays only; throws on miss |
+
+Set via `SHELL_CASSETTE_MODE=record|replay|passthrough|auto`. `CI=true` forces `replay`.
+
+## Security: redaction
+
+shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`. The ack gate forces a conscious "I know what gets redacted and what doesn't" decision before any cassette lands on disk.
+
+By default, env var values are redacted when KEY contains: `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `APIKEY`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`, `AUTH_TOKEN`, `BEARER_TOKEN`, `JWT`. Substring match, case-insensitive.
+
+shell-cassette does **NOT** redact:
+
+- stdout / stderr content
+- command args
+- env vars with non-curated names (`STRIPE_KEY`, `OPENAI_KEY`, etc. - extend via `redactEnvKeys` config)
+- paths in cwd
+
+**Always review cassettes before committing.** v0.3 ships pattern-based detection for stdout/stderr/args (GitHub PATs, AWS keys, Stripe keys, etc.). Until then: review.
+
+End-of-run summaries surface redaction events on every record:
+
+```
+shell-cassette: cassette saved (3 recordings, 1 redaction, 2 warnings): /path/to/cassette.json
+  redacted: GH_TOKEN
+  ⚠️  STRIPE_API_KEY: long value (104 chars), not in curated/configured list - may contain a credential...
+```
+
+Each cassette JSON also contains a `_warning` field reminding code reviewers to check before committing.
+
+## Configuration
+
+Optional `shell-cassette.config.{js,mjs}` walked up from cwd:
+
+```js
+export default {
+  // Where cassettes live (default '__cassettes__', relative to test file)
+  cassetteDir: '__cassettes__',
+
+  // Adds to the curated env-key redaction list (substring, case-insensitive)
+  redactEnvKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+
+  // Custom matcher (default: command + deep-equal args)
+  matcher: (call, rec) => call.command === rec.call.command,
+}
+```
+
+## Common gotchas
+
+If you hit one of these, see [docs/troubleshooting.md](docs/troubleshooting.md):
+
+- "Vitest failed to find the runner" → add `deps.inline: ['shell-cassette']`
+- "Cannot find module 'tinyexec'" → install the runner peer dep
+- `AckRequiredError` on a test you expected to replay → matcher missed; check cassette
+- `__cassettes__/` showing up as a test fixture → exclude alongside `__snapshots__/`
+- `vi.mock('tinyexec')` infinite loop → redirect at the import level instead
+
+## What this doesn't do
+
+Tracked in the [project backlog](https://github.com/slgoodrich/shell-cassette/issues). No version pins - items get pulled when signal arrives.
+
+- Streaming output (`buffer: false`)
+- IPC channels (`ipc: true`)
+- stdin support (buffered or streaming)
+- Bun.spawn / Deno.Command / native child_process adapters
+- jest plugin (vitest is the v0.2 plugin)
+- CLI tools (`shell-cassette show`, `prune`, `review`, etc.)
+- Pattern-based stdout/stderr/args redaction (v0.3 redact track)
+- Per-call matcher override / path-normalization for ephemeral temp dirs (v0.3 matcher track)
+
+## Real-world results
+
+| Project | Test execution speedup | Wall speedup | Notes |
+|---|---:|---:|---|
+| [cacjs/cac](https://github.com/cacjs/cac) | ~88x | ~4x | 17 tests, drop-in integration |
+| [import-js/eslint-import-resolver-typescript](https://github.com/import-js/eslint-import-resolver-typescript) | ~373x | ~55x | 15 tests, heavy `yarn eslint` per fixture |
+
+Wall-time speedup is bounded by vitest startup (~300-400ms regardless of mode). Test execution speedup scales with subprocess work per test.
+
+## Status
+
+v0.2 - tinyexec adapter shipping. Stable enough for solo and small-team use. Format won't break before v1.0.
+
+v0.3 will ship matcher flexibility (per-call overrides, path-normalization for ephemeral paths) and redact infrastructure (pattern-based detection, stable rule-tagged placeholders, stdout/stderr scrubbing). Both as the "team-ready foundation."
 
 ## License
 
-MIT — see `LICENSE`.
+MIT - see `LICENSE`.

--- a/docs/execa.md
+++ b/docs/execa.md
@@ -1,0 +1,134 @@
+# execa adapter
+
+Drop-in replacement for [`execa`](https://github.com/sindresorhus/execa) that records subprocess calls once and replays them on subsequent runs.
+
+## Setup
+
+```bash
+npm install --save-dev shell-cassette execa
+```
+
+`execa` is an optional peer dep - install it only if you use this adapter. Same for `vitest` if you use the auto-cassette plugin.
+
+## Usage
+
+### With the vitest plugin (auto-cassette per test)
+
+```ts
+// tests/sc-setup.ts
+import 'shell-cassette/vitest'
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./tests/sc-setup.ts'],
+    server: {
+      deps: {
+        inline: ['shell-cassette'],
+      },
+    },
+  },
+})
+```
+
+```ts
+// my-test.test.ts
+import { test, expect } from 'vitest'
+import { execa } from 'shell-cassette/execa'
+
+test('finds current branch', async () => {
+  const { stdout } = await execa('git', ['branch', '--show-current'])
+  expect(stdout).toBe('main')
+})
+```
+
+The plugin registers a `beforeEach`/`afterEach` pair that scopes each test to its own cassette under `__cassettes__/<test-file>/<test-name>.json`.
+
+If `deps.inline` is missing, you'll see a "Vitest failed to find the runner" error at test startup - see [troubleshooting](troubleshooting.md#vitest-failed-to-find-the-runner).
+
+### With explicit `useCassette` (non-vitest, or `test.concurrent`)
+
+```ts
+import { useCassette } from 'shell-cassette'
+import { execa } from 'shell-cassette/execa'
+
+test.concurrent('parallel test', async () => {
+  await useCassette('./cassettes/parallel.json', async () => {
+    await execa('git', ['status'])
+  })
+})
+```
+
+Each call to `useCassette` opens a scope; calls to `execa` inside the scope record/replay against the named cassette.
+
+## Recording and replaying
+
+First run (record):
+
+```bash
+SHELL_CASSETTE_ACK_REDACTION=true npm test
+```
+
+Subsequent runs (replay automatically from cassettes):
+
+```bash
+npm test
+```
+
+CI:
+
+```bash
+npm test  # CI=true forces replay-strict
+```
+
+The ack gate is required only on record. Replay needs nothing.
+
+## Mode reference
+
+| Mode | Behavior |
+|---|---|
+| `passthrough` | Calls real execa, no recording. Default outside a cassette scope. |
+| `auto` | Replays if recording exists; records if not. Default inside a scope. |
+| `record` | Always records (overwrites unmatched recordings). |
+| `replay` | Replays only; throws on miss. Forced by `CI=true`. |
+
+Set via `SHELL_CASSETTE_MODE=record|replay|passthrough|auto`.
+
+## Supported execa options
+
+execa's options pass through to the wrapped call. shell-cassette validates them at record time and rejects ones that don't replay correctly:
+
+| Option | Status |
+|---|---|
+| `cwd`, `env`, `timeout`, `signal`, `argv0`, `cleanup`, etc. | Supported, passed to real execa on record, captured in cassette where relevant |
+| `lines: true` | Supported (returns `string[]` from stdout/stderr) |
+| `all: true` | Supported (merged stdout+stderr in `result.all`) |
+| `reject: false` | Supported on both record and replay |
+| `buffer: false` | **Rejected** (streaming) |
+| `ipc: true` | **Rejected** (IPC channels) |
+| `inputFile` | **Rejected** (stdin from file) |
+| `input: 'string'` | **Rejected** (buffered stdin) |
+| `node: true` | **Rejected** (execaNode) |
+
+Rejected options throw `UnsupportedOptionError` at the record-mode wrapper entry. They're tracked in the [backlog](https://github.com/slgoodrich/shell-cassette).
+
+## Replay fidelity
+
+When the wrapper synthesizes a result on replay, it produces the same shape execa returns:
+
+- `stdout`, `stderr`, `exitCode`, `signal`, `command`, `escapedCommand`, `failed`, `timedOut`, `isCanceled`, `killed`, `durationMs`
+- `all` (when `all: true` was passed)
+- Throws synthesized `ExecaError` when exit code is non-zero AND `reject: false` not set (matching execa's default)
+
+Known limitations:
+
+- `isCanceled` is always `false` on replay (cassette schema doesn't preserve it; tracked in [#29](https://github.com/slgoodrich/shell-cassette/issues/29))
+- `durationMs` may be `0` if execa didn't report it (tracked in [#34](https://github.com/slgoodrich/shell-cassette/issues/34))
+
+## What's NOT redacted
+
+shell-cassette only redacts curated env-key values by default. **stdout, stderr, args, and non-curated env vars are not scrubbed.** See [troubleshooting → What shell-cassette does NOT redact](troubleshooting.md#what-shell-cassette-does-not-redact). Always review cassettes before committing.

--- a/docs/tinyexec.md
+++ b/docs/tinyexec.md
@@ -1,0 +1,103 @@
+# tinyexec adapter
+
+Drop-in replacement for [`tinyexec`](https://github.com/tinylibs/tinyexec)'s `x()` function.
+
+## Setup
+
+```bash
+npm install --save-dev shell-cassette tinyexec
+```
+
+`tinyexec` is an optional peer dep - install it only if you use this adapter. Same for `vitest`.
+
+## Usage
+
+```ts
+// tests/sc-setup.ts
+import 'shell-cassette/vitest'
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./tests/sc-setup.ts'],
+    server: {
+      deps: {
+        inline: ['shell-cassette'],
+      },
+    },
+  },
+})
+```
+
+```ts
+// my-test.test.ts
+import { test, expect } from 'vitest'
+import { x } from 'shell-cassette/tinyexec'
+
+test('captures git output', async () => {
+  const r = await x('git', ['branch', '--show-current'])
+  expect(r.exitCode).toBe(0)
+  expect(r.stdout.trim()).toBe('main')
+})
+```
+
+If `deps.inline` is missing, you'll see "Vitest failed to find the runner" - see [troubleshooting](troubleshooting.md#vitest-failed-to-find-the-runner).
+
+## Differences from execa
+
+tinyexec's API differs from execa in ways the adapter has to handle:
+
+| Concern | execa | tinyexec |
+|---|---|---|
+| **Default behavior on non-zero exit** | Throws (`reject: true` default) | **Does NOT throw**; check `result.exitCode` |
+| **Error escape hatch** | `reject: false` to suppress throw | `throwOnError: true` to opt INTO throwing |
+| **`cwd` and `env`** | Top-level options | Inside `nodeOptions: { cwd, env }` |
+| **`lines: true` (stdout as array)** | Supported | No equivalent; use `for await (line of proc)` for live iteration |
+| **`all: true` (merged stdout+stderr)** | Supported | No equivalent |
+
+The adapter mirrors all of this. If your real-tinyexec code didn't throw on `process.exit(1)`, the replay synthesis won't either. If you set `throwOnError: true`, replay throws on non-zero exit.
+
+## Replay limitations
+
+tinyexec returns a richer object than `Promise<Result>` - it's structurally `PromiseLike<Output> & ProcessApi`. shell-cassette can't fully synthesize that on replay. The following interactions are not supported on replay:
+
+| Interaction | Replay behavior | Reason |
+|---|---|---|
+| `result.process` | `null` | No live `ChildProcess` to expose |
+| `result.pipe(...)` | Throws `UnsupportedOptionError` | Pipe chaining requires a live subprocess to receive stdin |
+| `result.kill()` | No-op | The subprocess never spawned; nothing to kill |
+| `for await (line of result)` | Throws `UnsupportedOptionError` | Streaming iteration over recorded output isn't faithful (interleaving order is lost in storage) |
+| Synchronous reads of `proc.pid`, `proc.killed`, `proc.aborted` BEFORE `await` | Returns `undefined` | Replay returns `Promise<Result>`, not the live ProcessPromise shape |
+
+**Workaround:** `await` the result first, then read fields on the resolved object. All v0.2 validation targets (varlet-release, cac, eslint-import-resolver-typescript) follow this pattern, so it's the common case.
+
+## Lossy mappings
+
+The cassette schema is narrower than tinyexec's runtime result. Two mappings lose information:
+
+- **`signal` (string vs boolean)**: tinyexec exposes `killed: boolean` but not the actual signal name. We unconditionally store `'SIGTERM'` on kill. The real signal name is lost. Tracked for v1.0.
+- **`aborted` (always `false` on replay)**: cassette schema has no `aborted` field. tinyexec's `aborted: true` (set when AbortSignal triggered) is discarded on capture and synthesized as `false` on replay. Tracked in [#29](https://github.com/slgoodrich/shell-cassette/issues/29).
+
+In practice, code that relies on these specific fields after replay is rare. Code that uses AbortController to cancel and then checks `result.aborted` is the most likely failure path. If you hit this, comment on #29.
+
+## Supported tinyexec options
+
+| Option | Status |
+|---|---|
+| `signal` (AbortSignal) | Supported, passed to real tinyexec on record |
+| `timeout` | Supported, passed through |
+| `nodeOptions` (with `cwd`, `env`, etc.) | Supported, options destructured into the cassette `Call` shape |
+| `throwOnError` | Supported on record AND replay (synthesized error matches tinyexec's shape) |
+| `stdin` (string) | Accepted, not stored in cassette in v0.2 (record-only) |
+| `persist: true` | **Rejected** (subprocess outliving host can't replay) |
+| `stdin: Result` (pipe chaining) | **Rejected** (chaining requires live process) |
+
+Rejected options throw `UnsupportedOptionError` at the wrapper entry.
+
+## What's NOT redacted
+
+shell-cassette only redacts curated env-key values. stdout, stderr, args, and non-curated env vars are not scrubbed. See [troubleshooting → What shell-cassette does NOT redact](troubleshooting.md#what-shell-cassette-does-not-redact). Always review cassettes before committing.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,9 +33,9 @@ export default defineConfig({
 
 Required across vitest 3.x and 4.x. This is the standard pattern for vitest plugin packages.
 
-## "Cannot find module 'tinyexec'" (or 'execa', or 'vitest')
+## `MissingPeerDependencyError` on adapter import
 
-You imported a shell-cassette sub-path that requires a peer dependency you haven't installed.
+You imported a shell-cassette sub-path that requires a peer dependency you haven't installed. The error message includes the install command.
 
 **Fix:** install the matching peer dep:
 
@@ -45,12 +45,11 @@ npm install execa
 
 # For shell-cassette/tinyexec
 npm install tinyexec
-
-# For shell-cassette/vitest
-npm install --save-dev vitest
 ```
 
 Both `execa` and `tinyexec` are optional peer deps. Install whichever you import from.
+
+(`vitest` is required only if you use `shell-cassette/vitest`. Missing-vitest still surfaces as the bare "Cannot find module 'vitest'" error today; tracked as a future improvement.)
 
 ## `AckRequiredError` on a test you expected to replay
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,160 @@
+# Troubleshooting
+
+Common errors mapped to fixes. If you hit something that's not here, [open an issue](https://github.com/slgoodrich/shell-cassette/issues/new).
+
+## "Vitest failed to find the runner"
+
+Full error from vitest:
+
+> Error: Vitest failed to find the runner. One of the following is possible:
+> - "vitest" is imported directly without running "vitest" command
+> - "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, ...)
+> - ...
+
+**Cause:** vitest externalizes node_modules packages by default. shell-cassette/vitest registers `beforeEach` and `afterEach` at module top level, and externalized modules don't share the runner-state context with the test file.
+
+**Fix:** add `'shell-cassette'` to `test.server.deps.inline` in your vitest config:
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        inline: ['shell-cassette'],
+      },
+    },
+    // ... your other test config
+  },
+})
+```
+
+Required across vitest 3.x and 4.x. This is the standard pattern for vitest plugin packages.
+
+## "Cannot find module 'tinyexec'" (or 'execa', or 'vitest')
+
+You imported a shell-cassette sub-path that requires a peer dependency you haven't installed.
+
+**Fix:** install the matching peer dep:
+
+```bash
+# For shell-cassette/execa
+npm install execa
+
+# For shell-cassette/tinyexec
+npm install tinyexec
+
+# For shell-cassette/vitest
+npm install --save-dev vitest
+```
+
+Both `execa` and `tinyexec` are optional peer deps. Install whichever you import from.
+
+## `AckRequiredError` on a test you expected to replay
+
+The test expected to replay from a cassette but shell-cassette tried to record instead.
+
+**Most common cause:** the matcher missed. shell-cassette's default matcher is `command + deep-equal args`. If a recording captured `git status --porcelain` and the test now calls `git status -uall`, the matcher fails. In auto mode (default), failure falls through to the record path. The record path requires the ack gate.
+
+**Fix paths:**
+
+- **If you want to replay:** check the cassette JSON. Compare the recorded `call` shape against what your test is invoking. Common reasons matcher misses:
+  - Argument differences (added/removed flag, reordered args, version bump in args)
+  - Working directory differences (if you've configured cwd matching)
+  - Different env var values (if you've configured env matching)
+- **If you want to re-record:** delete the cassette file and re-run with `SHELL_CASSETTE_ACK_REDACTION=true`.
+- **If you're hitting this in CI:** CI=true forces replay-strict mode. Failures here mean the cassette is stale. Re-record locally and commit.
+
+Tracked by [#33](https://github.com/slgoodrich/shell-cassette/issues/33): error message will be augmented to include matcher-miss context in v0.3.
+
+## `ReplayMissError` in CI
+
+Same root cause as above (cassette doesn't match the call), but in `replay` mode (`CI=true` forces this) the wrapper throws directly instead of falling through.
+
+**Fix:** re-record locally, commit the cassette.
+
+## Test discovery picks up `__cassettes__/` directory as a fixture
+
+If your test file walks its own directory looking for fixture subdirs (e.g., `fs.readdir(testDir, { withFileTypes: true })`), shell-cassette's auto-created `__cassettes__/` shows up as a phantom fixture.
+
+**Fix:** exclude `__cassettes__` alongside any other meta-directories:
+
+```ts
+for (const dirent of dirents) {
+  if (
+    !dirent.isDirectory() ||
+    dirent.name === '__snapshots__' ||
+    dirent.name === '__cassettes__'
+  ) {
+    continue
+  }
+  // ... your fixture logic
+}
+```
+
+**Alternative:** configure shell-cassette to put cassettes in a non-test path via `Config.cassetteDir`:
+
+```ts
+// shell-cassette.config.js
+export default {
+  cassetteDir: '../cassettes',  // outside the test dir
+}
+```
+
+## `vi.mock('tinyexec')` (or 'execa') breaks shell-cassette
+
+If your project wraps the runner package via `vi.mock` for safety guards or assertion stubs, shell-cassette can't compose inside the mock chain.
+
+**Why:** `vi.mock('tinyexec')` catches ALL imports of `'tinyexec'`, including shell-cassette's internal one. If your mock then calls `shell-cassette/tinyexec`'s `x()`, that internally imports `'tinyexec'` again - which is the mock - infinite recursion.
+
+**Fix:** redirect at the test-import level instead of via mock:
+
+```diff
+- import { x } from 'tinyexec'
++ import { x } from 'shell-cassette/tinyexec'
+```
+
+If you previously relied on the mock for safety guards (e.g., refusing to run subprocess outside a sandbox), you'll need to drop that guard or move it elsewhere. shell-cassette doesn't provide an equivalent - it records and replays, it doesn't enforce.
+
+## `BinaryOutputError`
+
+Subprocess produced non-UTF-8 bytes in stdout/stderr. shell-cassette v0.2 only supports UTF-8 cassettes.
+
+**Workaround:** if you control the subprocess, redirect binary output to a file:
+
+```ts
+await x('ffmpeg', ['-i', 'input.mp4', '-y', 'output.mp4'])
+// stdout from ffmpeg is logging/progress text (UTF-8); the binary output
+// went to output.mp4. Reading output.mp4 in your test is fs work, not
+// subprocess output, so shell-cassette doesn't interfere.
+```
+
+If you need binary stdout/stderr support, [open an issue](https://github.com/slgoodrich/shell-cassette/issues/new).
+
+## "How do I redact a secret that isn't in the curated list?"
+
+Add the env var name to your `shell-cassette.config.js`:
+
+```js
+export default {
+  redactEnvKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+}
+```
+
+Substring match, case-insensitive. `STRIPE` would also match `STRIPE_KEY`, `STRIPE_TOKEN`, etc.
+
+The curated list (`TOKEN`, `SECRET`, `PASSWORD`, etc.) catches the common cases. Your config extends it.
+
+## What shell-cassette does NOT redact
+
+Worth being explicit so nothing gets committed by accident:
+
+- **stdout content** - if `git log` prints a token, shell-cassette captures it verbatim
+- **stderr content** - same
+- **command args** - `--token=ghp_xxx` lives in `call.args`, not redacted
+- **env vars with non-curated names** - anything not matching a curated keyword stays as-is. shell-cassette emits a warning if the value is over 100 chars, but doesn't redact.
+- **paths in cwd** - `/Users/yourname/projects/foo` stays in the cassette
+
+**Always review cassettes before committing.** v0.3 will ship pattern-based detection for stdout/stderr/args (GitHub PATs, AWS keys, Stripe keys, etc.), but for now: review.

--- a/docs/vitest-plugin.md
+++ b/docs/vitest-plugin.md
@@ -1,0 +1,157 @@
+# vitest plugin
+
+`shell-cassette/vitest` registers `beforeEach`/`afterEach` hooks that auto-cassette every test. One cassette per test, derived from the test's file path + describe chain + test name.
+
+## Setup
+
+Three lines:
+
+```ts
+// tests/sc-setup.ts
+import 'shell-cassette/vitest'
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./tests/sc-setup.ts'],
+    server: {
+      deps: {
+        inline: ['shell-cassette'],   // required - see Compatibility below
+      },
+    },
+  },
+})
+```
+
+```ts
+// my-test.test.ts
+import { test, expect } from 'vitest'
+import { execa } from 'shell-cassette/execa'  // or shell-cassette/tinyexec
+
+test('git branch', async () => {
+  const { stdout } = await execa('git', ['branch', '--show-current'])
+  expect(stdout).toBe('main')
+})
+```
+
+That's it. The plugin sets the active cassette per test; subprocess calls inside the test record/replay automatically.
+
+## Compatibility
+
+### `deps.inline` is required (vitest 3.x and 4.x)
+
+Vitest externalizes node_modules packages by default. The plugin's top-level `beforeEach`/`afterEach` calls fire outside the runner-aware context and throw "Vitest failed to find the runner."
+
+Add `'shell-cassette'` to `test.server.deps.inline`. This is the standard pattern for vitest plugin packages - many plugins document it.
+
+If you skip this: the test run fails immediately with the externalization error. See [troubleshooting](troubleshooting.md#vitest-failed-to-find-the-runner).
+
+### `vite-plus` (vite-plus/test) compatibility
+
+shell-cassette has been tested against `vite-plus` 0.1.18 (a vitest 4 wrapper used by varlet projects). The plugin loads with `deps.inline` configured correctly. No vp-specific config beyond the standard inline directive.
+
+### `vi.mock('execa')` or `vi.mock('tinyexec')` does NOT compose
+
+If your project already wraps the subprocess runner with `vi.mock` (e.g., for safety guards or assertion stubs), shell-cassette can't compose inside the mock chain. The mock catches shell-cassette's internal runner import and either recurses infinitely or bypasses our wrapper.
+
+**Fix:** redirect tests at the import level:
+
+```diff
+- import { x } from 'tinyexec'
++ import { x } from 'shell-cassette/tinyexec'
+```
+
+If the existing `vi.mock` provided safety guards, you'll need to drop them or move them elsewhere. shell-cassette doesn't enforce sandbox-cwd or similar guards - it records and replays.
+
+## Cassette path layout
+
+Default: cassettes land next to the test file in `__cassettes__/`:
+
+```
+tests/
+  my-feature.test.ts
+  __cassettes__/
+    my-feature.test.ts/
+      first-describe-block/
+        my-test-name.json
+      second-describe-block/
+        another-test-name.json
+```
+
+The full path is `<test-file-dir>/<cassetteDir>/<test-file-basename>/<sanitized-describe-segments>/<sanitized-test-name>.json` where `<cassetteDir>` defaults to `'__cassettes__'`.
+
+You can override `cassetteDir` via config:
+
+```js
+// shell-cassette.config.js
+export default {
+  cassetteDir: '../cassettes',  // outside the test directory
+}
+```
+
+## Test discovery and `__cassettes__/`
+
+If your test code dynamically registers tests by walking the test directory (e.g., one test per fixture subdir), make sure to exclude `__cassettes__/` alongside `__snapshots__/`:
+
+```ts
+for (const dirent of dirents) {
+  if (
+    !dirent.isDirectory() ||
+    dirent.name === '__snapshots__' ||
+    dirent.name === '__cassettes__'
+  ) {
+    continue
+  }
+  // ... register test for this fixture
+}
+```
+
+Otherwise the cassette directory shows up as a phantom fixture on subsequent runs (after the first record run creates it).
+
+## `test.concurrent` is rejected
+
+The plugin uses a module-global to set the active cassette per test. Concurrent tests would race on this. The plugin throws `ConcurrencyError` at `beforeEach` time when it detects a `test.concurrent`.
+
+**Use `useCassette` explicitly inside concurrent tests instead** - its AsyncLocalStorage-based context isolates per call:
+
+```ts
+import { useCassette } from 'shell-cassette'
+import { x } from 'shell-cassette/tinyexec'
+
+test.concurrent('parallel test 1', async () => {
+  await useCassette('./cassettes/parallel-1.json', async () => {
+    await x('git', ['status'])
+  })
+})
+
+test.concurrent('parallel test 2', async () => {
+  await useCassette('./cassettes/parallel-2.json', async () => {
+    await x('git', ['log'])
+  })
+})
+```
+
+## End-of-run summary
+
+When a test scope ends with new recordings, redactions, or warnings, the plugin emits a grouped summary to stderr:
+
+```
+shell-cassette: cassette saved (3 recordings, 1 redaction, 2 warnings): /path/to/cassette.json
+  redacted: GH_TOKEN
+  ⚠️  STRIPE_KEY: long value (104 chars), not in curated/configured list - may contain a credential...
+```
+
+Pure-replay tests stay silent. The summary makes redaction warnings hard to miss in vitest's output.
+
+## Plugin internals
+
+For the curious. The plugin's behavior:
+
+- **`beforeEach(ctx)`**: derives the cassette path from `ctx.task` (file path + describe chain + test name, sanitized). Creates a `CassetteSession` and calls `setActiveCassette` to make it visible to wrapper calls.
+- **`afterEach()`**: persists `session.newRecordings` to disk (if any), emits the end-of-run summary, clears the active cassette.
+
+If you don't want auto-cassetting for a particular test (e.g., a test that's deliberately calling real subprocess for live state), use `useCassette` explicitly with `mode: 'passthrough'` - but that requires per-call mode override, which is on the v0.3 roadmap. Today's escape hatch is to either move the test out of the auto-plugin's scope or stub manually.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -49,3 +49,7 @@ export class CassetteIOError extends ShellCassetteError {
 export class CassetteConfigError extends ShellCassetteError {
   static override code = 'CASSETTE_CONFIG'
 }
+
+export class MissingPeerDependencyError extends ShellCassetteError {
+  static override code = 'CASSETTE_MISSING_PEER_DEP'
+}

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -1,8 +1,27 @@
 import type { Options, ResultPromise } from 'execa'
-import { execa as realExeca } from 'execa'
+import { MissingPeerDependencyError } from './errors.js'
 import { validateOptions } from './options-execa.js'
 import type { Call, Recording, Result } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
+
+// Resolve execa via dynamic import so we can wrap "Cannot find module" with
+// an actionable error. Top-level await here means consumers importing
+// shell-cassette/execa wait for this resolution. If execa isn't installed,
+// shell-cassette/execa fails to load with a clear install instruction.
+let realExeca: typeof import('execa').execa
+try {
+  const mod = await import('execa')
+  realExeca = mod.execa
+} catch (e) {
+  throw new MissingPeerDependencyError(
+    'shell-cassette/execa requires execa as a peer dependency.\n\n' +
+      'Install it:\n' +
+      '  npm install execa\n' +
+      '  pnpm add execa\n' +
+      '  yarn add execa\n\n' +
+      `Original error: ${(e as Error).message}`,
+  )
+}
 
 export function execa(
   file: string,

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -12,9 +12,11 @@ export function record(
 
   for (const key of redactedKeys) {
     log(`redacted env var ${key} → ${session.path}`)
+    session.redactedKeys.push(key)
   }
   for (const warning of warnings) {
     log(warning)
+    session.warnings.push(warning)
   }
 
   session.newRecordings.push({

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -41,7 +41,7 @@ export function redactEnv(env: Record<string, string>, config: RedactConfig): Re
       redacted[key] = value
       if (value.length > LONG_VALUE_THRESHOLD) {
         warnings.push(
-          `env var ${key} has ${value.length}-char value, not in curated/configured list. Review before commit.`,
+          `${key}: long value (${value.length} chars), not in curated/configured list - may contain a credential. shell-cassette matches by key name only, not value pattern. Review cassette, or add ${key} to config.redactEnvKeys.`,
         )
       }
     }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -3,11 +3,21 @@ import type { CassetteFile, Recording } from './types.js'
 
 const SCHEMA_VERSION = 1
 
+const REVIEW_WARNING =
+  'REVIEW BEFORE COMMITTING. shell-cassette redacts curated env-key values; ' +
+  'it does NOT redact stdout, stderr, args, or env vars with non-curated names. ' +
+  'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md#what-shell-cassette-does-not-redact'
+
 export function serialize(file: CassetteFile): string {
   validateBeforeSerialize(file)
-  // Build object in canonical key order for stable diffs
+  // Build object in canonical key order for stable diffs.
+  // _warning is an additive optional field meant for code-review eyeballs:
+  // anyone reading the cassette JSON sees the redaction caveat at the top
+  // even if they never saw the stderr log when it was recorded.
+  // Underscore prefix marks it as metadata (deserialize ignores unknown fields).
   const ordered = {
     version: file.version,
+    _warning: REVIEW_WARNING,
     recordings: file.recordings.map(orderRecording),
   }
   return `${JSON.stringify(ordered, null, 2)}\n`

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -1,0 +1,33 @@
+import { log } from './log.js'
+import type { CassetteSession } from './types.js'
+
+/**
+ * Emit a grouped end-of-run summary listing redactions and warnings
+ * accumulated during this cassette session. Called by the vitest plugin's
+ * afterEach and useCassette's finally block when a session ends.
+ *
+ * Only emits when there's something worth surfacing: new recordings written,
+ * redactions performed, or warnings logged. Pure-replay sessions stay silent.
+ */
+export function summarizeSession(session: CassetteSession): void {
+  const recCount = session.newRecordings.length
+  const redCount = session.redactedKeys.length
+  const warnCount = session.warnings.length
+
+  if (recCount === 0 && redCount === 0 && warnCount === 0) {
+    return
+  }
+
+  log(
+    `cassette saved (${recCount} recording${recCount === 1 ? '' : 's'}, ` +
+      `${redCount} redaction${redCount === 1 ? '' : 's'}, ` +
+      `${warnCount} warning${warnCount === 1 ? '' : 's'}): ${session.path}`,
+  )
+
+  for (const key of session.redactedKeys) {
+    log(`  redacted: ${key}`)
+  }
+  for (const warning of session.warnings) {
+    log(`  ⚠️  ${warning}`)
+  }
+}

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -1,11 +1,30 @@
 import type { Options, Result as TinyResult } from 'tinyexec'
-import { x as realX } from 'tinyexec'
-import { UnsupportedOptionError } from './errors.js'
+import { MissingPeerDependencyError, UnsupportedOptionError } from './errors.js'
 import { validateOptions } from './options-tinyexec.js'
 import type { Call, Result as CassetteResult, Recording } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
 
 export type { Options, Result } from 'tinyexec'
+
+// Resolve tinyexec via dynamic import so we can wrap "Cannot find module"
+// with an actionable error. Top-level await here means consumers importing
+// shell-cassette/tinyexec wait for this resolution. If tinyexec isn't
+// installed, shell-cassette/tinyexec fails to load with a clear install
+// instruction.
+let realX: typeof import('tinyexec').x
+try {
+  const mod = await import('tinyexec')
+  realX = mod.x
+} catch (e) {
+  throw new MissingPeerDependencyError(
+    'shell-cassette/tinyexec requires tinyexec as a peer dependency.\n\n' +
+      'Install it:\n' +
+      '  npm install tinyexec\n' +
+      '  pnpm add tinyexec\n' +
+      '  yarn add tinyexec\n\n' +
+      `Original error: ${(e as Error).message}`,
+  )
+}
 
 export function x(
   file: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,10 @@ export type CassetteSession = {
   loadedFile: CassetteFile | null
   matcher: MatcherStateLike | null // built lazily; defined in matcher.ts
   newRecordings: Recording[]
+  // Accumulated across record() calls in this scope. Emitted as an
+  // end-of-run summary by the vitest plugin and useCassette finally.
+  redactedKeys: string[]
+  warnings: string[]
 }
 
 // Forward-declared interface; implemented in matcher.ts

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -6,6 +6,7 @@ import {
   unregisterSessionPath,
   withCassette as withCassetteScope,
 } from './state.js'
+import { summarizeSession } from './summary.js'
 import type { CassetteFile, CassetteSession } from './types.js'
 
 export async function useCassette<T>(cassettePath: string, fn: () => Promise<T>): Promise<T> {
@@ -19,6 +20,8 @@ export async function useCassette<T>(cassettePath: string, fn: () => Promise<T>)
       loadedFile: null,
       matcher: null,
       newRecordings: [],
+      redactedKeys: [],
+      warnings: [],
     }
 
     return await withCassetteScope(session, async () => {
@@ -26,6 +29,7 @@ export async function useCassette<T>(cassettePath: string, fn: () => Promise<T>)
         return await fn()
       } finally {
         await persistSession(session)
+        summarizeSession(session)
       }
     })
   } finally {

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -1,3 +1,16 @@
+// shell-cassette/vitest plugin: registers global beforeEach/afterEach hooks
+// for auto-cassetting per test.
+//
+// SETUP REQUIREMENT: when shell-cassette is installed as a node_modules
+// dependency, vitest externalizes it by default and the hook registration
+// at module top level fails with "Vitest failed to find the runner."
+// Add 'shell-cassette' to test.server.deps.inline in your vitest config:
+//
+//   test: { server: { deps: { inline: ['shell-cassette'] } } }
+//
+// See docs/vitest-plugin.md for details. This is the standard vitest plugin
+// pattern and applies to vitest 3.x and 4.x.
+
 import { afterEach, beforeEach } from 'vitest'
 import { getConfig } from './config.js'
 import { ConcurrencyError } from './errors.js'
@@ -10,6 +23,7 @@ import {
   setActiveCassette,
   unregisterSessionPath,
 } from './state.js'
+import { summarizeSession } from './summary.js'
 import type { CassetteSession } from './types.js'
 
 beforeEach((ctx) => {
@@ -38,6 +52,8 @@ beforeEach((ctx) => {
     loadedFile: null,
     matcher: null,
     newRecordings: [],
+    redactedKeys: [],
+    warnings: [],
   }
   setActiveCassette(session)
 })
@@ -54,6 +70,7 @@ afterEach(async () => {
     await writeCassetteFile(session.path, serialize(merged))
   }
   if (session) {
+    summarizeSession(session)
     unregisterSessionPath(session.path)
   }
   clearActiveCassette()

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -15,6 +15,8 @@ export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteS
     loadedFile: { version: 1, recordings: [] },
     matcher: null,
     newRecordings: [],
+    redactedKeys: [],
+    warnings: [],
     ...overrides,
   }
   if (base.loadedFile !== null && base.matcher === null) {

--- a/tests/unit/recorder.test.ts
+++ b/tests/unit/recorder.test.ts
@@ -9,6 +9,8 @@ const baseSession = (): CassetteSession => ({
   loadedFile: null,
   matcher: null,
   newRecordings: [],
+  redactedKeys: [],
+  warnings: [],
 })
 
 const callOf = (env: Record<string, string> = {}): Call => ({


### PR DESCRIPTION
## What Changed

### Code changes

1. **End-of-run redaction summary**: accumulates redacted env keys and length warnings on `CassetteSession` during record. At session end (vitest plugin afterEach OR useCassette finally), emits a grouped summary. Pure-replay sessions stay silent.

2. **Cassette `_warning` field**: every cassette JSON now has a top-level `_warning` field reminding code reviewers. Long-value warning text rewritten to mention key-only-matching limitation explicitly.

3. **MissingPeerDependencyError**: execa and tinyexec adapters now throw a clear actionable error if their peer dep isn't installed, instead of bare "Cannot find module." Adds a `tarball-smoke` CI job that packs and installs the tarball into a fresh project to catch dist-shape and exports-map regressions.

### Documentation

- README leads with reproducible-CI-failures framing.
- `docs/execa.md`, `docs/tinyexec.md`, `docs/vitest-plugin.md`, `docs/troubleshooting.md` (new).
- Removed all version pins from "What this doesn't do" section.
- CHANGELOG.md (new) in Keep-a-Changelog format with v0.2.0 entry covering Breaking Changes, Added, Changed, Notes (incl. known issues #29, #33, #34).

## Notes

Deliberately not in this PR:

- Pattern-based redaction: bigger work (~30 credential prefixes, regex engine, stable rule-tagged placeholders). This PR ships the visible-safety scaffolding (warnings, summary, `_warning` field).
- Matcher API expansion (per-call override, path-normalization heuristic).
- vitest plugin's MissingPeerDependencyError: would require lazy hook registration, which loses first-test auto-cassetting. Defer.
- Issue #29 (aborted state): schema-level fix.
- Issue #32 (replay-no-session passthrough): behavior change requires user opt-out path.
- Issue #33 (AckRequiredError on matcher miss): augment with matcher-miss context.

## Related Issues

- Closes #31 (deps.inline docs) covered in README + JSDoc + `docs/troubleshooting.md`.
- Partially closes #35 (MissingPeerDependencyError); execa and tinyexec done; vitest deferred.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (28 files / 179 tests / all green)
- [x] `npm run test:dogfood` (3 tests / all green)
- [x] `CI=true npm run test:dogfood` passes (replay-strict mode)
- [x] `npm run build` clean
- [x] Zero em dashes (per CLAUDE.md)
- [x] CI `tarball-smoke` job runs on this PR (verifies useCassette, `shell-cassette/tinyexec.x`, `shell-cassette/errors` resolve correctly)