### PR TITLE
feat(redact): add 25 bundled credential patterns

### DIFF
--- a/src/redact-patterns.ts
+++ b/src/redact-patterns.ts
@@ -86,6 +86,9 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
 
   // Anthropic
   // https://docs.anthropic.com/en/api/getting-started
+  // Note: Anthropic must precede OpenAI in this list. The OpenAI pattern's
+  // bare sk- prefix would otherwise match Anthropic keys (sk-ant-...) first
+  // and tag them as openai-api-key in placeholders.
   {
     name: 'anthropic-api-key',
     pattern: /sk-ant-(api03|sid01|admin01)-[A-Za-z0-9_-]{80,}/g,

--- a/src/redact-patterns.ts
+++ b/src/redact-patterns.ts
@@ -1,0 +1,195 @@
+import type { RedactRule } from './types.js'
+
+/**
+ * Bundled credential patterns shipped by shell-cassette as default-on detection.
+ *
+ * Reliability bar: every pattern in this file is anchored, character-class-locked,
+ * and length-bounded by the issuer's published documentation. Ambiguous shapes
+ * (AWS Secret Access Keys, JWTs, generic 32-hex tokens, Heroku/Datadog/Twilio
+ * tokens) are deliberately NOT in the bundle; the long-value warning and
+ * user-supplied custom rules cover those.
+ *
+ * Rule names are API-stable. Adding new rules is additive (safe). Renaming or
+ * removing existing rules is a breaking change requiring a major version bump
+ * (or a new shell-cassette major version line).
+ *
+ * Each rule's regex MUST have the `g` flag so `String.prototype.matchAll`
+ * finds every occurrence, not just the first. The pipeline uses
+ * `String.prototype.replace` with the global regex which iterates all matches.
+ */
+
+export const BUNDLED_PATTERNS: readonly RedactRule[] = [
+  // GitHub family
+  // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+  {
+    name: 'github-pat-classic',
+    pattern: /ghp_[A-Za-z0-9]{36}/g,
+    description: 'GitHub personal access token (classic)',
+  },
+  {
+    name: 'github-pat-fine-grained',
+    pattern: /github_pat_[A-Za-z0-9_]{82}/g,
+    description: 'GitHub fine-grained personal access token',
+  },
+  {
+    name: 'github-oauth',
+    pattern: /gho_[A-Za-z0-9]{36}/g,
+    description: 'GitHub OAuth access token',
+  },
+  {
+    name: 'github-user-to-server',
+    pattern: /ghu_[A-Za-z0-9]{36}/g,
+    description: 'GitHub user-to-server token',
+  },
+  {
+    name: 'github-server-to-server',
+    pattern: /ghs_[A-Za-z0-9]{36}/g,
+    description: 'GitHub server-to-server token',
+  },
+  {
+    name: 'github-refresh',
+    pattern: /ghr_[A-Za-z0-9]{36}/g,
+    description: 'GitHub refresh token',
+  },
+
+  // AWS Access Key ID family
+  // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
+  {
+    name: 'aws-access-key-id',
+    pattern: /(AKIA|ASIA|AROA|AIDA|AGPA|ANPA|ANVA|APKA|ABIA|ACCA)[A-Z0-9]{16}/g,
+    description: 'AWS Access Key ID (all documented prefix variants)',
+  },
+
+  // Stripe
+  // https://stripe.com/docs/keys
+  {
+    name: 'stripe-secret-live',
+    pattern: /sk_live_[A-Za-z0-9]{24,}/g,
+    description:
+      'Stripe live secret key. Also matches Clerk and other providers using the sk_live_ prefix shape; all such keys ARE secrets, so the redaction is correct even when the provider name is misleading.',
+  },
+  {
+    name: 'stripe-secret-test',
+    pattern: /sk_test_[A-Za-z0-9]{24,}/g,
+    description: 'Stripe test secret key (or any sk_test_ prefix variant)',
+  },
+  {
+    name: 'stripe-restricted-live',
+    pattern: /rk_live_[A-Za-z0-9]{24,}/g,
+    description: 'Stripe restricted live key',
+  },
+  {
+    name: 'stripe-restricted-test',
+    pattern: /rk_test_[A-Za-z0-9]{24,}/g,
+    description: 'Stripe restricted test key',
+  },
+
+  // OpenAI
+  // https://platform.openai.com/docs/api-reference/authentication
+  {
+    name: 'openai-api-key',
+    pattern: /sk-(proj-|svcacct-|admin-)?[A-Za-z0-9_-]{40,}/g,
+    description: 'OpenAI API key (sk-, sk-proj-, sk-svcacct-, sk-admin- variants)',
+  },
+
+  // Anthropic
+  // https://docs.anthropic.com/en/api/getting-started
+  {
+    name: 'anthropic-api-key',
+    pattern: /sk-ant-(api03|sid01|admin01)-[A-Za-z0-9_-]{80,}/g,
+    description: 'Anthropic API key (api03, sid01, admin01 variants)',
+  },
+
+  // Google API
+  // https://cloud.google.com/api-keys/docs/overview
+  {
+    name: 'google-api-key',
+    pattern: /AIza[A-Za-z0-9_-]{35}/g,
+    description: 'Google API key',
+  },
+
+  // Slack
+  // https://api.slack.com/authentication/token-types
+  {
+    name: 'slack-token',
+    pattern: /xox[baprso]-[A-Za-z0-9-]{10,}/g,
+    description: 'Slack token (bot, app, user, refresh, OAuth: xox[baprso]- prefix family)',
+  },
+  {
+    name: 'slack-webhook-url',
+    pattern: /https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/[A-Za-z0-9]+/g,
+    description: 'Slack incoming webhook URL (path-bearer credential)',
+  },
+
+  // GitLab
+  // https://docs.gitlab.com/ee/security/token_overview.html
+  {
+    name: 'gitlab-pat',
+    pattern: /glpat-[A-Za-z0-9_-]{20}/g,
+    description: 'GitLab personal access token',
+  },
+
+  // npm
+  // https://docs.npmjs.com/about-access-tokens
+  {
+    name: 'npm-token',
+    pattern: /npm_[A-Za-z0-9]{36}/g,
+    description: 'npm publish token',
+  },
+
+  // DigitalOcean
+  // https://docs.digitalocean.com/reference/api/create-personal-access-token/
+  {
+    name: 'digitalocean-pat',
+    pattern: /dop_v1_[A-Fa-f0-9]{64}/g,
+    description: 'DigitalOcean personal access token v1',
+  },
+
+  // SendGrid
+  // https://docs.sendgrid.com/api-reference/api-keys/create-api-keys
+  {
+    name: 'sendgrid-api-key',
+    pattern: /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g,
+    description: 'SendGrid API key',
+  },
+
+  // Mailgun
+  // https://documentation.mailgun.com/en/latest/api-intro.html#authentication
+  {
+    name: 'mailgun-api-key',
+    pattern: /key-[a-f0-9]{32}/g,
+    description: 'Mailgun API key',
+  },
+
+  // Hugging Face
+  // https://huggingface.co/docs/hub/security-tokens
+  {
+    name: 'huggingface-token',
+    pattern: /hf_[A-Za-z0-9]{34}/g,
+    description: 'Hugging Face access token',
+  },
+
+  // PyPI
+  // https://pypi.org/help/#apitoken
+  {
+    name: 'pypi-token',
+    pattern: /pypi-AgE[A-Za-z0-9_-]{50,}/g,
+    description: 'PyPI API token (pypi-AgE prefix is documented base64 header)',
+  },
+
+  // Discord
+  // https://discord.com/developers/docs/reference#authentication
+  {
+    name: 'discord-bot-token',
+    pattern: /[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}/g,
+    description: 'Discord bot token (M or N prefix, three-segment base64)',
+  },
+
+  // Square
+  // https://developer.squareup.com/docs/build-basics/access-tokens
+  {
+    name: 'square-production-token',
+    pattern: /EAAA[A-Za-z0-9_-]{60,}/g,
+    description: 'Square production access token',
+  },
+] as const

