### PR TITLE
fix: throw MissingPeerDependencyError when vitest is missing (closes #35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
           cd /tmp/sc-smoke
           npm init -y > /dev/null
           # Install the tarball plus required peer deps for the adapters
-          # we exercise. tinyexec is enough for the smoke check.
+          # we exercise. tinyexec is enough for the positive smoke check.
+          # vitest is intentionally NOT installed so we can also verify
+          # MissingPeerDependencyError fires for shell-cassette/vitest.
           npm install --silent "$GITHUB_WORKSPACE"/shell-cassette-*.tgz tinyexec
           # Verify each public sub-path resolves at runtime.
           node --input-type=module -e "
@@ -83,4 +85,30 @@ jobs:
             if (typeof useCassette !== 'function') process.exit(1)
             if (typeof x !== 'function') process.exit(1)
             if (typeof ShellCassetteError !== 'function') process.exit(1)
+          "
+
+      - name: negative smoke - shell-cassette/vitest without vitest installed
+        run: |
+          set -e
+          cd /tmp/sc-smoke
+          # vitest is NOT installed in this project. Importing
+          # shell-cassette/vitest must throw MissingPeerDependencyError.
+          node --input-type=module -e "
+            try {
+              await import('shell-cassette/vitest')
+              console.error('FAIL: import did not throw')
+              process.exit(1)
+            } catch (e) {
+              if (e?.constructor?.name !== 'MissingPeerDependencyError') {
+                console.error('FAIL: wrong error class:', e?.constructor?.name)
+                console.error('message:', e?.message)
+                process.exit(1)
+              }
+              if (!String(e.message).includes('shell-cassette/vitest requires vitest')) {
+                console.error('FAIL: error message missing required text')
+                console.error('actual:', e.message)
+                process.exit(1)
+              }
+              console.log('OK: MissingPeerDependencyError thrown as expected')
+            }
           "

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -11,9 +11,8 @@
 // See docs/vitest-plugin.md for details. This is the standard vitest plugin
 // pattern and applies to vitest 3.x and 4.x.
 
-import { afterEach, beforeEach } from 'vitest'
 import { getConfig } from './config.js'
-import { ConcurrencyError } from './errors.js'
+import { ConcurrencyError, MissingPeerDependencyError } from './errors.js'
 import { writeCassetteFile } from './io.js'
 import { deriveCassettePathFromTask } from './plugin.js'
 import { serialize } from './serialize.js'
@@ -25,6 +24,28 @@ import {
 } from './state.js'
 import { summarizeSession } from './summary.js'
 import type { CassetteSession } from './types.js'
+
+// Resolve vitest via dynamic import so we can wrap "Cannot find module" with
+// an actionable error. Top-level await means consumers importing
+// shell-cassette/vitest wait for this resolution. Hooks register synchronously
+// after the await; vitest's setupFile loading awaits the entire chain, so
+// hooks are registered before any test runs.
+let beforeEach: typeof import('vitest').beforeEach
+let afterEach: typeof import('vitest').afterEach
+try {
+  const mod = await import('vitest')
+  beforeEach = mod.beforeEach
+  afterEach = mod.afterEach
+} catch (e) {
+  throw new MissingPeerDependencyError(
+    'shell-cassette/vitest requires vitest as a peer dependency.\n\n' +
+      'Install it:\n' +
+      '  npm install --save-dev vitest\n' +
+      '  pnpm add --save-dev vitest\n' +
+      '  yarn add --dev vitest\n\n' +
+      `Original error: ${(e as Error).message}`,
+  )
+}
 
 beforeEach((ctx) => {
   const task = (ctx as { task?: unknown }).task as

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -18,6 +18,7 @@ import { deriveCassettePathFromTask } from './plugin.js'
 import { serialize } from './serialize.js'
 import {
   clearActiveCassette,
+  getActiveCassette,
   registerSessionPath,
   setActiveCassette,
   unregisterSessionPath,
@@ -43,7 +44,7 @@ try {
       '  npm install --save-dev vitest\n' +
       '  pnpm add --save-dev vitest\n' +
       '  yarn add --dev vitest\n\n' +
-      `Original error: ${(e as Error).message}`,
+      `Original error: ${e instanceof Error ? e.message : String(e)}`,
   )
 }
 
@@ -80,7 +81,6 @@ beforeEach((ctx) => {
 })
 
 afterEach(async () => {
-  const { getActiveCassette } = await import('./state.js')
   const session = getActiveCassette()
   if (session && session.newRecordings.length > 0) {
     const existingRecordings = session.loadedFile?.recordings ?? []


### PR DESCRIPTION
## What Changed

- `shell-cassette/vitest` used a static `import` for vitest, so users without it installed saw a vague `Cannot find module 'vitest'` ESM trace instead of the actionable error pattern `execa` and `tinyexec` already use.
- Apply the same TLA dynamic-import wrapper from `src/execa.ts` / `src/tinyexec.ts`: catch and re-throw as `MissingPeerDependencyError` with npm/pnpm/yarn install instructions.
- Extend the `tarball-smoke` CI job with a negative check that imports `shell-cassette/vitest` in a project where `vitest` is intentionally not installed and asserts the thrown error class + message.

## Related Issues

Closes #35.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (179/179 passing)
- [x] `npm run test:dogfood` (3/3 passing)
- [x] `npm run build` clean
- [ ] CI `tarball-smoke` job: positive smoke (execa/tinyexec resolve) + new negative smoke (vitest absent throws `MissingPeerDependencyError` with expected message)