### PR TITLE
fix: augment AckRequiredError on auto-mode matcher miss (closes #33)

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,6 +1,6 @@
 import { requireAckGate } from './ack.js'
 import { type Config, getConfig } from './config.js'
-import { AckRequiredError, ReplayMissError } from './errors.js'
+import { ReplayMissError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { MatcherState } from './matcher.js'
 import { resolveMode } from './mode.js'
@@ -78,13 +78,11 @@ export async function runWrapped<Opts, ResultShape>(
     // Default scope mode is 'auto'. When the matcher misses, the wrapper
     // falls through to the record path, which then asks for ack. From the
     // user's perspective they tried to replay; the ack error obscures the
-    // real cause (matcher miss). Augment the message so the actual problem
-    // path is visible without changing the error class — programmatic
-    // catches on AckRequiredError still work.
-    if (cameFromAutoMiss && e instanceof AckRequiredError) {
-      throw new AckRequiredError(
-        `auto mode: no recording matched \`${call.command} ${call.args.join(' ')}\`, attempted to record but ack gate not set.\n\n${e.message}`,
-      )
+    // real cause (matcher miss). Mutate the original error's message so the
+    // actual problem path is visible. Stack and class are preserved —
+    // programmatic catches on AckRequiredError still work.
+    if (cameFromAutoMiss && e instanceof Error) {
+      e.message = `auto mode: no recording matched \`${formatCallSignature(call)}\`, attempted to record but ack gate not set.\n\n${e.message}`
     }
     throw e
   }
@@ -118,10 +116,10 @@ function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
 
 function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
   const recordedCalls = session.loadedFile?.recordings
-    .map((r) => `${r.call.command} ${r.call.args.join(' ')}`)
+    .map((r) => formatCallSignature(r.call))
     .join('\n  - ')
   return new ReplayMissError(
-    `no matching recording for \`${call.command} ${call.args.join(' ')}\`
+    `no matching recording for \`${formatCallSignature(call)}\`
   cassette: ${session.path}
   matcher:  default (command + deep-equal args)
 
@@ -130,4 +128,8 @@ Recorded calls in this cassette:
 
 To re-record: delete the cassette file and run tests again.`,
   )
+}
+
+function formatCallSignature(call: Call): string {
+  return `${call.command} ${call.args.join(' ')}`
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,6 +1,6 @@
 import { requireAckGate } from './ack.js'
 import { type Config, getConfig } from './config.js'
-import { ReplayMissError } from './errors.js'
+import { AckRequiredError, ReplayMissError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { MatcherState } from './matcher.js'
 import { resolveMode } from './mode.js'
@@ -61,16 +61,33 @@ export async function runWrapped<Opts, ResultShape>(
     return hooks.synthesize(recording, options)
   }
 
+  let cameFromAutoMiss = false
   if (mode === 'auto') {
     const recording = matcher.findMatch(call)
     if (recording !== null) {
       return hooks.synthesize(recording, options)
     }
+    cameFromAutoMiss = true
     // fall through to record path (auto-additive)
   }
 
   // mode is 'record' OR auto-with-no-match
-  requireAckGate()
+  try {
+    requireAckGate()
+  } catch (e) {
+    // Default scope mode is 'auto'. When the matcher misses, the wrapper
+    // falls through to the record path, which then asks for ack. From the
+    // user's perspective they tried to replay; the ack error obscures the
+    // real cause (matcher miss). Augment the message so the actual problem
+    // path is visible without changing the error class — programmatic
+    // catches on AckRequiredError still work.
+    if (cameFromAutoMiss && e instanceof AckRequiredError) {
+      throw new AckRequiredError(
+        `auto mode: no recording matched \`${call.command} ${call.args.join(' ')}\`, attempted to record but ack gate not set.\n\n${e.message}`,
+      )
+    }
+    throw e
+  }
   try {
     const result = await hooks.realCall(file, args, options)
     captureAndRecord(call, result, hooks, session, config)

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -205,9 +205,10 @@ describe('runWrapped (envelope)', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(AckRequiredError)
       const msg = (e as Error).message
-      // No matcher-miss prefix on the explicit-record path
-      expect(msg).not.toContain('auto mode')
-      expect(msg).not.toContain('no recording matched')
+      // Positive assertion: explicit-record path returns the unmodified ack
+      // help text from src/ack.ts, which starts with "refusing to record".
+      // Augmented messages instead start with "auto mode:".
+      expect(msg.startsWith('refusing to record')).toBe(true)
       expect(msg).toContain('SHELL_CASSETTE_ACK_REDACTION')
     } finally {
       expect(realCall).not.toHaveBeenCalled()

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -153,4 +153,65 @@ describe('runWrapped (envelope)', () => {
     expect(session.newRecordings[0]?.result.exitCode).toBe(1)
     clearActiveCassette()
   })
+
+  test('auto matcher miss without ack: AckRequiredError message includes matcher-miss context', async () => {
+    // Existing recording for `git status`; we'll call `git log` so the matcher misses.
+    const recording: Recording = {
+      call: { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['', ''],
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+      },
+    }
+    const session = makeSession({
+      scopeDefault: 'auto',
+      loadedFile: { version: 1, recordings: [recording] },
+    })
+    setActiveCassette(session)
+    // ack intentionally NOT set
+    const realCall = vi.fn()
+
+    try {
+      await runWrapped('git', ['log'], {}, baseHooks(realCall as never))
+      throw new Error('should not reach')
+    } catch (e) {
+      expect(e).toBeInstanceOf(AckRequiredError)
+      const msg = (e as Error).message
+      expect(msg).toContain('auto mode')
+      expect(msg).toContain('no recording matched')
+      expect(msg).toContain('git log')
+      // Original ack help text is still appended
+      expect(msg).toContain('SHELL_CASSETTE_ACK_REDACTION')
+    } finally {
+      expect(realCall).not.toHaveBeenCalled()
+      clearActiveCassette()
+    }
+  })
+
+  test('explicit record mode without ack: AckRequiredError message is NOT augmented', async () => {
+    const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_MODE = 'record'
+    // ack intentionally NOT set
+    const realCall = vi.fn()
+
+    try {
+      await runWrapped('git', ['log'], {}, baseHooks(realCall as never))
+      throw new Error('should not reach')
+    } catch (e) {
+      expect(e).toBeInstanceOf(AckRequiredError)
+      const msg = (e as Error).message
+      // No matcher-miss prefix on the explicit-record path
+      expect(msg).not.toContain('auto mode')
+      expect(msg).not.toContain('no recording matched')
+      expect(msg).toContain('SHELL_CASSETTE_ACK_REDACTION')
+    } finally {
+      expect(realCall).not.toHaveBeenCalled()
+      clearActiveCassette()
+    }
+  })
 })


### PR DESCRIPTION
## What Changed

- In default `auto` mode, a matcher miss falls through to the record path which then throws `AckRequiredError`. The user's mental model is "I expected replay" but the error talks only about redaction acknowledgment.
- Wrap the auto fall-through ack failure with a matcher-miss prefix (call signature + "no recording matched") and append the existing ack help text. Same error class, programmatic catches unaffected.
- Explicit `SHELL_CASSETTE_MODE=record` paths still throw the original unaugmented message (the user did intend to record there).

## Related Issues

Closes #33.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (181/181; added 2 tests)
- [x] `npm run test:dogfood` (3/3)
- [x] `npm run build` clean
- [x] CI green on ubuntu + windows + tarball-smoke