--- a/src/redact-patterns.ts
+++ b/src/redact-patterns.ts
@@ -84,20 +84,20 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
     description: 'Stripe restricted test key',
   },
 
-  // OpenAI
-  // https://platform.openai.com/docs/api-reference/authentication
-  {
-    name: 'openai-api-key',
-    pattern: /sk-(proj-|svcacct-|admin-)?[A-Za-z0-9_-]{40,}/g,
-    description: 'OpenAI API key (sk-, sk-proj-, sk-svcacct-, sk-admin- variants)',
-  },
-
   // Anthropic
   // https://docs.anthropic.com/en/api/getting-started
   {
     name: 'anthropic-api-key',
     pattern: /sk-ant-(api03|sid01|admin01)-[A-Za-z0-9_-]{80,}/g,
     description: 'Anthropic API key (api03, sid01, admin01 variants)',
+  },
+
+  // OpenAI
+  // https://platform.openai.com/docs/api-reference/authentication
+  {
+    name: 'openai-api-key',
+    pattern: /sk-(proj-|svcacct-|admin-)?[A-Za-z0-9_-]{40,}/g,
+    description: 'OpenAI API key (sk-, sk-proj-, sk-svcacct-, sk-admin- variants)',
   },
 
   // Google API

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,11 @@ export type RedactRule = {
    * Either a global regex (most rules) or a transform function (for advanced
    * cases where the user wants full control over the replacement). Regex rules
    * use `String.prototype.matchAll` semantics; the regex MUST have the `g` flag.
+   * Note: the `g` flag carries `lastIndex` state. Callers must use
+   * `String.prototype.replace` (stateless) or construct a fresh
+   * `new RegExp(re.source, re.flags)` copy before `.test()` or `.exec()`;
+   * direct `.test()` on the stored object will silently misfire on alternating
+   * calls.
    */
   pattern: RegExp | ((s: string) => string)
   /**

--- a/tests/unit/redact-patterns.test.ts
+++ b/tests/unit/redact-patterns.test.ts
@@ -50,6 +50,8 @@ describe('per-rule regression fixtures', () => {
     const sample = `github_pat_${'A'.repeat(82)}`
     expect(matches('github-pat-fine-grained', sample)).toBe(true)
     expect(matches('github-pat-fine-grained', 'github_pat_TOOSHORT')).toBe(false)
+    // off-by-one: 81 chars is one short
+    expect(matches('github-pat-fine-grained', `github_pat_${'A'.repeat(81)}`)).toBe(false)
   })
 
   test('github-oauth, user-to-server, server-to-server, refresh', () => {
@@ -87,6 +89,8 @@ describe('per-rule regression fixtures', () => {
     expect(matches('stripe-restricted-live', `rk_live_${'a'.repeat(24)}`)).toBe(true)
     expect(matches('stripe-restricted-test', `rk_test_${'a'.repeat(24)}`)).toBe(true)
     expect(matches('stripe-secret-live', 'sk_live_short')).toBe(false)
+    // off-by-one: 23 chars after prefix
+    expect(matches('stripe-secret-live', `sk_live_${'a'.repeat(23)}`)).toBe(false)
   })
 
   test('openai-api-key with all prefix variants', () => {
@@ -95,6 +99,8 @@ describe('per-rule regression fixtures', () => {
     expect(matches('openai-api-key', `sk-svcacct-${'a'.repeat(48)}`)).toBe(true)
     expect(matches('openai-api-key', `sk-admin-${'a'.repeat(48)}`)).toBe(true)
     expect(matches('openai-api-key', 'sk-short')).toBe(false)
+    // off-by-one: 39 chars after sk- prefix
+    expect(matches('openai-api-key', `sk-${'a'.repeat(39)}`)).toBe(false)
   })
 
   test('anthropic-api-key with all prefix variants', () => {
@@ -102,6 +108,8 @@ describe('per-rule regression fixtures', () => {
     expect(matches('anthropic-api-key', `sk-ant-sid01-${'a'.repeat(80)}`)).toBe(true)
     expect(matches('anthropic-api-key', `sk-ant-admin01-${'a'.repeat(80)}`)).toBe(true)
     expect(matches('anthropic-api-key', `sk-ant-other-${'a'.repeat(80)}`)).toBe(false)
+    // off-by-one: 79 chars after prefix
+    expect(matches('anthropic-api-key', `sk-ant-api03-${'a'.repeat(79)}`)).toBe(false)
   })
 
   test('google-api-key', () => {
@@ -115,6 +123,8 @@ describe('per-rule regression fixtures', () => {
       expect(matches('slack-token', `${p}-1234567890`)).toBe(true)
     }
     expect(matches('slack-token', 'xoxz-1234567890')).toBe(false)
+    // off-by-one: 9 chars after xoxb-
+    expect(matches('slack-token', `xoxb-${'a'.repeat(9)}`)).toBe(false)
   })
 
   test('slack-webhook-url', () => {
@@ -130,46 +140,60 @@ describe('per-rule regression fixtures', () => {
   test('gitlab-pat', () => {
     expect(matches('gitlab-pat', `glpat-${'a'.repeat(20)}`)).toBe(true)
     expect(matches('gitlab-pat', 'glpat-short')).toBe(false)
+    // off-by-one short
+    expect(matches('gitlab-pat', `glpat-${'a'.repeat(19)}`)).toBe(false)
   })
 
   test('npm-token', () => {
     expect(matches('npm-token', `npm_${'a'.repeat(36)}`)).toBe(true)
     expect(matches('npm-token', 'npm_short')).toBe(false)
+    expect(matches('npm-token', `npm_${'a'.repeat(35)}`)).toBe(false)
   })
 
   test('digitalocean-pat', () => {
     expect(matches('digitalocean-pat', `dop_v1_${'0'.repeat(64)}`)).toBe(true)
     expect(matches('digitalocean-pat', 'dop_v1_short')).toBe(false)
+    expect(matches('digitalocean-pat', `dop_v1_${'0'.repeat(63)}`)).toBe(false)
   })
 
   test('sendgrid-api-key', () => {
     expect(matches('sendgrid-api-key', `SG.${'a'.repeat(22)}.${'a'.repeat(43)}`)).toBe(true)
     expect(matches('sendgrid-api-key', 'SG.short.short')).toBe(false)
+    // off-by-one in first segment
+    expect(matches('sendgrid-api-key', `SG.${'a'.repeat(21)}.${'a'.repeat(43)}`)).toBe(false)
   })
 
   test('mailgun-api-key', () => {
     expect(matches('mailgun-api-key', `key-${'0'.repeat(32)}`)).toBe(true)
     expect(matches('mailgun-api-key', 'key-short')).toBe(false)
+    expect(matches('mailgun-api-key', `key-${'0'.repeat(31)}`)).toBe(false)
   })
 
   test('huggingface-token', () => {
     expect(matches('huggingface-token', `hf_${'a'.repeat(34)}`)).toBe(true)
     expect(matches('huggingface-token', 'hf_short')).toBe(false)
+    expect(matches('huggingface-token', `hf_${'a'.repeat(33)}`)).toBe(false)
   })
 
   test('pypi-token', () => {
     expect(matches('pypi-token', `pypi-AgE${'a'.repeat(50)}`)).toBe(true)
     expect(matches('pypi-token', 'pypi-other')).toBe(false)
+    expect(matches('pypi-token', `pypi-AgE${'a'.repeat(49)}`)).toBe(false)
   })
 
   test('discord-bot-token', () => {
     const sample = `M${'a'.repeat(23)}.${'a'.repeat(6)}.${'a'.repeat(27)}`
     expect(matches('discord-bot-token', sample)).toBe(true)
     expect(matches('discord-bot-token', 'M.short.short')).toBe(false)
+    // off-by-one in first segment
+    expect(
+      matches('discord-bot-token', `M${'a'.repeat(22)}.${'a'.repeat(6)}.${'a'.repeat(27)}`),
+    ).toBe(false)
   })
 
   test('square-production-token', () => {
     expect(matches('square-production-token', `EAAA${'a'.repeat(60)}`)).toBe(true)
     expect(matches('square-production-token', 'EAAA-short')).toBe(false)
+    expect(matches('square-production-token', `EAAA${'a'.repeat(59)}`)).toBe(false)
   })
 })

--- a/tests/unit/redact-patterns.test.ts
+++ b/tests/unit/redact-patterns.test.ts
@@ -20,9 +20,12 @@ describe('BUNDLED_PATTERNS', () => {
 
   test('all regex patterns have the global flag', () => {
     for (const rule of BUNDLED_PATTERNS) {
-      if (rule.pattern instanceof RegExp) {
-        expect(rule.pattern.flags).toContain('g')
+      if (!(rule.pattern instanceof RegExp)) {
+        throw new Error(
+          `bundled rule ${rule.name} has a function pattern; bundle currently expects RegExp only`,
+        )
       }
+      expect(rule.pattern.flags).toContain('g')
     }
   })
 })
@@ -55,12 +58,19 @@ describe('per-rule regression fixtures', () => {
   })
 
   test('github-oauth, user-to-server, server-to-server, refresh', () => {
-    expect(matches('github-oauth', 'gho_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
-    expect(matches('github-user-to-server', 'ghu_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
-    expect(matches('github-server-to-server', 'ghs_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(
+    expect(matches('github-oauth', `gho_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`)).toBe(true)
+    expect(matches('github-user-to-server', `ghu_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`)).toBe(
       true,
     )
-    expect(matches('github-refresh', 'ghr_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
+    expect(
+      matches('github-server-to-server', `ghs_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`),
+    ).toBe(true)
+    expect(matches('github-refresh', `ghr_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`)).toBe(true)
+    // off-by-one short for each (35 chars instead of 36)
+    expect(matches('github-oauth', `gho_${'a'.repeat(35)}`)).toBe(false)
+    expect(matches('github-user-to-server', `ghu_${'a'.repeat(35)}`)).toBe(false)
+    expect(matches('github-server-to-server', `ghs_${'a'.repeat(35)}`)).toBe(false)
+    expect(matches('github-refresh', `ghr_${'a'.repeat(35)}`)).toBe(false)
   })
 
   test('aws-access-key-id covers all 10 prefix variants', () => {
@@ -89,8 +99,11 @@ describe('per-rule regression fixtures', () => {
     expect(matches('stripe-restricted-live', `rk_live_${'a'.repeat(24)}`)).toBe(true)
     expect(matches('stripe-restricted-test', `rk_test_${'a'.repeat(24)}`)).toBe(true)
     expect(matches('stripe-secret-live', 'sk_live_short')).toBe(false)
-    // off-by-one: 23 chars after prefix
+    // off-by-one: 23 chars after prefix for each variant
     expect(matches('stripe-secret-live', `sk_live_${'a'.repeat(23)}`)).toBe(false)
+    expect(matches('stripe-secret-test', `sk_test_${'a'.repeat(23)}`)).toBe(false)
+    expect(matches('stripe-restricted-live', `rk_live_${'a'.repeat(23)}`)).toBe(false)
+    expect(matches('stripe-restricted-test', `rk_test_${'a'.repeat(23)}`)).toBe(false)
   })
 
   test('openai-api-key with all prefix variants', () => {

--- a/tests/unit/redact-patterns.test.ts
+++ b/tests/unit/redact-patterns.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'vitest'
+import { BUNDLED_PATTERNS } from '../../src/redact-patterns.js'
+
+describe('BUNDLED_PATTERNS', () => {
+  test('exports exactly 25 rules', () => {
+    expect(BUNDLED_PATTERNS.length).toBe(25)
+  })
+
+  test('all rule names are unique', () => {
+    const names = BUNDLED_PATTERNS.map((r) => r.name)
+    const unique = new Set(names)
+    expect(unique.size).toBe(names.length)
+  })
+
+  test('all rule names are kebab-case', () => {
+    for (const rule of BUNDLED_PATTERNS) {
+      expect(rule.name).toMatch(/^[a-z][a-z0-9-]*$/)
+    }
+  })
+
+  test('all regex patterns have the global flag', () => {
+    for (const rule of BUNDLED_PATTERNS) {
+      if (rule.pattern instanceof RegExp) {
+        expect(rule.pattern.flags).toContain('g')
+      }
+    }
+  })
+})
+
+describe('per-rule regression fixtures', () => {
+  function findRule(name: string) {
+    const rule = BUNDLED_PATTERNS.find((r) => r.name === name)
+    if (!rule) throw new Error(`rule not found: ${name}`)
+    if (!(rule.pattern instanceof RegExp)) throw new Error(`rule ${name} is not a RegExp`)
+    return rule.pattern
+  }
+
+  function matches(name: string, input: string): boolean {
+    const re = findRule(name)
+    return new RegExp(re.source, re.flags).test(input)
+  }
+
+  test('github-pat-classic', () => {
+    expect(matches('github-pat-classic', 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
+    expect(matches('github-pat-classic', 'ghp_TooShort')).toBe(false)
+    expect(matches('github-pat-classic', 'gha_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(false)
+  })
+
+  test('github-pat-fine-grained', () => {
+    const sample = `github_pat_${'A'.repeat(82)}`
+    expect(matches('github-pat-fine-grained', sample)).toBe(true)
+    expect(matches('github-pat-fine-grained', 'github_pat_TOOSHORT')).toBe(false)
+  })
+
+  test('github-oauth, user-to-server, server-to-server, refresh', () => {
+    expect(matches('github-oauth', 'gho_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
+    expect(matches('github-user-to-server', 'ghu_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
+    expect(matches('github-server-to-server', 'ghs_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(
+      true,
+    )
+    expect(matches('github-refresh', 'ghr_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
+  })
+
+  test('aws-access-key-id covers all 10 prefix variants', () => {
+    const prefixes = [
+      'AKIA',
+      'ASIA',
+      'AROA',
+      'AIDA',
+      'AGPA',
+      'ANPA',
+      'ANVA',
+      'APKA',
+      'ABIA',
+      'ACCA',
+    ]
+    for (const p of prefixes) {
+      expect(matches('aws-access-key-id', `${p}0123456789ABCDEF`)).toBe(true)
+    }
+    expect(matches('aws-access-key-id', 'akia0123456789ABCDEF')).toBe(false)
+    expect(matches('aws-access-key-id', 'AKIA0123')).toBe(false)
+  })
+
+  test('stripe-secret-live, stripe-secret-test, stripe-restricted-live, stripe-restricted-test', () => {
+    expect(matches('stripe-secret-live', `sk_live_${'a'.repeat(24)}`)).toBe(true)
+    expect(matches('stripe-secret-test', `sk_test_${'a'.repeat(24)}`)).toBe(true)
+    expect(matches('stripe-restricted-live', `rk_live_${'a'.repeat(24)}`)).toBe(true)
+    expect(matches('stripe-restricted-test', `rk_test_${'a'.repeat(24)}`)).toBe(true)
+    expect(matches('stripe-secret-live', 'sk_live_short')).toBe(false)
+  })
+
+  test('openai-api-key with all prefix variants', () => {
+    expect(matches('openai-api-key', `sk-${'a'.repeat(48)}`)).toBe(true)
+    expect(matches('openai-api-key', `sk-proj-${'a'.repeat(48)}`)).toBe(true)
+    expect(matches('openai-api-key', `sk-svcacct-${'a'.repeat(48)}`)).toBe(true)
+    expect(matches('openai-api-key', `sk-admin-${'a'.repeat(48)}`)).toBe(true)
+    expect(matches('openai-api-key', 'sk-short')).toBe(false)
+  })
+
+  test('anthropic-api-key with all prefix variants', () => {
+    expect(matches('anthropic-api-key', `sk-ant-api03-${'a'.repeat(80)}`)).toBe(true)
+    expect(matches('anthropic-api-key', `sk-ant-sid01-${'a'.repeat(80)}`)).toBe(true)
+    expect(matches('anthropic-api-key', `sk-ant-admin01-${'a'.repeat(80)}`)).toBe(true)
+    expect(matches('anthropic-api-key', `sk-ant-other-${'a'.repeat(80)}`)).toBe(false)
+  })
+
+  test('google-api-key', () => {
+    expect(matches('google-api-key', `AIza${'a'.repeat(35)}`)).toBe(true)
+    expect(matches('google-api-key', `AIza${'a'.repeat(34)}`)).toBe(false)
+    expect(matches('google-api-key', `AIzb${'a'.repeat(35)}`)).toBe(false)
+  })
+
+  test('slack-token covers all xox[baprso] prefixes', () => {
+    for (const p of ['xoxb', 'xoxa', 'xoxp', 'xoxr', 'xoxs', 'xoxo']) {
+      expect(matches('slack-token', `${p}-1234567890`)).toBe(true)
+    }
+    expect(matches('slack-token', 'xoxz-1234567890')).toBe(false)
+  })
+
+  test('slack-webhook-url', () => {
+    expect(
+      matches(
+        'slack-webhook-url',
+        'https://hooks.slack.com/services/T0AB12CDE/B0FG34HIJ/0123456789ABCDEF',
+      ),
+    ).toBe(true)
+    expect(matches('slack-webhook-url', 'https://hooks.slack.com/incomplete')).toBe(false)
+  })
+
+  test('gitlab-pat', () => {
+    expect(matches('gitlab-pat', `glpat-${'a'.repeat(20)}`)).toBe(true)
+    expect(matches('gitlab-pat', 'glpat-short')).toBe(false)
+  })
+
+  test('npm-token', () => {
+    expect(matches('npm-token', `npm_${'a'.repeat(36)}`)).toBe(true)
+    expect(matches('npm-token', 'npm_short')).toBe(false)
+  })
+
+  test('digitalocean-pat', () => {
+    expect(matches('digitalocean-pat', `dop_v1_${'0'.repeat(64)}`)).toBe(true)
+    expect(matches('digitalocean-pat', 'dop_v1_short')).toBe(false)
+  })
+
+  test('sendgrid-api-key', () => {
+    expect(matches('sendgrid-api-key', `SG.${'a'.repeat(22)}.${'a'.repeat(43)}`)).toBe(true)
+    expect(matches('sendgrid-api-key', 'SG.short.short')).toBe(false)
+  })
+
+  test('mailgun-api-key', () => {
+    expect(matches('mailgun-api-key', `key-${'0'.repeat(32)}`)).toBe(true)
+    expect(matches('mailgun-api-key', 'key-short')).toBe(false)
+  })
+
+  test('huggingface-token', () => {
+    expect(matches('huggingface-token', `hf_${'a'.repeat(34)}`)).toBe(true)
+    expect(matches('huggingface-token', 'hf_short')).toBe(false)
+  })
+
+  test('pypi-token', () => {
+    expect(matches('pypi-token', `pypi-AgE${'a'.repeat(50)}`)).toBe(true)
+    expect(matches('pypi-token', 'pypi-other')).toBe(false)
+  })
+
+  test('discord-bot-token', () => {
+    const sample = `M${'a'.repeat(23)}.${'a'.repeat(6)}.${'a'.repeat(27)}`
+    expect(matches('discord-bot-token', sample)).toBe(true)
+    expect(matches('discord-bot-token', 'M.short.short')).toBe(false)
+  })
+
+  test('square-production-token', () => {
+    expect(matches('square-production-token', `EAAA${'a'.repeat(60)}`)).toBe(true)
+    expect(matches('square-production-token', 'EAAA-short')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What Changed

- Adds `src/redact-patterns.ts` with 25 bundled credential patterns (GitHub family, AWS access key ID family, Stripe family, OpenAI, Anthropic, Google API, Slack, GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI, Discord, Square).
- Adds `tests/unit/redact-patterns.test.ts` with 23 tests: 4 structural invariants + 19 per-rule positive/negative/off-by-one fixtures.

## Notes

Every pattern is anchored, character-class-locked, and length-bounded by the issuer's published documentation. Ambiguous shapes (AWS Secret Access Keys, JWTs, generic 32-hex tokens) are deliberately excluded; they fall to the long-value warning and user-supplied custom rules.

`anthropic-api-key` is placed before `openai-api-key` so `sk-ant-*` keys tag correctly (the openai pattern's no-prefix branch would otherwise match Anthropic keys first).

Rule names are stable; renaming would be a breaking change. Adding new rules later is additive. Pattern URLs cited inline.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (260 passed, 1 pre-existing skip; +23 new tests vs main)
- [x] `npm run build` produces clean dist/