### PR TITLE
fix: measure durationMs uniformly around realCall (closes #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to shell-cassette are documented here. The format is based o
 - Core `shell-cassette` entry shrinks to `useCassette` and shared types.
 - Long-value warning text rewritten to mention the key-only-matching limitation explicitly, so users know what they're being warned about.
 - README rewrite: leads with reproducible-CI-failures framing instead of speed. Adapter content moved to `docs/` for cleaner separation.
+- **`durationMs` is now measured uniformly** around `realCall` via `performance.now()` for both adapters. Previously: tinyexec recorded `0` (no native field), execa relied on its own field which is sometimes `0`. Closes [#34](https://github.com/slgoodrich/shell-cassette/issues/34).
 
 ### Notes
 
@@ -43,8 +44,6 @@ All notable changes to shell-cassette are documented here. The format is based o
 - **vitest 3.x and 4.x users must add `'shell-cassette'` to `test.server.deps.inline`**. See `docs/troubleshooting.md`.
 - **tinyexec adapter limitations**: `result.process` is `null` on replay, `result.pipe()` and `for await (line of result)` throw `UnsupportedOptionError`, `result.kill()` is a no-op, sync field reads before await return undefined. See `docs/tinyexec.md`.
 - **Known issue [#33](https://github.com/slgoodrich/shell-cassette/issues/33)**: `AckRequiredError` thrown on matcher miss in auto mode is misleading; will be augmented with matcher-miss context in v0.3.
-- **Known issue [#34](https://github.com/slgoodrich/shell-cassette/issues/34)**: `durationMs` is recorded as `0` for tinyexec captures and may be `0` for execa. Will be properly measured in v0.3.
-
 ## [0.1.0] - 2026-04-25
 
 Initial release.

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -49,14 +49,13 @@ function buildCall(file: string, args: readonly string[], options: Options): Cal
   }
 }
 
-function captureResult(raw: unknown): Result {
+function captureResult(raw: unknown, durationMs: number): Result {
   const r = raw as {
     stdout?: string | string[]
     stderr?: string | string[]
     all?: string | string[]
     exitCode?: number
     signal?: string | null
-    durationMs?: number
     isCanceled?: boolean
   }
   return {
@@ -65,7 +64,7 @@ function captureResult(raw: unknown): Result {
     allLines: r.all === undefined ? null : toLines(r.all),
     exitCode: r.exitCode ?? 0,
     signal: r.signal ?? null,
-    durationMs: r.durationMs ?? 0,
+    durationMs,
     aborted: r.isCanceled === true,
   }
 }

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -57,7 +57,7 @@ function buildCall(file: string, args: readonly string[], options: Partial<Optio
   }
 }
 
-function captureResult(raw: unknown): CassetteResult {
+function captureResult(raw: unknown, durationMs: number): CassetteResult {
   const r = raw as {
     stdout?: string
     stderr?: string
@@ -78,7 +78,7 @@ function captureResult(raw: unknown): CassetteResult {
     allLines: null,
     exitCode: r.exitCode ?? 0,
     signal: r.killed === true ? 'SIGTERM' : null,
-    durationMs: 0,
+    durationMs,
     aborted: r.aborted === true,
   }
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -21,7 +21,11 @@ export type RunnerHooks<Opts, ResultShape> = {
   validate: (options: Opts | undefined) => void
   buildCall: (file: string, args: readonly string[], options: Opts) => Call
   realCall: (file: string, args: readonly string[], options: Opts) => Promise<ResultShape>
-  captureResult: (raw: unknown) => Result
+  // The wrapper measures elapsed time around realCall and passes it here.
+  // Adapters use this value rather than reading runner-provided fields so
+  // the measurement is uniform across runners (execa exposes durationMs;
+  // tinyexec does not).
+  captureResult: (raw: unknown, durationMs: number) => Result
   synthesize: (rec: Recording, options: Opts) => ResultShape
 }
 
@@ -108,12 +112,13 @@ export async function runWrapped<Opts, ResultShape>(
     }
     throw e
   }
+  const start = performance.now()
   try {
     const result = await hooks.realCall(file, args, options)
-    captureAndRecord(call, result, hooks, session, config)
+    captureAndRecord(call, result, performance.now() - start, hooks, session, config)
     return result
   } catch (err) {
-    captureAndRecord(call, err, hooks, session, config)
+    captureAndRecord(call, err, performance.now() - start, hooks, session, config)
     throw err
   }
 }
@@ -121,11 +126,12 @@ export async function runWrapped<Opts, ResultShape>(
 function captureAndRecord<Opts, ResultShape>(
   call: Call,
   raw: unknown,
+  durationMs: number,
   hooks: RunnerHooks<Opts, ResultShape>,
   session: CassetteSession,
   config: Config,
 ): void {
-  const result = hooks.captureResult(raw)
+  const result = hooks.captureResult(raw, durationMs)
   record(call, result, session, config)
 }
 

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -273,16 +273,17 @@ describe('runWrapped (envelope)', () => {
     const realCall = vi.fn(
       () =>
         new Promise<FakeResult>((resolve) => {
-          setTimeout(() => resolve({ stdout: 'slow', exitCode: 0 }), 30)
+          setTimeout(() => resolve({ stdout: 'slow', exitCode: 0 }), 50)
         }),
     )
 
     await runWrapped('sleep', [], {}, baseHooks(realCall))
     expect(session.newRecordings).toHaveLength(1)
     const measured = session.newRecordings[0]?.result.durationMs ?? 0
-    // Asserting ≥20ms with a 30ms artificial delay leaves headroom for timer
-    // imprecision on Windows CI without making the test flaky.
-    expect(measured).toBeGreaterThanOrEqual(20)
+    // Windows default timer resolution is ~15.6ms and slow CI runners can
+    // delay timer firing by another 5-10ms. 50ms timer with a 30ms threshold
+    // leaves enough cushion for that jitter without weakening the assertion.
+    expect(measured).toBeGreaterThanOrEqual(30)
     clearActiveCassette()
   })
 
@@ -295,13 +296,14 @@ describe('runWrapped (envelope)', () => {
     const realCall = vi.fn(
       () =>
         new Promise<FakeResult>((_, reject) => {
-          setTimeout(() => reject(fakeError), 25)
+          setTimeout(() => reject(fakeError), 50)
         }),
     )
 
     await expect(runWrapped('sleep', [], {}, baseHooks(realCall))).rejects.toBe(fakeError)
     expect(session.newRecordings).toHaveLength(1)
-    expect(session.newRecordings[0]?.result.durationMs).toBeGreaterThanOrEqual(15)
+    // Same Windows timer-jitter cushion as the success-path test above.
+    expect(session.newRecordings[0]?.result.durationMs).toBeGreaterThanOrEqual(30)
     clearActiveCassette()
   })
 })

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -25,7 +25,7 @@ const baseHooks = (
     stdin: null,
   }),
   realCall,
-  captureResult: (raw) => {
+  captureResult: (raw, durationMs) => {
     const r = raw as FakeResult
     return {
       stdoutLines: r.stdout.split('\n'),
@@ -33,7 +33,7 @@ const baseHooks = (
       allLines: null,
       exitCode: r.exitCode,
       signal: null,
-      durationMs: 0,
+      durationMs,
       aborted: false,
     }
   },
@@ -213,6 +213,7 @@ describe('runWrapped (envelope)', () => {
         exitCode: 0,
         signal: null,
         durationMs: 0,
+        aborted: false,
       },
     }
     const session = makeSession({
@@ -262,5 +263,45 @@ describe('runWrapped (envelope)', () => {
       expect(realCall).not.toHaveBeenCalled()
       clearActiveCassette()
     }
+  })
+
+  test('record path captures non-zero durationMs measured around realCall', async () => {
+    const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+
+    const realCall = vi.fn(
+      () =>
+        new Promise<FakeResult>((resolve) => {
+          setTimeout(() => resolve({ stdout: 'slow', exitCode: 0 }), 30)
+        }),
+    )
+
+    await runWrapped('sleep', [], {}, baseHooks(realCall))
+    expect(session.newRecordings).toHaveLength(1)
+    const measured = session.newRecordings[0]?.result.durationMs ?? 0
+    // Asserting ≥20ms with a 30ms artificial delay leaves headroom for timer
+    // imprecision on Windows CI without making the test flaky.
+    expect(measured).toBeGreaterThanOrEqual(20)
+    clearActiveCassette()
+  })
+
+  test('record path captures durationMs even when realCall throws', async () => {
+    const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
+    setActiveCassette(session)
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+
+    const fakeError = Object.assign(new Error('boom'), { stdout: '', exitCode: 1 })
+    const realCall = vi.fn(
+      () =>
+        new Promise<FakeResult>((_, reject) => {
+          setTimeout(() => reject(fakeError), 25)
+        }),
+    )
+
+    await expect(runWrapped('sleep', [], {}, baseHooks(realCall))).rejects.toBe(fakeError)
+    expect(session.newRecordings).toHaveLength(1)
+    expect(session.newRecordings[0]?.result.durationMs).toBeGreaterThanOrEqual(15)
+    clearActiveCassette()
   })
 })


### PR DESCRIPTION
## What Changed

- tinyexec captures recorded `durationMs: 0`; execa captures sometimes did too. Misleading data, breaks future per-call timing tooling.
- Wrap `realCall` in `performance.now()` brackets in the wrapper envelope, plumb elapsed ms to `RunnerHooks.captureResult(raw, durationMs)`.
- Both adapters now use the wrapper-measured value uniformly. Measurement covers both success and error paths.

Internal-only API change (`RunnerHooks` is not exported). Cassette schema unchanged.

## Related Issues

Closes #34.

## Test Plan

- [x] `npm run lint`, `typecheck`, `build` clean
- [x] `npm test` (181/181; added 2: non-zero duration on success, non-zero duration on throw)
- [x] `npm run test:dogfood` (3/3)