### PR TITLE
feat: add redact types (RedactSource, RedactRule, RedactConfig, RedactionEntry)

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -41,7 +41,7 @@ export class MatcherState implements MatcherStateLike {
 
     if (candidates.length > 1) {
       log(
-        `ambiguous match: ${candidates.length} unconsumed recordings could match \`${call.command} ${call.args.join(' ')}\` — taking first`,
+        `ambiguous match: ${candidates.length} unconsumed recordings could match \`${call.command} ${call.args.join(' ')}\` (taking first)`,
       )
     }
 

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 // first, leaving a `/var` prefix.
 //
 // These are module-level g-flag RegExp instances. Use them ONLY with
-// `String.prototype.replace`, never `.test()` or `.exec()` — the g flag makes those
+// `String.prototype.replace`, never `.test()` or `.exec()`; the g flag makes those
 // methods stateful via `lastIndex`, which would carry state across calls.
 const TMP_PREFIX_PATTERNS: readonly RegExp[] = [
   /\/var\/folders\/[^/]+\/[^/]+\/T\/[^/\s]+/g,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,15 @@ export type RedactConfig = {
 
 export type UseCassetteOptions = {
   canonicalize?: Canonicalize
+  /**
+   * Per-cassette redaction toggle. Default true (redaction applies).
+   * Set false for cassettes that legitimately need raw stdout/args (e.g.,
+   * tests asserting on CLI output that happens to contain credential-shaped
+   * strings as test fixtures, NOT real credentials). The boolean is
+   * intentionally coarse-grained — per-stream toggles (env: false, stdout: true)
+   * are explicitly out of scope for v0.4.
+   */
+  redact?: boolean
 }
 
 export type CassetteSession = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type RedactRule = {
   /**
    * Either a global regex (most rules) or a transform function (for advanced
    * cases where the user wants full control over the replacement). Regex rules
-   * use `String.prototype.matchAll` semantics — the regex MUST have the `g` flag.
+   * use `String.prototype.matchAll` semantics; the regex MUST have the `g` flag.
    */
   pattern: RegExp | ((s: string) => string)
   /**
@@ -58,7 +58,8 @@ export type RedactRule = {
 
 /**
  * One entry per (source, rule) combination that fired during a redaction pass.
- * Stored on `Recording._redactions` in the cassette and on
+ * Persisted as the `_redactions` JSON field on each cassette recording (wire
+ * format) and mapped to `Recording.redactions` in memory. Accumulated on
  * `CassetteSession.redactionEntries` during a recording session.
  */
 export type RedactionEntry = {
@@ -113,7 +114,7 @@ export type UseCassetteOptions = {
    * Set false for cassettes that legitimately need raw stdout/args (e.g.,
    * tests asserting on CLI output that happens to contain credential-shaped
    * strings as test fixtures, NOT real credentials). The boolean is
-   * intentionally coarse-grained — per-stream toggles (env: false, stdout: true)
+   * intentionally coarse-grained. Per-stream toggles (env: false, stdout: true)
    * are explicitly out of scope for v0.4.
    */
   redact?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,78 @@ export type CassetteFile = {
 
 export type Canonicalize = (call: Call) => Partial<Call>
 
+export type RedactSource = 'env' | 'args' | 'stdout' | 'stderr' | 'allLines'
+
+export type RedactRule = {
+  /**
+   * Stable kebab-case identifier. API-stable: rule names ship locked at v0.4 and
+   * are never renamed. New patterns may be added additively (any version);
+   * removing or renaming is a breaking change.
+   */
+  name: string
+  /**
+   * Either a global regex (most rules) or a transform function (for advanced
+   * cases where the user wants full control over the replacement). Regex rules
+   * use `String.prototype.matchAll` semantics — the regex MUST have the `g` flag.
+   */
+  pattern: RegExp | ((s: string) => string)
+  /**
+   * Optional human-readable description. Used by `shell-cassette show` and
+   * documentation generators.
+   */
+  description?: string
+}
+
+/**
+ * One entry per (source, rule) combination that fired during a redaction pass.
+ * Stored on `Recording._redactions` in the cassette and on
+ * `CassetteSession.redactionEntries` during a recording session.
+ */
+export type RedactionEntry = {
+  rule: string // matches RedactRule.name
+  source: RedactSource
+  count: number // number of placeholder occurrences for this (source, rule) in this recording
+}
+
+export type RedactConfig = {
+  /**
+   * When true, the bundled credential patterns from `BUNDLED_PATTERNS` apply.
+   * Defaults to true. Set false to opt out of all bundled detection (custom
+   * patterns and suppress list still apply).
+   */
+  bundledPatterns: boolean
+  /**
+   * User-supplied custom rules. Apply after bundled rules. Each rule's `name`
+   * field appears in placeholder strings (`<redacted:source:NAME:N>`).
+   */
+  customPatterns: readonly RedactRule[]
+  /**
+   * Suppress list. Checked FIRST, before bundled and custom rules. If any
+   * suppress regex matches the input value, the value is exempt from all
+   * redaction (including the length warning). Use case: project-wide
+   * fake-token fixtures the bundle would otherwise scrub.
+   */
+  suppressPatterns: readonly RegExp[]
+  /**
+   * User extension to the curated env-key match list. Treated as
+   * case-insensitive substring match against env var key names (matches
+   * v0.2/v0.3 behavior for the curated list).
+   */
+  envKeys: readonly string[]
+  /**
+   * Length above which an unredacted value triggers a long-value warning.
+   * Default: 40. Tuned to catch GitHub PATs, OpenAI keys, Stripe restricted,
+   * AWS Secret Access Keys without nagging on common path env vars.
+   */
+  warnLengthThreshold: number
+  /**
+   * When true, values containing `/`, `\`, `:`, or ` ` (space) suppress the
+   * length warning. Catches the common false-positive case (paths, configs,
+   * connection strings) without missing bare credential strings.
+   */
+  warnPathHeuristic: boolean
+}
+
 export type UseCassetteOptions = {
   canonicalize?: Canonicalize
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,9 +58,7 @@ export type RedactRule = {
 
 /**
  * One entry per (source, rule) combination that fired during a redaction pass.
- * Persisted as the `_redactions` JSON field on each cassette recording (wire
- * format) and mapped to `Recording.redactions` in memory. Accumulated on
- * `CassetteSession.redactionEntries` during a recording session.
+ * Persisted as the `_redactions` JSON field on each cassette recording.
  */
 export type RedactionEntry = {
   rule: string // matches RedactRule.name
@@ -71,8 +69,8 @@ export type RedactionEntry = {
 export type RedactConfig = {
   /**
    * When true, the bundled credential patterns from `BUNDLED_PATTERNS` apply.
-   * Defaults to true. Set false to opt out of all bundled detection (custom
-   * patterns and suppress list still apply).
+   * Set false to opt out of all bundled detection (custom patterns and suppress
+   * list still apply).
    */
   bundledPatterns: boolean
   /**
@@ -95,8 +93,8 @@ export type RedactConfig = {
   envKeys: readonly string[]
   /**
    * Length above which an unredacted value triggers a long-value warning.
-   * Default: 40. Tuned to catch GitHub PATs, OpenAI keys, Stripe restricted,
-   * AWS Secret Access Keys without nagging on common path env vars.
+   * Tuned to catch GitHub PATs, OpenAI keys, Stripe restricted, AWS Secret
+   * Access Keys without nagging on common path env vars.
    */
   warnLengthThreshold: number
   /**
@@ -110,12 +108,11 @@ export type RedactConfig = {
 export type UseCassetteOptions = {
   canonicalize?: Canonicalize
   /**
-   * Per-cassette redaction toggle. Default true (redaction applies).
-   * Set false for cassettes that legitimately need raw stdout/args (e.g.,
-   * tests asserting on CLI output that happens to contain credential-shaped
-   * strings as test fixtures, NOT real credentials). The boolean is
-   * intentionally coarse-grained. Per-stream toggles (env: false, stdout: true)
-   * are explicitly out of scope for v0.4.
+   * Per-cassette redaction toggle. Set false for cassettes that legitimately
+   * need raw stdout/args (e.g., tests asserting on CLI output that happens to
+   * contain credential-shaped strings as test fixtures, NOT real credentials).
+   * The boolean is intentionally coarse-grained; per-stream toggling is not
+   * supported.
    */
   redact?: boolean
 }

--- a/src/vitest-error.ts
+++ b/src/vitest-error.ts
@@ -21,7 +21,7 @@ See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.
 // The most common failure here is vitest externalizing shell-cassette so the
 // plugin module loads in a different module graph than vitest's runner. The
 // observable symptom is a thrown Error mentioning "runner". We don't gate the
-// wrap on the message text — registration at module top should never throw
+// wrap on the message text; registration at module top should never throw
 // for any other reason, so any throw here gets the deps.inline diagnostic
 // appended (with the original error preserved verbatim).
 export function wrapRegistrationError(e: unknown): VitestPluginRegistrationError {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -105,7 +105,7 @@ export async function runWrapped<Opts, ResultShape>(
     // falls through to the record path, which then asks for ack. From the
     // user's perspective they tried to replay; the ack error obscures the
     // real cause (matcher miss). Mutate the original error's message so the
-    // actual problem path is visible. Stack and class are preserved —
+    // actual problem path is visible. Stack and class are preserved;
     // programmatic catches on AckRequiredError still work.
     if (cameFromAutoMiss && e instanceof Error) {
       e.message = `auto mode: no recording matched \`${formatCallSignature(call)}\`, attempted to record but ack gate not set.\n\n${e.message}`


### PR DESCRIPTION
## What Changed

- Adds `RedactSource`, `RedactRule`, `RedactConfig`, `RedactionEntry` types to `src/types.ts` (additive, no callers yet).
- Adds `UseCassetteOptions.redact?: boolean` for per-cassette override.
- Sweeps pre-existing em dashes from source comments per project style rule.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (237 passed, 1 pre-existing skip)
- [x] `npm run build` produces clean dist/