### PR TITLE
fix!: throw NoActiveSessionError on replay-without-session (closes #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to shell-cassette are documented here. The format is based o
   + import { execa } from 'shell-cassette/execa'
   ```
 - Both `execa` and `tinyexec` peer deps are now optional. Install only the runner(s) you actually use.
+- **Replay mode now refuses to passthrough when no active cassette session is bound.** v0.1/v0.2-pre would silently fall through to the real subprocess if `CI=true` (which forces replay) but the user called `execa`/`x` outside any `useCassette` scope and without the vitest plugin loaded. v0.2 throws `NoActiveSessionError` with fix instructions. Opt out by setting `SHELL_CASSETTE_MODE=passthrough` explicitly. Closes [#32](https://github.com/slgoodrich/shell-cassette/issues/32).
 
 ### Added
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -53,3 +53,7 @@ export class CassetteConfigError extends ShellCassetteError {
 export class MissingPeerDependencyError extends ShellCassetteError {
   static override code = 'CASSETTE_MISSING_PEER_DEP'
 }
+
+export class NoActiveSessionError extends ShellCassetteError {
+  static override code = 'CASSETTE_NO_ACTIVE_SESSION'
+}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -8,6 +8,15 @@ import { record } from './recorder.js'
 import { getActiveCassette } from './state.js'
 import type { Call, CassetteSession, MatcherStateLike, Recording, Result } from './types.js'
 
+const NO_ACTIVE_SESSION_HELP = `shell-cassette is in replay mode but no active cassette session is bound.
+
+Fix one of:
+  - Wrap the call site with useCassette(path, async () => { ... })
+  - Import 'shell-cassette/vitest' as a setupFile so the plugin auto-binds per test
+  - Set SHELL_CASSETTE_MODE=passthrough to opt out of strict replay
+
+CI=true forces replay mode by default; without a session shell-cassette refuses to run real subprocesses.`
+
 export type RunnerHooks<Opts, ResultShape> = {
   validate: (options: Opts | undefined) => void
   buildCall: (file: string, args: readonly string[], options: Opts) => Call
@@ -37,15 +46,7 @@ export async function runWrapped<Opts, ResultShape>(
       'passthrough',
     )
     if (mode === 'replay') {
-      throw new NoActiveSessionError(
-        'shell-cassette is in replay mode but no active cassette session is bound.\n\n' +
-          'Fix one of:\n' +
-          '  - Wrap the call site with `useCassette(path, async () => { ... })`\n' +
-          '  - Import `shell-cassette/vitest` as a setupFile so the plugin auto-binds per test\n' +
-          '  - Set `SHELL_CASSETTE_MODE=passthrough` to opt out of strict replay\n\n' +
-          'CI=true forces replay mode by default; without a session shell-cassette refuses ' +
-          'to run real subprocesses.',
-      )
+      throw new NoActiveSessionError(NO_ACTIVE_SESSION_HELP)
     }
     return hooks.realCall(file, args, options)
   }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,6 +1,6 @@
 import { requireAckGate } from './ack.js'
 import { type Config, getConfig } from './config.js'
-import { ReplayMissError } from './errors.js'
+import { NoActiveSessionError, ReplayMissError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { MatcherState } from './matcher.js'
 import { resolveMode } from './mode.js'
@@ -25,7 +25,28 @@ export async function runWrapped<Opts, ResultShape>(
   hooks.validate(options)
 
   const session = getActiveCassette()
+
+  // Resolve mode before the no-session passthrough check. If the user is in
+  // replay mode (env-set or CI-forced) but no session is active, falling
+  // through to realCall would silently run real subprocesses despite the
+  // user's "no real shell" intent. Refuse instead.
   if (session === null) {
+    const mode = resolveMode(
+      process.env.SHELL_CASSETTE_MODE,
+      Boolean(process.env.CI),
+      'passthrough',
+    )
+    if (mode === 'replay') {
+      throw new NoActiveSessionError(
+        'shell-cassette is in replay mode but no active cassette session is bound.\n\n' +
+          'Fix one of:\n' +
+          '  - Wrap the call site with `useCassette(path, async () => { ... })`\n' +
+          '  - Import `shell-cassette/vitest` as a setupFile so the plugin auto-binds per test\n' +
+          '  - Set `SHELL_CASSETTE_MODE=passthrough` to opt out of strict replay\n\n' +
+          'CI=true forces replay mode by default; without a session shell-cassette refuses ' +
+          'to run real subprocesses.',
+      )
+    }
     return hooks.realCall(file, args, options)
   }
 

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { AckRequiredError, ReplayMissError, UnsupportedOptionError } from '../../src/errors.js'
+import {
+  AckRequiredError,
+  NoActiveSessionError,
+  ReplayMissError,
+  UnsupportedOptionError,
+} from '../../src/errors.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { Recording } from '../../src/types.js'
 import { type RunnerHooks, runWrapped } from '../../src/wrapper.js'
@@ -50,11 +55,46 @@ describe('runWrapped (envelope)', () => {
     clearActiveCassette()
   })
 
-  test('passthrough when no active cassette', async () => {
+  test('passthrough when no active cassette and mode is not replay', async () => {
     const realCall = vi.fn(async () => ({ stdout: 'hello', exitCode: 0 }))
     const result = await runWrapped('echo', ['hello'], {}, baseHooks(realCall))
     expect(realCall).toHaveBeenCalledOnce()
     expect(result).toEqual({ stdout: 'hello', exitCode: 0 })
+  })
+
+  test('NoActiveSessionError when CI=true forces replay and no session is bound', async () => {
+    process.env.CI = 'true'
+    const realCall = vi.fn()
+    try {
+      await runWrapped('rm', ['-rf', '/tmp/whatever'], {}, baseHooks(realCall as never))
+      throw new Error('should not reach')
+    } catch (e) {
+      expect(e).toBeInstanceOf(NoActiveSessionError)
+      const msg = (e as Error).message
+      expect(msg).toContain('replay mode')
+      expect(msg).toContain('useCassette')
+      expect(msg).toContain('shell-cassette/vitest')
+      expect(msg).toContain('SHELL_CASSETTE_MODE=passthrough')
+    }
+    expect(realCall).not.toHaveBeenCalled()
+  })
+
+  test('NoActiveSessionError when SHELL_CASSETTE_MODE=replay and no session is bound', async () => {
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    const realCall = vi.fn()
+    await expect(
+      runWrapped('echo', ['hi'], {}, baseHooks(realCall as never)),
+    ).rejects.toBeInstanceOf(NoActiveSessionError)
+    expect(realCall).not.toHaveBeenCalled()
+  })
+
+  test('explicit SHELL_CASSETTE_MODE=passthrough still passes through with no session', async () => {
+    process.env.CI = 'true'
+    process.env.SHELL_CASSETTE_MODE = 'passthrough'
+    const realCall = vi.fn(async () => ({ stdout: 'hi', exitCode: 0 }))
+    const result = await runWrapped('echo', ['hi'], {}, baseHooks(realCall))
+    expect(realCall).toHaveBeenCalledOnce()
+    expect(result.exitCode).toBe(0)
   })
 
   test('validate is called even when no active cassette', async () => {

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -53,6 +53,12 @@ describe('runWrapped (envelope)', () => {
   afterEach(() => {
     _resetForTesting()
     clearActiveCassette()
+    // Symmetric with beforeEach so the last test's env state doesn't leak past
+    // this file (vitest's per-file isolation hides this today, but a future
+    // pool config without isolation would expose it).
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
   })
 
   test('passthrough when no active cassette and mode is not replay', async () => {


### PR DESCRIPTION
## What Changed

- In CI (`CI=true` forces replay) with no active cassette session, the wrapper silently fell through to the real subprocess. Tests built around "no real shell in CI" silently made real calls.
- Resolve mode before the no-session passthrough. If `session === null && mode === 'replay'`, throw the new `NoActiveSessionError` with three concrete fix paths.
- Other modes (passthrough, auto, record) still passthrough on no-session, so explicit opt-out via `SHELL_CASSETTE_MODE=passthrough` works.

## Notes

Breaking change. Documented in CHANGELOG. Affects users who relied on `CI=true` + no-session passthrough. Mitigation is a single env var.

## Related Issues

Closes #32.

## Test Plan

- [x] `npm run lint`, `typecheck`, `build` clean
- [x] `npm test` (182/182; added 3 tests: CI-forced replay throws; `SHELL_CASSETTE_MODE=replay` throws; `SHELL_CASSETTE_MODE=passthrough` overrides CI forced-replay)
- [x] `npm run test:dogfood` (3/3; vitest plugin always binds a session, unaffected)