### PR TITLE
feat!: replace MatcherFn with Canonicalize primitive

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,25 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noConsole": {
+          "level": "error",
+          "options": { "allow": ["warn", "error"] }
+        }
+      },
+      "style": {
+        "noNonNullAssertion": "error",
+        "useImportType": "error"
+      }
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
     }
   },
   "formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@vitest/coverage-v8": "^4.1.5",
         "execa": "^9.0.0",
         "fast-check": "^4.7.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
         "tinyexec": "^1.1.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
@@ -837,6 +839,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -867,6 +911,56 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/convert-source-map": {
@@ -901,6 +995,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
@@ -917,6 +1031,13 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "9.6.1",
@@ -1027,6 +1148,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
@@ -1069,6 +1203,38 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -1424,6 +1590,85 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1457,6 +1702,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1521,6 +1779,22 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
@@ -1635,6 +1909,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -1725,6 +2023,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1748,6 +2063,49 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
@@ -2062,6 +2420,59 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yoctocolors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,6 +261,31 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node": "^22.19.17",
         "@vitest/coverage-v8": "^4.1.5",
         "execa": "^9.0.0",
+        "fast-check": "^4.7.0",
         "tinyexec": "^1.1.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
@@ -258,31 +259,6 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -954,6 +930,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1593,6 +1592,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@types/node": "^22.19.17",
     "@vitest/coverage-v8": "^4.1.5",
     "execa": "^9.0.0",
+    "fast-check": "^4.7.0",
     "tinyexec": "^1.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,11 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
+    "prepare": "husky",
     "prepublishOnly": "npm run build"
