### PR TITLE
test: property + integration + e2e + error-path tests for canonicalize matcher

### DIFF
--- a/tests/e2e/tmp-path-record-replay.test.ts
+++ b/tests/e2e/tmp-path-record-replay.test.ts
@@ -7,6 +7,9 @@ import { useCassette } from '../../src/use-cassette.js'
 
 describe('e2e: tmp path record-replay across mkdtemp variance', () => {
   let workspace: string
+  const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+  const originalMode = process.env.SHELL_CASSETTE_MODE
+  const originalCI = process.env.CI
 
   beforeEach(async () => {
     workspace = await mkdtemp(path.join(tmpdir(), 'shell-cassette-e2e-'))
@@ -17,44 +20,56 @@ describe('e2e: tmp path record-replay across mkdtemp variance', () => {
 
   afterEach(async () => {
     await rm(workspace, { recursive: true, force: true })
-    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+    restoreEnv('CI', originalCI)
   })
+
+  function restoreEnv(key: string, original: string | undefined): void {
+    if (original === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = original
+    }
+  }
 
   test('cassette recorded with one mkdtemp path replays under a different mkdtemp path', async () => {
     const cassettePath = path.join(workspace, 'cassette.json')
 
+    // Nested try/finally so tmpA is cleaned even if mkdtemp(tmpB) throws.
     const tmpA = await mkdtemp(path.join(tmpdir(), 'shell-cassette-tmp-a-'))
-    const tmpB = await mkdtemp(path.join(tmpdir(), 'shell-cassette-tmp-b-'))
-    expect(tmpA).not.toBe(tmpB) // sanity: mkdtemp gives different paths
-
     try {
-      // First run: record. Pass tmp path as argv (NOT embedded in the -e source)
-      // so node doesn't interpret backslash sequences as JS escapes on Windows.
-      await useCassette(cassettePath, async () => {
-        await execa('node', ['-e', 'console.log("recorded:" + process.argv[1])', tmpA])
-      })
+      const tmpB = await mkdtemp(path.join(tmpdir(), 'shell-cassette-tmp-b-'))
+      try {
+        // First run: record. Pass tmp path as argv (NOT embedded in the -e source)
+        // so node doesn't interpret backslash sequences as JS escapes on Windows.
+        await useCassette(cassettePath, async () => {
+          await execa('node', ['-e', 'console.log("recorded:" + process.argv[1])', tmpA])
+        })
 
-      // Sanity: cassette was created and is non-empty.
-      const stored = await readFile(cassettePath, 'utf8')
-      expect(stored.length).toBeGreaterThan(0)
+        // Sanity: cassette was created and is non-empty.
+        const stored = await readFile(cassettePath, 'utf8')
+        expect(stored.length).toBeGreaterThan(0)
 
-      // Second run: different mkdtemp dir; canonicalize must match the prior recording.
-      // The synthesized stdout MUST be from the recording (which captured tmpA's
-      // path in its stdout), NOT a fresh execution (which would emit tmpB).
-      // Asserting `not.toContain(tmpB)` proves we got the recording: live execution
-      // would always include the new tmpB path that the script just printed.
-      await useCassette(cassettePath, async () => {
-        const r = await execa('node', ['-e', 'console.log("recorded:" + process.argv[1])', tmpB])
-        expect(r.stdout).toContain('recorded:')
-        expect(r.stdout).not.toContain(tmpB)
-      })
+        // Second run: different mkdtemp dir; canonicalize must match the prior recording.
+        // The synthesized stdout MUST be from the recording (which captured tmpA's
+        // path in its stdout), NOT a fresh execution (which would emit tmpB).
+        // Asserting `not.toContain(tmpB)` proves we got the recording: live execution
+        // would always include the new tmpB path that the script just printed.
+        await useCassette(cassettePath, async () => {
+          const r = await execa('node', ['-e', 'console.log("recorded:" + process.argv[1])', tmpB])
+          expect(r.stdout).toContain('recorded:')
+          expect(r.stdout).not.toContain(tmpB)
+        })
 
-      // No new recording should have been added; cassette content is unchanged.
-      const after = await readFile(cassettePath, 'utf8')
-      expect(after).toBe(stored)
+        // No new recording should have been added; cassette content is unchanged.
+        const after = await readFile(cassettePath, 'utf8')
+        expect(after).toBe(stored)
+      } finally {
+        await rm(tmpB, { recursive: true, force: true })
+      }
     } finally {
       await rm(tmpA, { recursive: true, force: true })
-      await rm(tmpB, { recursive: true, force: true })
     }
   })
 })

--- a/tests/e2e/tmp-path-record-replay.test.ts
+++ b/tests/e2e/tmp-path-record-replay.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+describe('e2e: tmp path record-replay across mkdtemp variance', () => {
+  let workspace: string
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(tmpdir(), 'shell-cassette-e2e-'))
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.CI
+  })
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true })
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+  })
+
+  test('cassette recorded with one mkdtemp path replays under a different mkdtemp path', async () => {
+    const cassettePath = path.join(workspace, 'cassette.json')
+
+    const tmpA = await mkdtemp(path.join(tmpdir(), 'shell-cassette-tmp-a-'))
+    const tmpB = await mkdtemp(path.join(tmpdir(), 'shell-cassette-tmp-b-'))
+    expect(tmpA).not.toBe(tmpB) // sanity: mkdtemp gives different paths
+
+    try {
+      // First run: record. Pass tmp path as argv (NOT embedded in the -e source)
+      // so node doesn't interpret backslash sequences as JS escapes on Windows.
+      await useCassette(cassettePath, async () => {
+        await execa('node', ['-e', 'console.log("recorded:" + process.argv[1])', tmpA])
+      })
+
+      // Sanity: cassette was created and is non-empty.
+      const stored = await readFile(cassettePath, 'utf8')
+      expect(stored.length).toBeGreaterThan(0)
+
+      // Second run: different mkdtemp dir; canonicalize must match the prior recording.
+      // The synthesized stdout MUST be from the recording (which captured tmpA's
+      // path in its stdout), NOT a fresh execution (which would emit tmpB).
+      // Asserting `not.toContain(tmpB)` proves we got the recording: live execution
+      // would always include the new tmpB path that the script just printed.
+      await useCassette(cassettePath, async () => {
+        const r = await execa('node', ['-e', 'console.log("recorded:" + process.argv[1])', tmpB])
+        expect(r.stdout).toContain('recorded:')
+        expect(r.stdout).not.toContain(tmpB)
+      })
+
+      // No new recording should have been added; cassette content is unchanged.
+      const after = await readFile(cassettePath, 'utf8')
+      expect(after).toBe(stored)
+    } finally {
+      await rm(tmpA, { recursive: true, force: true })
+      await rm(tmpB, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/error-path/canonicalize-limits.test.ts
+++ b/tests/error-path/canonicalize-limits.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { ReplayMissError } from '../../src/errors.js'
+import { execa } from '../../src/execa.js'
+import { writeCassetteFile } from '../../src/io.js'
+import { serialize } from '../../src/serialize.js'
+import type { CassetteFile } from '../../src/types.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+// Build a cassette with a single recording whose call.command is `node` and
+// one positional arg. The args field drives the matcher comparison.
+function makeCassette(args: string[]): CassetteFile {
+  return {
+    version: 1,
+    recordings: [
+      {
+        call: {
+          command: 'node',
+          args,
+          cwd: null,
+          env: {},
+          stdin: null,
+        },
+        result: {
+          stdoutLines: ['recorded', ''],
+          stderrLines: [''],
+          allLines: null,
+          exitCode: 0,
+          signal: null,
+          durationMs: 1,
+          aborted: false,
+        },
+      },
+    ],
+  }
+}
+
+describe('canonicalize limitations - documented current behavior', () => {
+  let workspace: string
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(path.join(tmpdir(), 'shell-cassette-limits-'))
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    process.env.SHELL_CASSETTE_MODE = 'replay' // strict replay so misses throw
+    delete process.env.CI
+  })
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true })
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.SHELL_CASSETTE_MODE
+  })
+
+  test('relative tmp path (path.relative-style) does NOT normalize - documented limitation', async () => {
+    // Recording was canonicalized as if it had been '<tmp>/foo' (a normalized
+    // absolute path). Replay attempts a RELATIVE path that doesn't match any
+    // tmp prefix regex, so canonicalize leaves it unchanged. Match fails.
+    const cassettePath = path.join(workspace, 'rel.json')
+    await writeCassetteFile(cassettePath, serialize(makeCassette(['-e', '<tmp>/foo'])))
+
+    let caught: unknown
+    try {
+      await useCassette(cassettePath, async () => {
+        await execa('node', ['-e', '../../tmp/foo'])
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ReplayMissError)
+    // Error message includes 'canonical' so users see what was compared.
+    expect((caught as Error).message).toContain('canonical')
+  })
+
+  test('custom $TMPDIR outside our regex table does NOT normalize - documented limitation', async () => {
+    // Recording has a /scratch/... path. The default regex table covers
+    // /tmp, /var/tmp, /var/folders/X/Y/T, /private/tmp, and Windows
+    // C:\\Users\\<u>\\AppData\\Local\\Temp. /scratch is NOT covered, so the
+    // recorded path is canonicalized as the literal string. A different
+    // /scratch/... path on replay does not match.
+    const cassettePath = path.join(workspace, 'scratch.json')
+    await writeCassetteFile(cassettePath, serialize(makeCassette(['-e', '/scratch/RECORDED/foo'])))
+
+    let caught: unknown
+    try {
+      await useCassette(cassettePath, async () => {
+        await execa('node', ['-e', '/scratch/REPLAY/foo'])
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ReplayMissError)
+  })
+})

--- a/tests/error-path/canonicalize-limits.test.ts
+++ b/tests/error-path/canonicalize-limits.test.ts
@@ -39,6 +39,9 @@ function makeCassette(args: string[]): CassetteFile {
 
 describe('canonicalize limitations - documented current behavior', () => {
   let workspace: string
+  const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+  const originalMode = process.env.SHELL_CASSETTE_MODE
+  const originalCI = process.env.CI
 
   beforeEach(async () => {
     workspace = await mkdtemp(path.join(tmpdir(), 'shell-cassette-limits-'))
@@ -49,9 +52,18 @@ describe('canonicalize limitations - documented current behavior', () => {
 
   afterEach(async () => {
     await rm(workspace, { recursive: true, force: true })
-    delete process.env.SHELL_CASSETTE_ACK_REDACTION
-    delete process.env.SHELL_CASSETTE_MODE
+    restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+    restoreEnv('CI', originalCI)
   })
+
+  function restoreEnv(key: string, original: string | undefined): void {
+    if (original === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = original
+    }
+  }
 
   test('relative tmp path (path.relative-style) does NOT normalize - documented limitation', async () => {
     // Recording was canonicalized as if it had been '<tmp>/foo' (a normalized
@@ -60,17 +72,12 @@ describe('canonicalize limitations - documented current behavior', () => {
     const cassettePath = path.join(workspace, 'rel.json')
     await writeCassetteFile(cassettePath, serialize(makeCassette(['-e', '<tmp>/foo'])))
 
-    let caught: unknown
-    try {
-      await useCassette(cassettePath, async () => {
-        await execa('node', ['-e', '../../tmp/foo'])
-      })
-    } catch (e) {
-      caught = e
-    }
-    expect(caught).toBeInstanceOf(ReplayMissError)
+    const result = useCassette(cassettePath, async () => {
+      await execa('node', ['-e', '../../tmp/foo'])
+    })
+    await expect(result).rejects.toBeInstanceOf(ReplayMissError)
     // Error message includes 'canonical' so users see what was compared.
-    expect((caught as Error).message).toContain('canonical')
+    await expect(result).rejects.toThrow(/canonical/)
   })
 
   test('custom $TMPDIR outside our regex table does NOT normalize - documented limitation', async () => {
@@ -82,14 +89,9 @@ describe('canonicalize limitations - documented current behavior', () => {
     const cassettePath = path.join(workspace, 'scratch.json')
     await writeCassetteFile(cassettePath, serialize(makeCassette(['-e', '/scratch/RECORDED/foo'])))
 
-    let caught: unknown
-    try {
-      await useCassette(cassettePath, async () => {
-        await execa('node', ['-e', '/scratch/REPLAY/foo'])
-      })
-    } catch (e) {
-      caught = e
-    }
-    expect(caught).toBeInstanceOf(ReplayMissError)
+    const result = useCassette(cassettePath, async () => {
+      await execa('node', ['-e', '/scratch/REPLAY/foo'])
+    })
+    await expect(result).rejects.toBeInstanceOf(ReplayMissError)
   })
 })

--- a/tests/integration/use-cassette-options.test.ts
+++ b/tests/integration/use-cassette-options.test.ts
@@ -8,6 +8,10 @@ import { useCassette } from '../../src/use-cassette.js'
 
 describe('useCassette per-call options - canonicalize override', () => {
   let tmp: string
+  const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+  const originalMode = process.env.SHELL_CASSETTE_MODE
+  const originalCI = process.env.CI
+
   beforeEach(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
     process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
@@ -16,8 +20,18 @@ describe('useCassette per-call options - canonicalize override', () => {
   })
   afterEach(async () => {
     await rm(tmp, { recursive: true, force: true })
-    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+    restoreEnv('CI', originalCI)
   })
+
+  function restoreEnv(key: string, original: string | undefined): void {
+    if (original === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = original
+    }
+  }
 
   test('default canonicalize matches recordings with same command + args', async () => {
     const cassettePath = path.join(tmp, 'default.json')

--- a/tests/integration/use-cassette-options.test.ts
+++ b/tests/integration/use-cassette-options.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import type { Canonicalize } from '../../src/types.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+describe('useCassette per-call options - canonicalize override', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.CI
+  })
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true })
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+  })
+
+  test('default canonicalize matches recordings with same command + args', async () => {
+    const cassettePath = path.join(tmp, 'default.json')
+    // First pass: record
+    await useCassette(cassettePath, async () => {
+      await execa('node', ['-e', 'console.log("a")'])
+    })
+    // Second pass: replay (must match)
+    await useCassette(cassettePath, async () => {
+      const r = await execa('node', ['-e', 'console.log("a")'])
+      expect(r.stdout).toBe('a')
+    })
+  })
+
+  test('custom canonicalize: command-only matches across different args', async () => {
+    const cassettePath = path.join(tmp, 'custom.json')
+    const commandOnly: Canonicalize = (call) => ({ command: call.command })
+    // Record one call
+    await useCassette(cassettePath, { canonicalize: commandOnly }, async () => {
+      await execa('node', ['-e', 'console.log("first")'])
+    })
+    // Replay with completely different args; matches because canonicalize ignores args
+    await useCassette(cassettePath, { canonicalize: commandOnly }, async () => {
+      const r = await execa('node', ['-e', 'console.log("second")'])
+      // Synthesized output is from the recording, not the live call
+      expect(r.stdout).toBe('first')
+    })
+  })
+
+  test('cassette file content is identical between 2-arg and 3-arg useCassette forms', async () => {
+    const a = path.join(tmp, 'two-arg.json')
+    const b = path.join(tmp, 'three-arg.json')
+    await useCassette(a, async () => {
+      await execa('node', ['-e', 'console.log("x")'])
+    })
+    await useCassette(b, {}, async () => {
+      await execa('node', ['-e', 'console.log("x")'])
+    })
+    const aContent = await readFile(a, 'utf8')
+    const bContent = await readFile(b, 'utf8')
+    // durationMs varies between real calls, so compare structure excluding timing
+    const stripTiming = (raw: string) => {
+      const parsed = JSON.parse(raw) as { recordings: { result: { durationMs?: number } }[] }
+      for (const rec of parsed.recordings) {
+        delete rec.result.durationMs
+      }
+      return parsed
+    }
+    expect(stripTiming(aContent)).toEqual(stripTiming(bContent))
+  })
+})

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -1,0 +1,124 @@
+import * as fc from 'fast-check'
+import { describe, expect, test } from 'vitest'
+import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
+import { normalizeTmpPath } from '../../src/normalize.js'
+import type { Call, Recording } from '../../src/types.js'
+
+// Reuse generators (deliberate inline duplication — rule of three; two
+// property test files don't justify a shared helpers module yet)
+const genArg = fc.string({ minLength: 0, maxLength: 50 }).filter((s) => !s.includes('\n'))
+const genArgs = fc.array(genArg, { minLength: 0, maxLength: 5 })
+const genCommand = fc
+  .string({ minLength: 1, maxLength: 30 })
+  .filter((s) => !s.includes('\n') && s.trim().length > 0)
+
+const genCall: fc.Arbitrary<Call> = fc.record({
+  command: genCommand,
+  args: genArgs,
+  cwd: fc.option(
+    fc.string({ maxLength: 30 }).filter((s) => !s.includes('\n')),
+    { nil: null },
+  ),
+  env: fc.dictionary(
+    fc.string({ minLength: 1, maxLength: 10 }).filter((s) => /^[A-Z_]+$/.test(s)),
+    fc.string({ maxLength: 30 }).filter((s) => !s.includes('\n')),
+    { maxKeys: 3 },
+  ),
+  stdin: fc.constant(null),
+})
+
+const dummyResult = {
+  stdoutLines: [''],
+  stderrLines: [''],
+  allLines: null,
+  exitCode: 0,
+  signal: null,
+  durationMs: 0,
+  aborted: false,
+}
+
+const recOf = (call: Call): Recording => ({ call, result: dummyResult })
+
+describe('normalizeTmpPath properties', () => {
+  test('idempotence: normalizeTmpPath(normalizeTmpPath(s)) === normalizeTmpPath(s)', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        const once = normalizeTmpPath(s)
+        const twice = normalizeTmpPath(once)
+        expect(twice).toBe(once)
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  test('non-tmp strings are unchanged', () => {
+    // Generate strings that don't contain any tmp prefix substring
+    const genNonTmp = fc
+      .string()
+      .filter(
+        (s) =>
+          !s.includes('/tmp/') &&
+          !s.includes('/var/tmp/') &&
+          !s.includes('/var/folders/') &&
+          !s.includes('/private/tmp/') &&
+          !/[A-Z]:\\Users\\[^\\]*\\AppData\\Local\\Temp\\/.test(s),
+      )
+    fc.assert(
+      fc.property(genNonTmp, (s) => {
+        expect(normalizeTmpPath(s)).toBe(s)
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('defaultCanonicalize properties', () => {
+  test('determinism: same input produces same output', () => {
+    fc.assert(
+      fc.property(genCall, (call) => {
+        expect(defaultCanonicalize(call)).toEqual(defaultCanonicalize(call))
+      }),
+      { numRuns: 100 },
+    )
+  })
+
+  test('omits cwd, env, stdin from canonical form', () => {
+    fc.assert(
+      fc.property(genCall, (call) => {
+        const c = defaultCanonicalize(call)
+        expect(c.cwd).toBeUndefined()
+        expect(c.env).toBeUndefined()
+        expect(c.stdin).toBeUndefined()
+      }),
+      { numRuns: 100 },
+    )
+  })
+})
+
+describe('MatcherState properties', () => {
+  test('equal canonical forms imply match succeeds', () => {
+    // Take a recording made from a call; the same call must match it
+    fc.assert(
+      fc.property(genCall, (call) => {
+        const state = new MatcherState([recOf(call)], defaultCanonicalize)
+        const matched = state.findMatch(call)
+        expect(matched).not.toBeNull()
+      }),
+      { numRuns: 100 },
+    )
+  })
+
+  test('sequential consumption: N copies match N times then exhaust', () => {
+    fc.assert(
+      fc.property(genCall, fc.integer({ min: 1, max: 8 }), (call, n) => {
+        const recordings = Array.from({ length: n }, () => recOf(call))
+        const state = new MatcherState(recordings, defaultCanonicalize)
+        for (let i = 0; i < n; i++) {
+          expect(state.findMatch(call)).not.toBeNull()
+        }
+        expect(state.findMatch(call)).toBeNull()
+      }),
+      { numRuns: 50 },
+    )
+  })
+})

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -1,7 +1,7 @@
 import * as fc from 'fast-check'
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
-import { normalizeTmpPath } from '../../src/normalize.js'
+import { normalizeTmpPath, TMP_TOKEN } from '../../src/normalize.js'
 import type { Call, Recording, Result } from '../../src/types.js'
 
 // Reuse generators (deliberate inline duplication — rule of three; two
@@ -52,11 +52,17 @@ describe('normalizeTmpPath properties', () => {
   })
 
   test('non-tmp strings are unchanged', () => {
-    // Generate strings that don't contain any tmp prefix substring
+    // Generate strings that contain neither a tmp prefix substring nor the
+    // already-normalized TMP_TOKEN. Filtering on TMP_TOKEN prevents this test
+    // from accidentally generating "<tmp>/x" which the matcher would treat as
+    // already-canonical (passing the assertion for the wrong reason). The
+    // explicit prefix list mirrors normalize.ts's TMP_PREFIX_PATTERNS; if a
+    // new platform pattern is added there, add it here too.
     const genNonTmp = fc
       .string()
       .filter(
         (s) =>
+          !s.includes(TMP_TOKEN) &&
           !s.includes('/tmp/') &&
           !s.includes('/var/tmp/') &&
           !s.includes('/var/folders/') &&

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -1,8 +1,8 @@
 import * as fc from 'fast-check'
-import { describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
 import { normalizeTmpPath } from '../../src/normalize.js'
-import type { Call, Recording } from '../../src/types.js'
+import type { Call, Recording, Result } from '../../src/types.js'
 
 // Reuse generators (deliberate inline duplication — rule of three; two
 // property test files don't justify a shared helpers module yet)
@@ -27,7 +27,7 @@ const genCall: fc.Arbitrary<Call> = fc.record({
   stdin: fc.constant(null),
 })
 
-const dummyResult = {
+const dummyResult: Result = {
   stdoutLines: [''],
   stderrLines: [''],
   allLines: null,
@@ -95,15 +95,39 @@ describe('defaultCanonicalize properties', () => {
   })
 })
 
+// Suppress the matcher's "ambiguous match" warnings in this describe block.
+// The sequential-consumption test deliberately creates N identical recordings,
+// which fires the warning every time there are 2+ unconsumed candidates.
+// That's correct behavior under test, but ~150 lines of stderr noise per run.
 describe('MatcherState properties', () => {
-  test('equal canonical forms imply match succeeds', () => {
-    // Take a recording made from a call; the same call must match it
+  const originalLog = process.env.SHELL_CASSETTE_LOG
+  beforeAll(() => {
+    process.env.SHELL_CASSETTE_LOG = 'silent'
+  })
+  afterAll(() => {
+    if (originalLog === undefined) {
+      delete process.env.SHELL_CASSETTE_LOG
+    } else {
+      process.env.SHELL_CASSETTE_LOG = originalLog
+    }
+  })
+
+  test('equal canonical forms imply match succeeds (calls differ in non-canonical fields)', () => {
+    // Build call A and call B that differ in cwd/env (NOT in the canonical form
+    // since defaultCanonicalize omits both), and verify B matches a recording of A.
+    // This actually tests the canonicalization-driven matching contract, vs. the
+    // weaker "single recording matches its own call" tautology.
     fc.assert(
-      fc.property(genCall, (call) => {
-        const state = new MatcherState([recOf(call)], defaultCanonicalize)
-        const matched = state.findMatch(call)
-        expect(matched).not.toBeNull()
-      }),
+      fc.property(
+        genCall,
+        fc.string({ maxLength: 30 }).filter((s) => !s.includes('\n')),
+        (callA, otherCwd) => {
+          const callB: Call = { ...callA, cwd: otherCwd, env: { OTHER: 'value' } }
+          const state = new MatcherState([recOf(callA)], defaultCanonicalize)
+          const matched = state.findMatch(callB)
+          expect(matched).not.toBeNull()
+        },
+      ),
       { numRuns: 100 },
     )
   })

--- a/tests/property/serialize.property.test.ts
+++ b/tests/property/serialize.property.test.ts
@@ -1,0 +1,78 @@
+import * as fc from 'fast-check'
+import { describe, expect, test } from 'vitest'
+import { deserialize, serialize } from '../../src/serialize.js'
+import type { Call, CassetteFile, Recording, Result } from '../../src/types.js'
+
+// Generators
+const genArg = fc.string({ minLength: 0, maxLength: 50 }).filter((s) => !s.includes('\n'))
+const genArgs = fc.array(genArg, { minLength: 0, maxLength: 5 })
+const genCommand = fc
+  .string({ minLength: 1, maxLength: 30 })
+  .filter((s) => !s.includes('\n') && s.trim().length > 0)
+
+const genCall: fc.Arbitrary<Call> = fc.record({
+  command: genCommand,
+  args: genArgs,
+  cwd: fc.option(
+    fc.string({ minLength: 0, maxLength: 30 }).filter((s) => !s.includes('\n')),
+    {
+      nil: null,
+    },
+  ),
+  env: fc.dictionary(
+    fc.string({ minLength: 1, maxLength: 10 }).filter((s) => /^[A-Z_]+$/.test(s)),
+    fc.string({ minLength: 0, maxLength: 30 }).filter((s) => !s.includes('\n')),
+    { maxKeys: 3 },
+  ),
+  stdin: fc.constant(null),
+})
+
+const genResult: fc.Arbitrary<Result> = fc.record({
+  stdoutLines: fc.array(
+    fc.string({ maxLength: 50 }).filter((s) => !s.includes('\n')),
+    {
+      maxLength: 5,
+    },
+  ),
+  stderrLines: fc.array(
+    fc.string({ maxLength: 50 }).filter((s) => !s.includes('\n')),
+    {
+      maxLength: 5,
+    },
+  ),
+  allLines: fc.option(
+    fc.array(
+      fc.string({ maxLength: 50 }).filter((s) => !s.includes('\n')),
+      { maxLength: 5 },
+    ),
+    { nil: null },
+  ),
+  exitCode: fc.integer({ min: 0, max: 255 }),
+  signal: fc.option(fc.constantFrom('SIGTERM', 'SIGKILL', 'SIGINT'), { nil: null }),
+  durationMs: fc.integer({ min: 0, max: 10000 }),
+  aborted: fc.boolean(),
+})
+
+const genRecording: fc.Arbitrary<Recording> = fc.record({
+  call: genCall,
+  result: genResult,
+})
+
+const genCassetteFile: fc.Arbitrary<CassetteFile> = fc.record({
+  version: fc.constant(1 as const),
+  recordings: fc.array(genRecording, { maxLength: 5 }),
+})
+
+describe('serialize round-trip property', () => {
+  test('serialize(deserialize(serialize(x))) === serialize(x)', () => {
+    fc.assert(
+      fc.property(genCassetteFile, (cf) => {
+        const s1 = serialize(cf)
+        const cf2 = deserialize(s1)
+        const s2 = serialize(cf2)
+        expect(s2).toBe(s1)
+      }),
+      { numRuns: 100 },
+    )
+  })
+})


### PR DESCRIPTION
## What Changed

5 new test files, 13 new tests, ~850 fast-check property invocations. All 237 tests pass; coverage thresholds met.

- `tests/property/serialize.property.test.ts`: fast-check round-trip property: `serialize(deserialize(serialize(cf))) === serialize(cf)` over generated CassetteFile shapes (100 runs). Catches the off-by-one toLines risk.
- `tests/property/canonicalize.property.test.ts`: 6 properties: normalizeTmpPath idempotence + non-tmp pass-through, defaultCanonicalize determinism + field omission, MatcherState equal-canonical to match symmetry, sequential consumption with N copies.
- `tests/integration/use-cassette-options.test.ts`: argcount dispatch (2-arg vs 3-arg useCassette), per-call canonicalize override, structural equality of cassette content between forms.
- `tests/e2e/tmp-path-record-replay.test.ts`: real node subprocess + real mkdtemp producing different paths each run. Default canonicalize must normalize tmp prefixes so the cassette recorded under tmpA replays correctly when called under tmpB. Cross-platform design (passes tmp path as argv arg, asserts `not.toContain(tmpB)` to prove synthesized vs live execution).
- `tests/error-path/canonicalize-limits.test.ts`: assert documented limitations: relative tmp paths via `path.relative` and custom `$TMPDIR` (e.g., `/scratch`) do NOT normalize. Locks in current behavior so future regex additions can't silently change semantics.

## Test Plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (237 passed, 1 skipped, 0 failed)
- [x] `npm run build`