+  },
+  "lint-staged": {
+    "**/*.{ts,js,mjs,json}": "biome check --write --no-errors-on-unmatched"
   },
   "peerDependencies": {
     "execa": "^9.0.0",
@@ -98,6 +102,8 @@
     "@vitest/coverage-v8": "^4.1.5",
     "execa": "^9.0.0",
     "fast-check": "^4.7.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "tinyexec": "^1.1.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,11 +2,11 @@ import { stat } from 'node:fs/promises'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { CassetteConfigError } from './errors.js'
-import { defaultMatcher } from './matcher.js'
-import type { MatcherFn } from './types.js'
+import { defaultCanonicalize } from './matcher.js'
+import type { Canonicalize } from './types.js'
 
 export type Config = {
-  matcher: MatcherFn
+  canonicalize: Canonicalize
   cassetteDir: string
   redactEnvKeys: string[]
 }
@@ -14,14 +14,14 @@ export type Config = {
 export type PartialConfig = Partial<Config>
 
 export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
-  matcher: defaultMatcher,
+  canonicalize: defaultCanonicalize,
   cassetteDir: '__cassettes__',
   redactEnvKeys: [] as string[],
 })
 
 export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Config> {
   return Object.freeze({
-    matcher: input?.matcher ?? DEFAULT_CONFIG.matcher,
+    canonicalize: input?.canonicalize ?? DEFAULT_CONFIG.canonicalize,
     cassetteDir: input?.cassetteDir ?? DEFAULT_CONFIG.cassetteDir,
     redactEnvKeys: input?.redactEnvKeys ?? DEFAULT_CONFIG.redactEnvKeys,
   })
@@ -37,8 +37,8 @@ export function validateConfig(input: unknown): asserts input is PartialConfig {
   if ('cassetteDir' in obj && typeof obj.cassetteDir !== 'string') {
     throw new CassetteConfigError('config.cassetteDir must be a string')
   }
-  if ('matcher' in obj && typeof obj.matcher !== 'function') {
-    throw new CassetteConfigError('config.matcher must be a function (call, recording) => boolean')
+  if ('canonicalize' in obj && typeof obj.canonicalize !== 'function') {
+    throw new CassetteConfigError('config.canonicalize must be a function (call) => Partial<Call>')
   }
   if ('redactEnvKeys' in obj) {
     if (!Array.isArray(obj.redactEnvKeys)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
+export { defaultCanonicalize } from './matcher.js'
+export { basenameCommand, normalizeTmpPath } from './normalize.js'
 export type {
   Call,
+  Canonicalize,
   CassetteFile,
   CassetteSession,
-  MatcherFn,
   Mode,
   Recording,
   Result,
+  UseCassetteOptions,
 } from './types.js'
 export { useCassette } from './use-cassette.js'

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -2,10 +2,11 @@ import { log } from './log.js'
 import { normalizeTmpPath } from './normalize.js'
 import type { Call, Canonicalize, MatcherStateLike, Recording } from './types.js'
 
+// cwd/env/stdin are omitted: their values vary per-machine and would break
+// cross-machine replay. Users who need them must opt in via custom canonicalize.
 export const defaultCanonicalize: Canonicalize = (call) => ({
   command: call.command,
   args: call.args.map(normalizeTmpPath),
-  // cwd, env, stdin: omitted from default canonical form
 })
 
 export class MatcherState implements MatcherStateLike {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,33 +1,38 @@
 import { log } from './log.js'
-import type { Call, MatcherFn, MatcherStateLike, Recording } from './types.js'
+import { normalizeTmpPath } from './normalize.js'
+import type { Call, Canonicalize, MatcherStateLike, Recording } from './types.js'
 
-export const defaultMatcher: MatcherFn = (call, rec) =>
-  call.command === rec.call.command && deepEqualArgs(call.args, rec.call.args)
-
-function deepEqualArgs(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false
-  }
-  return true
-}
+export const defaultCanonicalize: Canonicalize = (call) => ({
+  command: call.command,
+  args: call.args.map(normalizeTmpPath),
+  // cwd, env, stdin: omitted from default canonical form
+})
 
 export class MatcherState implements MatcherStateLike {
   private consumedIndices: Set<number> = new Set()
+  private canonicalRecordings: ReadonlyArray<Partial<Call>>
 
   constructor(
     private readonly recordings: readonly Recording[],
-    private readonly matcher: MatcherFn,
-  ) {}
+    private readonly canonicalize: Canonicalize,
+  ) {
+    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call))
+  }
 
   findMatch(call: Call): Recording | null {
+    const canonicalCall = this.canonicalize(call)
     const candidates: { index: number; rec: Recording }[] = []
-    let i = 0
-    for (const rec of this.recordings) {
-      if (!this.consumedIndices.has(i) && this.matcher(call, rec)) {
+    for (let i = 0; i < this.recordings.length; i++) {
+      if (this.consumedIndices.has(i)) continue
+      const canonicalRec = this.canonicalRecordings[i]
+      const rec = this.recordings[i]
+      if (
+        canonicalRec !== undefined &&
+        rec !== undefined &&
+        canonicalEqual(canonicalCall, canonicalRec)
+      ) {
         candidates.push({ index: i, rec })
       }
-      i++
     }
 
     const first = candidates[0]
@@ -42,4 +47,41 @@ export class MatcherState implements MatcherStateLike {
     this.consumedIndices.add(first.index)
     return first.rec
   }
+}
+
+// Hand-rolled comparator over the known Partial<Call> field set.
+// Fast (no allocation per comparison), explicit, no JSON quirks.
+// "undefined" on either side is treated as "field not part of canonical form".
+function canonicalEqual(a: Partial<Call>, b: Partial<Call>): boolean {
+  if (a.command !== b.command) return false
+  if (!arraysEqual(a.args, b.args)) return false
+  if (a.cwd !== b.cwd) return false
+  if (!envsEqual(a.env, b.env)) return false
+  if (a.stdin !== b.stdin) return false
+  return true
+}
+
+function arraysEqual(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+  if (a === undefined && b === undefined) return true
+  if (a === undefined || b === undefined) return false
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function envsEqual(
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined,
+): boolean {
+  if (a === undefined && b === undefined) return true
+  if (a === undefined || b === undefined) return false
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) {
+    if (a[k] !== b[k]) return false
+  }
+  return true
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -4,6 +4,10 @@
 // Order matters: more-specific prefixes (/var/tmp, /private/tmp, /var/folders) must
 // run before the plain /tmp pattern so /var/tmp and /private/tmp are not partially
 // consumed by /tmp first, leaving a `/var` or `/private` prefix.
+//
+// IMPORTANT: these are module-level g-flag RegExp instances. Use them ONLY with
+// `String.prototype.replace`, never `.test()` or `.exec()`. The g flag makes those
+// methods stateful via `lastIndex`, which would carry state across calls.
 const TMP_PREFIX_PATTERNS: readonly RegExp[] = [
   /\/var\/folders\/[^/]+\/[^/]+\/T\/[^/\s]+/g,
   /\/var\/tmp\/[^/\s]+/g,

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 // Per-OS regex table for absolute mkdtemp prefixes.
 // Each pattern matches a tmp prefix followed by exactly one path component.
 // `g` flag so substring-anywhere replacement works (e.g., `--config=/tmp/abc/x.json`).
@@ -24,4 +26,12 @@ export function normalizeTmpPath(s: string): string {
     out = out.replace(re, TMP_TOKEN)
   }
   return out
+}
+
+export function basenameCommand(cmd: string): string {
+  const base = path.basename(cmd)
+  if (process.platform === 'win32' && base.toLowerCase().endsWith('.exe')) {
+    return base.slice(0, -4)
+  }
+  return base
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,14 +1,11 @@
 import path from 'node:path'
 
-// Per-OS regex table for absolute mkdtemp prefixes.
-// Each pattern matches a tmp prefix followed by exactly one path component.
-// `g` flag so substring-anywhere replacement works (e.g., `--config=/tmp/abc/x.json`).
 // Order matters: more-specific prefixes (/var/tmp, /private/tmp, /var/folders) must
-// run before the plain /tmp pattern so /var/tmp and /private/tmp are not partially
-// consumed by /tmp first, leaving a `/var` or `/private` prefix.
+// run before the plain /tmp pattern, otherwise /var/tmp is partially consumed by /tmp
+// first, leaving a `/var` prefix.
 //
-// IMPORTANT: these are module-level g-flag RegExp instances. Use them ONLY with
-// `String.prototype.replace`, never `.test()` or `.exec()`. The g flag makes those
+// These are module-level g-flag RegExp instances. Use them ONLY with
+// `String.prototype.replace`, never `.test()` or `.exec()` — the g flag makes those
 // methods stateful via `lastIndex`, which would carry state across calls.
 const TMP_PREFIX_PATTERNS: readonly RegExp[] = [
   /\/var\/folders\/[^/]+\/[^/]+\/T\/[^/\s]+/g,
@@ -18,7 +15,7 @@ const TMP_PREFIX_PATTERNS: readonly RegExp[] = [
   /[A-Z]:\\Users\\[^\\]+\\AppData\\Local\\Temp\\[^\\\s]+/g,
 ]
 
-const TMP_TOKEN = '<tmp>'
+export const TMP_TOKEN = '<tmp>'
 
 export function normalizeTmpPath(s: string): string {
   let out = s

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,0 +1,23 @@
+// Per-OS regex table for absolute mkdtemp prefixes.
+// Each pattern matches a tmp prefix followed by exactly one path component.
+// `g` flag so substring-anywhere replacement works (e.g., `--config=/tmp/abc/x.json`).
+// Order matters: more-specific prefixes (/var/tmp, /private/tmp, /var/folders) must
+// run before the plain /tmp pattern so /var/tmp and /private/tmp are not partially
+// consumed by /tmp first, leaving a `/var` or `/private` prefix.
+const TMP_PREFIX_PATTERNS: readonly RegExp[] = [
+  /\/var\/folders\/[^/]+\/[^/]+\/T\/[^/\s]+/g,
+  /\/var\/tmp\/[^/\s]+/g,
+  /\/private\/tmp\/[^/\s]+/g,
+  /\/tmp\/[^/\s]+/g,
+  /[A-Z]:\\Users\\[^\\]+\\AppData\\Local\\Temp\\[^\\\s]+/g,
+]
+
+const TMP_TOKEN = '<tmp>'
+
+export function normalizeTmpPath(s: string): string {
+  let out = s
+  for (const re of TMP_PREFIX_PATTERNS) {
+    out = out.replace(re, TMP_TOKEN)
+  }
+  return out
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,13 @@ export type CassetteFile = {
   recordings: Recording[]
 }
 
-export type MatcherFn = (call: Call, recording: Recording) => boolean
+// v0.3: replaces MatcherFn. The matcher compares deep-equal canonical forms.
+export type Canonicalize = (call: Call) => Partial<Call>
+
+// v0.3: per-call options for useCassette.
+export type UseCassetteOptions = {
+  canonicalize?: Canonicalize
+}
 
 export type CassetteSession = {
   name: string
@@ -40,6 +46,7 @@ export type CassetteSession = {
   scopeDefault: 'auto' | 'passthrough'
   loadedFile: CassetteFile | null
   matcher: MatcherStateLike | null // built lazily; defined in matcher.ts
+  canonicalize: Canonicalize // v0.3: resolved per-session canonicalize
   newRecordings: Recording[]
   // Accumulated across record() calls in this scope. Emitted as an
   // end-of-run summary by the vitest plugin and useCassette finally.

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,10 +32,8 @@ export type CassetteFile = {
   recordings: Recording[]
 }
 
-// v0.3: replaces MatcherFn. The matcher compares deep-equal canonical forms.
 export type Canonicalize = (call: Call) => Partial<Call>
 
-// v0.3: per-call options for useCassette.
 export type UseCassetteOptions = {
   canonicalize?: Canonicalize
 }
@@ -46,7 +44,7 @@ export type CassetteSession = {
   scopeDefault: 'auto' | 'passthrough'
   loadedFile: CassetteFile | null
   matcher: MatcherStateLike | null // built lazily; defined in matcher.ts
-  canonicalize: Canonicalize // v0.3: resolved per-session canonicalize
+  canonicalize: Canonicalize
   newRecordings: Recording[]
   // Accumulated across record() calls in this scope. Emitted as an
   // end-of-run summary by the vitest plugin and useCassette finally.

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -24,7 +24,6 @@ export async function useCassette<T>(
   maybeFn?: () => Promise<T>,
 ): Promise<T> {
   const options: UseCassetteOptions = typeof fnOrOptions === 'function' ? {} : fnOrOptions
-  // maybeFn is always defined when fnOrOptions is not a function (enforced by overloads)
   const fn: () => Promise<T> =
     typeof fnOrOptions === 'function' ? fnOrOptions : (maybeFn as () => Promise<T>)
   const canonicalize: Canonicalize = options.canonicalize ?? defaultCanonicalize

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { writeCassetteFile } from './io.js'
+import { defaultCanonicalize } from './matcher.js'
 import { serialize } from './serialize.js'
 import {
   registerSessionPath,
@@ -7,9 +8,27 @@ import {
   withCassette as withCassetteScope,
 } from './state.js'
 import { summarizeSession } from './summary.js'
-import type { CassetteFile, CassetteSession } from './types.js'
+import type { Canonicalize, CassetteFile, CassetteSession, UseCassetteOptions } from './types.js'
 
-export async function useCassette<T>(cassettePath: string, fn: () => Promise<T>): Promise<T> {
+// Public overloads
+export function useCassette<T>(cassettePath: string, fn: () => Promise<T>): Promise<T>
+export function useCassette<T>(
+  cassettePath: string,
+  options: UseCassetteOptions,
+  fn: () => Promise<T>,
+): Promise<T>
+// Implementation
+export async function useCassette<T>(
+  cassettePath: string,
+  fnOrOptions: UseCassetteOptions | (() => Promise<T>),
+  maybeFn?: () => Promise<T>,
+): Promise<T> {
+  const options: UseCassetteOptions = typeof fnOrOptions === 'function' ? {} : fnOrOptions
+  // maybeFn is always defined when fnOrOptions is not a function (enforced by overloads)
+  const fn: () => Promise<T> =
+    typeof fnOrOptions === 'function' ? fnOrOptions : (maybeFn as () => Promise<T>)
+  const canonicalize: Canonicalize = options.canonicalize ?? defaultCanonicalize
+
   const absolutePath = path.resolve(cassettePath)
   registerSessionPath(absolutePath, `useCassette(${cassettePath})`)
   try {
@@ -19,6 +38,7 @@ export async function useCassette<T>(cassettePath: string, fn: () => Promise<T>)
       scopeDefault: 'auto',
       loadedFile: null,
       matcher: null,
+      canonicalize,
       newRecordings: [],
       redactedKeys: [],
       warnings: [],

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -77,6 +77,7 @@ try {
       scopeDefault: 'auto',
       loadedFile: null,
       matcher: null,
+      canonicalize: config.canonicalize,
       newRecordings: [],
       redactedKeys: [],
       warnings: [],

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -142,14 +142,22 @@ function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
   return matcher
 }
 
+const REPLAY_MISS_DIAGNOSTIC_LIMIT = 10
+
 function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
   const canonical = session.canonicalize(call)
-  const recordedCalls = session.loadedFile?.recordings
-    .map((r) => formatCallSignature(r.call))
-    .join('\n  - ')
-  const recordedCanonical = session.loadedFile?.recordings
-    .map((r) => JSON.stringify(session.canonicalize(r.call)))
-    .join('\n  - ')
+  const recordings = session.loadedFile?.recordings ?? []
+  const shown = recordings.slice(0, REPLAY_MISS_DIAGNOSTIC_LIMIT)
+  const truncated =
+    recordings.length > REPLAY_MISS_DIAGNOSTIC_LIMIT
+      ? `\n  ... (${recordings.length - REPLAY_MISS_DIAGNOSTIC_LIMIT} more)`
+      : ''
+  const recordedCalls = shown.length
+    ? shown.map((r) => formatCallSignature(r.call)).join('\n  - ') + truncated
+    : '(none)'
+  const recordedCanonical = shown.length
+    ? shown.map((r) => JSON.stringify(session.canonicalize(r.call))).join('\n  - ') + truncated
+    : '(none)'
   return new ReplayMissError(
     `no matching recording for \`${formatCallSignature(call)}\`
   cassette:        ${session.path}
@@ -157,10 +165,10 @@ function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissE
   call canonical:  ${JSON.stringify(canonical)}
 
 Recorded calls in this cassette:
-  - ${recordedCalls ?? '(none)'}
+  - ${recordedCalls}
 
 Recorded canonical forms:
-  - ${recordedCanonical ?? '(none)'}
+  - ${recordedCanonical}
 
 To re-record: delete the cassette file and run tests again.`,
   )

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -58,7 +58,7 @@ export async function runWrapped<Opts, ResultShape>(
   const config = getConfig()
   if (session.loadedFile === null) {
     session.loadedFile = await loadCassette(session.path)
-    session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], config.matcher)
+    session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], session.canonicalize)
   }
 
   const mode = resolveMode(
@@ -143,16 +143,24 @@ function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
 }
 
 function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
+  const canonical = session.canonicalize(call)
   const recordedCalls = session.loadedFile?.recordings
     .map((r) => formatCallSignature(r.call))
     .join('\n  - ')
+  const recordedCanonical = session.loadedFile?.recordings
+    .map((r) => JSON.stringify(session.canonicalize(r.call)))
+    .join('\n  - ')
   return new ReplayMissError(
     `no matching recording for \`${formatCallSignature(call)}\`
-  cassette: ${session.path}
-  matcher:  default (command + deep-equal args)
+  cassette:        ${session.path}
+  matcher:         canonicalize-then-equal (default normalizes mkdtemp paths in args)
+  call canonical:  ${JSON.stringify(canonical)}
 
 Recorded calls in this cassette:
   - ${recordedCalls ?? '(none)'}
+
+Recorded canonical forms:
+  - ${recordedCanonical ?? '(none)'}
 
 To re-record: delete the cassette file and run tests again.`,
   )

--- a/tests/error-path/error-classes.test.ts
+++ b/tests/error-path/error-classes.test.ts
@@ -13,6 +13,7 @@ import {
   UnsupportedOptionError,
 } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
+import { defaultCanonicalize } from '../../src/matcher.js'
 import { cassettePath } from '../../src/paths.js'
 import { deriveCassettePathFromTask } from '../../src/plugin.js'
 import { deserialize } from '../../src/serialize.js'
@@ -54,7 +55,10 @@ describe('all error classes are instanceof ShellCassetteError', () => {
         scopeDefault: 'auto',
         loadedFile: null,
         matcher: null,
+        canonicalize: defaultCanonicalize,
         newRecordings: [],
+        redactedKeys: [],
+        warnings: [],
       })
       try {
         await execa('node', ['-v'])
@@ -89,7 +93,10 @@ describe('all error classes are instanceof ShellCassetteError', () => {
         scopeDefault: 'auto',
         loadedFile: null,
         matcher: null,
+        canonicalize: defaultCanonicalize,
         newRecordings: [],
+        redactedKeys: [],
+        warnings: [],
       })
       try {
         await execa('node', ['-v'])

--- a/tests/error-path/error-classes.test.ts
+++ b/tests/error-path/error-classes.test.ts
@@ -13,12 +13,12 @@ import {
   UnsupportedOptionError,
 } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
-import { defaultCanonicalize } from '../../src/matcher.js'
 import { cassettePath } from '../../src/paths.js'
 import { deriveCassettePathFromTask } from '../../src/plugin.js'
 import { deserialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { makeSession } from '../helpers/session.js'
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
 const originalMode = process.env.SHELL_CASSETTE_MODE
@@ -49,17 +49,9 @@ describe('all error classes are instanceof ShellCassetteError', () => {
     delete process.env.SHELL_CASSETTE_ACK_REDACTION
     const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
     try {
-      setActiveCassette({
-        name: 'x',
-        path: path.join(tmp, 'a.json'),
-        scopeDefault: 'auto',
-        loadedFile: null,
-        matcher: null,
-        canonicalize: defaultCanonicalize,
-        newRecordings: [],
-        redactedKeys: [],
-        warnings: [],
-      })
+      setActiveCassette(
+        makeSession({ name: 'x', path: path.join(tmp, 'a.json'), loadedFile: null, matcher: null }),
+      )
       try {
         await execa('node', ['-v'])
         throw new Error('should not reach')
@@ -87,17 +79,14 @@ describe('all error classes are instanceof ShellCassetteError', () => {
     process.env.SHELL_CASSETTE_MODE = 'replay'
     const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
     try {
-      setActiveCassette({
-        name: 'x',
-        path: path.join(tmp, 'missing.json'),
-        scopeDefault: 'auto',
-        loadedFile: null,
-        matcher: null,
-        canonicalize: defaultCanonicalize,
-        newRecordings: [],
-        redactedKeys: [],
-        warnings: [],
-      })
+      setActiveCassette(
+        makeSession({
+          name: 'x',
+          path: path.join(tmp, 'missing.json'),
+          loadedFile: null,
+          matcher: null,
+        }),
+      )
       try {
         await execa('node', ['-v'])
         throw new Error('should not reach')

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -8,19 +8,21 @@ import type { CassetteSession } from '../../src/types.js'
 // or ensureMatcher() throws "internal bug" on the first call. Tracked under
 // issue #26 (CassetteSession type permits unreachable states).
 export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
+  const canonicalize = overrides.canonicalize ?? DEFAULT_CONFIG.canonicalize
   const base: CassetteSession = {
     name: 'test',
     path: '/tmp/test.json',
     scopeDefault: 'auto',
     loadedFile: { version: 1, recordings: [] },
     matcher: null,
+    canonicalize,
     newRecordings: [],
     redactedKeys: [],
     warnings: [],
     ...overrides,
   }
   if (base.loadedFile !== null && base.matcher === null) {
-    base.matcher = new MatcherState(base.loadedFile.recordings, DEFAULT_CONFIG.matcher)
+    base.matcher = new MatcherState(base.loadedFile.recordings, base.canonicalize)
   }
   return base
 }

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -4,22 +4,13 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa as wrappedExeca } from '../../src/execa.js'
 import { writeCassetteFile } from '../../src/io.js'
-import { defaultCanonicalize } from '../../src/matcher.js'
 import { serialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { CassetteSession } from '../../src/types.js'
+import { makeSession } from '../helpers/session.js'
 
-const sessionAt = (sessionPath: string): CassetteSession => ({
-  name: 'test',
-  path: sessionPath,
-  scopeDefault: 'auto',
-  loadedFile: null,
-  matcher: null,
-  canonicalize: defaultCanonicalize,
-  newRecordings: [],
-  redactedKeys: [],
-  warnings: [],
-})
+const sessionAt = (sessionPath: string): CassetteSession =>
+  makeSession({ name: 'test', path: sessionPath, loadedFile: null, matcher: null })
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
 const originalMode = process.env.SHELL_CASSETTE_MODE

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa as wrappedExeca } from '../../src/execa.js'
 import { writeCassetteFile } from '../../src/io.js'
+import { defaultCanonicalize } from '../../src/matcher.js'
 import { serialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { CassetteSession } from '../../src/types.js'
@@ -14,7 +15,10 @@ const sessionAt = (sessionPath: string): CassetteSession => ({
   scopeDefault: 'auto',
   loadedFile: null,
   matcher: null,
+  canonicalize: defaultCanonicalize,
   newRecordings: [],
+  redactedKeys: [],
+  warnings: [],
 })
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -11,21 +11,9 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.redactEnvKeys).toEqual([])
   })
 
-  test('default matcher matches command + args', () => {
+  test('default canonicalize returns command + args', () => {
     const call = { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null } as const
-    const rec = {
-      call,
-      result: {
-        stdoutLines: [''],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 1,
-        aborted: false,
-      },
-    }
-    expect(DEFAULT_CONFIG.matcher(call, rec)).toBe(true)
+    expect(DEFAULT_CONFIG.canonicalize(call)).toEqual({ command: 'git', args: ['status'] })
   })
 })
 
@@ -76,7 +64,7 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ redactEnvKeys: [1, 2] })).toThrow(CassetteConfigError)
   })
 
-  test('throws if matcher is not function', () => {
-    expect(() => validateConfig({ matcher: 'foo' })).toThrow(CassetteConfigError)
+  test('throws if canonicalize is not function', () => {
+    expect(() => validateConfig({ canonicalize: 'foo' })).toThrow(CassetteConfigError)
   })
 })

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test, vi } from 'vitest'
-import { defaultMatcher, MatcherState } from '../../src/matcher.js'
-import type { Call, Recording } from '../../src/types.js'
+import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
+import type { Call, Canonicalize, Recording } from '../../src/types.js'
 
-const callOf = (command: string, args: string[]): Call => ({
+const callOf = (command: string, args: string[], extra: Partial<Call> = {}): Call => ({
   command,
   args,
   cwd: null,
   env: {},
   stdin: null,
+  ...extra,
 })
 
 const recordingOf = (command: string, args: string[], stdout = ''): Recording => ({
@@ -23,42 +24,88 @@ const recordingOf = (command: string, args: string[], stdout = ''): Recording =>
   },
 })
 
-describe('defaultMatcher', () => {
-  test('matches on command + deep-equal args', () => {
-    const c = callOf('git', ['status'])
-    const r = recordingOf('git', ['status'])
-    expect(defaultMatcher(c, r)).toBe(true)
+describe('defaultCanonicalize', () => {
+  test('includes command and args', () => {
+    const canonical = defaultCanonicalize(callOf('git', ['status']))
+    expect(canonical.command).toBe('git')
+    expect(canonical.args).toEqual(['status'])
   })
 
-  test('does not match on different command', () => {
-    expect(defaultMatcher(callOf('git', ['status']), recordingOf('hg', ['status']))).toBe(false)
+  test('omits cwd, env, stdin from canonical form', () => {
+    const canonical = defaultCanonicalize(
+      callOf('git', ['status'], { cwd: '/some/dir', env: { FOO: 'bar' } }),
+    )
+    expect(canonical.cwd).toBeUndefined()
+    expect(canonical.env).toBeUndefined()
+    expect(canonical.stdin).toBeUndefined()
   })
 
-  test('does not match on different args', () => {
-    expect(defaultMatcher(callOf('git', ['status']), recordingOf('git', ['log']))).toBe(false)
+  test('normalizes mkdtemp paths in args', () => {
+    const canonical = defaultCanonicalize(
+      callOf('git', ['remote', 'set-url', 'origin', '/tmp/test-abc/remote.git']),
+    )
+    expect(canonical.args).toEqual(['remote', 'set-url', 'origin', '<tmp>/remote.git'])
   })
 
-  test('args order matters', () => {
-    expect(defaultMatcher(callOf('git', ['a', 'b']), recordingOf('git', ['b', 'a']))).toBe(false)
+  test('is deterministic — same input produces same output', () => {
+    const c = callOf('git', ['log'])
+    expect(defaultCanonicalize(c)).toEqual(defaultCanonicalize(c))
   })
 })
 
-describe('MatcherState sequential consumption', () => {
+describe('MatcherState — basic matching', () => {
   test('returns null when no recordings', () => {
-    const m = new MatcherState([], defaultMatcher)
+    const m = new MatcherState([], defaultCanonicalize)
     expect(m.findMatch(callOf('git', []))).toBeNull()
   })
 
-  test('returns first match for first call, second match for second call', () => {
+  test('matches on command + args', () => {
+    const recs = [recordingOf('git', ['status'], 'output')]
+    const m = new MatcherState(recs, defaultCanonicalize)
+    expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('output')
+  })
+
+  test('does not match on different command', () => {
+    const recs = [recordingOf('git', ['status'])]
+    const m = new MatcherState(recs, defaultCanonicalize)
+    expect(m.findMatch(callOf('hg', ['status']))).toBeNull()
+  })
+
+  test('does not match on different args', () => {
+    const recs = [recordingOf('git', ['status'])]
+    const m = new MatcherState(recs, defaultCanonicalize)
+    expect(m.findMatch(callOf('git', ['log']))).toBeNull()
+  })
+
+  test('args order matters under default', () => {
+    const recs = [recordingOf('git', ['a', 'b'])]
+    const m = new MatcherState(recs, defaultCanonicalize)
+    expect(m.findMatch(callOf('git', ['b', 'a']))).toBeNull()
+  })
+
+  test('matches when canonical forms equal even if raw args differ (tmp normalization)', () => {
+    const recs = [
+      recordingOf('git', ['remote', 'set-url', 'origin', '/tmp/test-RECORD/remote.git']),
+    ]
+    const m = new MatcherState(recs, defaultCanonicalize)
+    const matched = m.findMatch(
+      callOf('git', ['remote', 'set-url', 'origin', '/tmp/test-REPLAY/remote.git']),
+    )
+    expect(matched).not.toBeNull()
+  })
+})
+
+describe('MatcherState — sequential consumption', () => {
+  test('first call gets first match, second call gets second match', () => {
     const recs = [recordingOf('git', ['status'], 'first'), recordingOf('git', ['status'], 'second')]
-    const m = new MatcherState(recs, defaultMatcher)
+    const m = new MatcherState(recs, defaultCanonicalize)
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('first')
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('second')
   })
 
   test('returns null when consumption exhausted', () => {
     const recs = [recordingOf('git', ['status'])]
-    const m = new MatcherState(recs, defaultMatcher)
+    const m = new MatcherState(recs, defaultCanonicalize)
     m.findMatch(callOf('git', ['status']))
     expect(m.findMatch(callOf('git', ['status']))).toBeNull()
   })
@@ -69,17 +116,19 @@ describe('MatcherState sequential consumption', () => {
       recordingOf('git', ['log'], 'l1'),
       recordingOf('git', ['status'], 's2'),
     ]
-    const m = new MatcherState(recs, defaultMatcher)
+    const m = new MatcherState(recs, defaultCanonicalize)
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('s1')
     expect(m.findMatch(callOf('git', ['log']))?.result.stdoutLines[0]).toBe('l1')
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('s2')
   })
+})
 
-  test('logs ambiguity warning when multiple unconsumed recordings could match', () => {
+describe('MatcherState — ambiguity warning', () => {
+  test('logs warning when multiple unconsumed recordings could match', () => {
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     try {
       const recs = [recordingOf('git', ['status'], 'a'), recordingOf('git', ['status'], 'b')]
-      const m = new MatcherState(recs, defaultMatcher)
+      const m = new MatcherState(recs, defaultCanonicalize)
       m.findMatch(callOf('git', ['status']))
       const warnCalls = stderrSpy.mock.calls
         .map((c) => c[0] as string)
@@ -89,12 +138,24 @@ describe('MatcherState sequential consumption', () => {
       stderrSpy.mockRestore()
     }
   })
+})
 
-  test('uses custom matcher function', () => {
+describe('MatcherState — custom canonicalize', () => {
+  test('uses provided canonicalize fn (e.g., command-only matching)', () => {
+    const commandOnly: Canonicalize = (call) => ({ command: call.command })
     const recs = [recordingOf('git', ['status'])]
-    const customMatcher = (c: Call, r: Recording) => c.command === r.call.command
-    const m = new MatcherState(recs, customMatcher)
-    // Custom matcher matches by command alone
+    const m = new MatcherState(recs, commandOnly)
     expect(m.findMatch(callOf('git', ['anything']))).not.toBeNull()
+  })
+
+  test('caches canonical forms at construction (canonicalize called once per recording)', () => {
+    const calls: Call[] = []
+    const tracking: Canonicalize = (c) => {
+      calls.push(c)
+      return { command: c.command, args: c.args }
+    }
+    const recs = [recordingOf('git', ['a']), recordingOf('git', ['b'])]
+    new MatcherState(recs, tracking)
+    expect(calls).toHaveLength(2)
   })
 })

--- a/tests/unit/normalize.test.ts
+++ b/tests/unit/normalize.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+import { normalizeTmpPath } from '../../src/normalize.js'
+
+describe('normalizeTmpPath - Linux /tmp', () => {
+  test('replaces /tmp/<dir> with <tmp>', () => {
+    expect(normalizeTmpPath('/tmp/test-abc/foo.git')).toBe('<tmp>/foo.git')
+  })
+
+  test('replaces multiple occurrences', () => {
+    expect(normalizeTmpPath('/tmp/a/x.txt /tmp/b/y.txt')).toBe('<tmp>/x.txt <tmp>/y.txt')
+  })
+
+  test('preserves path beyond first component', () => {
+    expect(normalizeTmpPath('/tmp/abc/sub/file.json')).toBe('<tmp>/sub/file.json')
+  })
+})
+
+describe('normalizeTmpPath - Linux /var/tmp', () => {
+  test('replaces /var/tmp/<dir> with <tmp>', () => {
+    expect(normalizeTmpPath('/var/tmp/x/y')).toBe('<tmp>/y')
+  })
+})
+
+describe('normalizeTmpPath - macOS /var/folders', () => {
+  test('replaces /var/folders/<a>/<b>/T/<dir> with <tmp>', () => {
+    expect(normalizeTmpPath('/var/folders/qw/abc123/T/release-test-AbCdEf/remote.git')).toBe(
+      '<tmp>/remote.git',
+    )
+  })
+})
+
+describe('normalizeTmpPath - macOS /private/tmp', () => {
+  test('replaces /private/tmp/<dir> with <tmp>', () => {
+    expect(normalizeTmpPath('/private/tmp/test/x.txt')).toBe('<tmp>/x.txt')
+  })
+})
+
+describe('normalizeTmpPath - Windows', () => {
+  test('replaces C:\\Users\\<u>\\AppData\\Local\\Temp\\<dir> with <tmp>', () => {
+    expect(
+      normalizeTmpPath('C:\\Users\\steve\\AppData\\Local\\Temp\\foo-AbC\\bar\\baz.txt'),
+    ).toBe('<tmp>\\bar\\baz.txt')
+  })
+})
+
+describe('normalizeTmpPath - embedded substring', () => {
+  test('replaces tmp prefix appearing inside an arg', () => {
+    expect(normalizeTmpPath('--config=/tmp/abc/x.json')).toBe('--config=<tmp>/x.json')
+  })
+})
+
+describe('normalizeTmpPath - disambiguation', () => {
+  test('two files in same tmp dir produce different canonical forms', () => {
+    expect(normalizeTmpPath('/tmp/abc/file-a.txt')).not.toBe(
+      normalizeTmpPath('/tmp/abc/file-b.txt'),
+    )
+  })
+})
+
+describe('normalizeTmpPath - boundaries', () => {
+  test('does not normalize /tmpfile (no slash after /tmp)', () => {
+    expect(normalizeTmpPath('/tmpfile')).toBe('/tmpfile')
+  })
+
+  test('does not normalize /tmp/ (trailing slash, no component)', () => {
+    expect(normalizeTmpPath('/tmp/')).toBe('/tmp/')
+  })
+
+  test('non-tmp string is unchanged', () => {
+    expect(normalizeTmpPath('/usr/local/bin/foo')).toBe('/usr/local/bin/foo')
+  })
+
+  test('empty string is unchanged', () => {
+    expect(normalizeTmpPath('')).toBe('')
+  })
+})
+
+describe('normalizeTmpPath - idempotence', () => {
+  test('applying twice is the same as applying once', () => {
+    const inputs = [
+      '/tmp/abc/x',
+      '/var/folders/q/w/T/abc/y',
+      'C:\\Users\\steve\\AppData\\Local\\Temp\\foo\\z',
+      '--config=/tmp/abc/x.json',
+      'no-tmp-here',
+    ]
+    for (const s of inputs) {
+      const once = normalizeTmpPath(s)
+      const twice = normalizeTmpPath(once)
+      expect(twice).toBe(once)
+    }
+  })
+})

--- a/tests/unit/normalize.test.ts
+++ b/tests/unit/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { normalizeTmpPath } from '../../src/normalize.js'
+import { basenameCommand, normalizeTmpPath } from '../../src/normalize.js'
 
 describe('normalizeTmpPath - Linux /tmp', () => {
   test('replaces /tmp/<dir> with <tmp>', () => {
@@ -89,5 +89,37 @@ describe('normalizeTmpPath - idempotence', () => {
       const twice = normalizeTmpPath(once)
       expect(twice).toBe(once)
     }
+  })
+})
+
+describe('basenameCommand', () => {
+  test('absolute path returns basename', () => {
+    expect(basenameCommand('/usr/bin/git')).toBe('git')
+  })
+
+  test('bare command returns itself', () => {
+    expect(basenameCommand('git')).toBe('git')
+  })
+
+  test('Windows-style path returns basename', () => {
+    expect(basenameCommand('C:\\Program Files\\Git\\bin\\git.exe')).toMatch(/^git(\.exe)?$/)
+  })
+})
+
+describe('basenameCommand - Windows .exe strip', () => {
+  // These behavior tests assume process.platform === 'win32'.
+  // Skipped on non-Windows runners but documented for cross-platform clarity.
+  const isWindows = process.platform === 'win32'
+
+  test.skipIf(!isWindows)('strips lowercase .exe on Windows', () => {
+    expect(basenameCommand('git.exe')).toBe('git')
+  })
+
+  test.skipIf(!isWindows)('strips uppercase .EXE on Windows (case-insensitive)', () => {
+    expect(basenameCommand('node.EXE')).toBe('node')
+  })
+
+  test.skipIf(isWindows)('does NOT strip .exe on non-Windows', () => {
+    expect(basenameCommand('foo.exe')).toBe('foo.exe')
   })
 })

--- a/tests/unit/normalize.test.ts
+++ b/tests/unit/normalize.test.ts
@@ -37,9 +37,9 @@ describe('normalizeTmpPath - macOS /private/tmp', () => {
 
 describe('normalizeTmpPath - Windows', () => {
   test('replaces C:\\Users\\<u>\\AppData\\Local\\Temp\\<dir> with <tmp>', () => {
-    expect(
-      normalizeTmpPath('C:\\Users\\steve\\AppData\\Local\\Temp\\foo-AbC\\bar\\baz.txt'),
-    ).toBe('<tmp>\\bar\\baz.txt')
+    expect(normalizeTmpPath('C:\\Users\\steve\\AppData\\Local\\Temp\\foo-AbC\\bar\\baz.txt')).toBe(
+      '<tmp>\\bar\\baz.txt',
+    )
   })
 })
 

--- a/tests/unit/normalize.test.ts
+++ b/tests/unit/normalize.test.ts
@@ -1,51 +1,53 @@
 import { describe, expect, test } from 'vitest'
-import { basenameCommand, normalizeTmpPath } from '../../src/normalize.js'
+import { basenameCommand, normalizeTmpPath, TMP_TOKEN } from '../../src/normalize.js'
 
 describe('normalizeTmpPath - Linux /tmp', () => {
   test('replaces /tmp/<dir> with <tmp>', () => {
-    expect(normalizeTmpPath('/tmp/test-abc/foo.git')).toBe('<tmp>/foo.git')
+    expect(normalizeTmpPath('/tmp/test-abc/foo.git')).toBe(`${TMP_TOKEN}/foo.git`)
   })
 
   test('replaces multiple occurrences', () => {
-    expect(normalizeTmpPath('/tmp/a/x.txt /tmp/b/y.txt')).toBe('<tmp>/x.txt <tmp>/y.txt')
+    expect(normalizeTmpPath('/tmp/a/x.txt /tmp/b/y.txt')).toBe(
+      `${TMP_TOKEN}/x.txt ${TMP_TOKEN}/y.txt`,
+    )
   })
 
   test('preserves path beyond first component', () => {
-    expect(normalizeTmpPath('/tmp/abc/sub/file.json')).toBe('<tmp>/sub/file.json')
+    expect(normalizeTmpPath('/tmp/abc/sub/file.json')).toBe(`${TMP_TOKEN}/sub/file.json`)
   })
 })
 
 describe('normalizeTmpPath - Linux /var/tmp', () => {
   test('replaces /var/tmp/<dir> with <tmp>', () => {
-    expect(normalizeTmpPath('/var/tmp/x/y')).toBe('<tmp>/y')
+    expect(normalizeTmpPath('/var/tmp/x/y')).toBe(`${TMP_TOKEN}/y`)
   })
 })
 
 describe('normalizeTmpPath - macOS /var/folders', () => {
   test('replaces /var/folders/<a>/<b>/T/<dir> with <tmp>', () => {
     expect(normalizeTmpPath('/var/folders/qw/abc123/T/release-test-AbCdEf/remote.git')).toBe(
-      '<tmp>/remote.git',
+      `${TMP_TOKEN}/remote.git`,
     )
   })
 })
 
 describe('normalizeTmpPath - macOS /private/tmp', () => {
   test('replaces /private/tmp/<dir> with <tmp>', () => {
-    expect(normalizeTmpPath('/private/tmp/test/x.txt')).toBe('<tmp>/x.txt')
+    expect(normalizeTmpPath('/private/tmp/test/x.txt')).toBe(`${TMP_TOKEN}/x.txt`)
   })
 })
 
 describe('normalizeTmpPath - Windows', () => {
   test('replaces C:\\Users\\<u>\\AppData\\Local\\Temp\\<dir> with <tmp>', () => {
     expect(normalizeTmpPath('C:\\Users\\steve\\AppData\\Local\\Temp\\foo-AbC\\bar\\baz.txt')).toBe(
-      '<tmp>\\bar\\baz.txt',
+      `${TMP_TOKEN}\\bar\\baz.txt`,
     )
   })
 })
 
 describe('normalizeTmpPath - embedded substring', () => {
   test('replaces tmp prefix appearing inside an arg', () => {
-    expect(normalizeTmpPath('--config=/tmp/abc/x.json')).toBe('--config=<tmp>/x.json')
+    expect(normalizeTmpPath('--config=/tmp/abc/x.json')).toBe(`--config=${TMP_TOKEN}/x.json`)
   })
 })
 

--- a/tests/unit/normalize.test.ts
+++ b/tests/unit/normalize.test.ts
@@ -94,8 +94,13 @@ describe('normalizeTmpPath - idempotence', () => {
   })
 })
 
+// basenameCommand uses path.basename, which is platform-aware: on POSIX it only
+// recognizes forward slashes; on Windows it recognizes both. Tests that pass
+// backslash paths must be guarded with skipIf on non-Windows.
+const isWindows = process.platform === 'win32'
+
 describe('basenameCommand', () => {
-  test('absolute path returns basename', () => {
+  test('absolute POSIX path returns basename', () => {
     expect(basenameCommand('/usr/bin/git')).toBe('git')
   })
 
@@ -103,16 +108,12 @@ describe('basenameCommand', () => {
     expect(basenameCommand('git')).toBe('git')
   })
 
-  test('Windows-style path returns basename', () => {
+  test.skipIf(!isWindows)('Windows-style path returns basename', () => {
     expect(basenameCommand('C:\\Program Files\\Git\\bin\\git.exe')).toMatch(/^git(\.exe)?$/)
   })
 })
 
 describe('basenameCommand - Windows .exe strip', () => {
-  // These behavior tests assume process.platform === 'win32'.
-  // Skipped on non-Windows runners but documented for cross-platform clarity.
-  const isWindows = process.platform === 'win32'
-
   test.skipIf(!isWindows)('strips lowercase .exe on Windows', () => {
     expect(basenameCommand('git.exe')).toBe('git')
   })

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -9,15 +9,10 @@ import {
   withCassette,
 } from '../../src/state.js'
 import type { CassetteSession } from '../../src/types.js'
+import { makeSession } from '../helpers/session.js'
 
-const sessionAt = (path: string): CassetteSession => ({
-  name: `s-${path}`,
-  path,
-  scopeDefault: 'auto',
-  loadedFile: null,
-  matcher: null,
-  newRecordings: [],
-})
+const sessionAt = (path: string): CassetteSession =>
+  makeSession({ name: `s-${path}`, path, loadedFile: null, matcher: null })
 
 afterEach(() => {
   clearActiveCassette()

--- a/tests/unit/use-cassette.test.ts
+++ b/tests/unit/use-cassette.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import type { Canonicalize } from '../../src/types.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+describe('useCassette - argcount dispatch', () => {
+  let tmp: string
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test('2-arg form: useCassette(path, fn) works (no options)', async () => {
+    let called = false
+    await useCassette(path.join(tmp, 'a.json'), async () => {
+      called = true
+    })
+    expect(called).toBe(true)
+  })
+
+  test('3-arg form: useCassette(path, options, fn) works (with options)', async () => {
+    let called = false
+    const customCanonicalize: Canonicalize = (call) => ({ command: call.command })
+    await useCassette(path.join(tmp, 'b.json'), { canonicalize: customCanonicalize }, async () => {
+      called = true
+    })
+    expect(called).toBe(true)
+  })
+
+  test('3-arg form with empty options object', async () => {
+    let called = false
+    await useCassette(path.join(tmp, 'c.json'), {}, async () => {
+      called = true
+    })
+    expect(called).toBe(true)
+  })
+})


### PR DESCRIPTION
## What Changed

Breaking change. The `MatcherFn` type and the `(call, recording) => boolean` shape are removed. Replaced by `Canonicalize: (call) => Partial<Call>` with implicit deep-equal of canonical forms. v0.2 cassettes load and replay correctly under the new code (strictly more permissive matching: anything that matched before still matches; tests that bounced on mkdtemp variance now succeed).

- `src/normalize.ts` (NEW): `normalizeTmpPath` (per-OS regex table for absolute mkdtemp prefixes) + `basenameCommand` (cross-platform basename with Windows `.exe` strip).
- `src/matcher.ts` (MOD): `defaultCanonicalize` replaces `defaultMatcher`. `MatcherState` refactored to operate on `Canonicalize`, caches canonical forms at construction. Hand-rolled `canonicalEqual` over the known `Partial<Call>` field set.
- `src/types.ts` (MOD): adds `Canonicalize`, `UseCassetteOptions`; removes `MatcherFn`; adds `canonicalize` field to `CassetteSession`.
- `src/config.ts` (MOD): `Config.matcher` renamed to `Config.canonicalize`. Validation updated.
- `src/use-cassette.ts` (MOD): argcount dispatch via TS overloads. `useCassette(path, fn)` and `useCassette(path, options, fn)` both work; options carries optional `canonicalize` for per-call override.
- `src/wrapper.ts` (MOD): `MatcherState` constructed from `session.canonicalize` instead of `config.matcher`. `ReplayMissError` now shows canonical forms of the unmatched call and recordings.
- `src/vitest.ts` (MOD): plugin populates `session.canonicalize` from `config.canonicalize`.
- `src/index.ts` (MOD): adds `Canonicalize`, `defaultCanonicalize`, `normalizeTmpPath`, `basenameCommand`, `UseCassetteOptions` exports; removes `MatcherFn`.
- `package.json`: adds `fast-check` as devDep (used by property tests).

## Default canonicalize behavior

`defaultCanonicalize(call)` returns `{ command, args }` only. `cwd`, `env`, `stdin` are excluded so cassettes are portable across machines and runs. Args go through `normalizeTmpPath`, which replaces absolute mkdtemp-style prefixes (`/tmp/<dir>`, `/var/tmp/<dir>`, `/var/folders/X/Y/T/<dir>`, `/private/tmp/<dir>`, `C:\Users\<u>\AppData\Local\Temp\<dir>`) plus exactly one path component with `<tmp>`. The path beyond the first component is preserved so basenames still differentiate (`/tmp/abc/file-a.txt` and `/tmp/abc/file-b.txt` produce different canonical forms).

Order of regex patterns matters: more-specific prefixes (`/var/tmp`, `/private/tmp`, `/var/folders`) run before the plain `/tmp` pattern so they are not partially consumed.

## Test Plan

- [x] `npm test` (224 passed, 1 skipped, 0 failed)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build` + spot-check `dist/index.d.ts` includes new exports and excludes `MatcherFn`