### PR TITLE
feat(redact): add redaction pipeline

### DIFF
--- a/src/redact-patterns.ts
+++ b/src/redact-patterns.ts
@@ -9,13 +9,11 @@ import type { RedactRule } from './types.js'
  * tokens) are deliberately NOT in the bundle; the long-value warning and
  * user-supplied custom rules cover those.
  *
- * Rule names are API-stable. Adding new rules is additive (safe). Renaming or
- * removing existing rules is a breaking change requiring a major version bump
- * (or a new shell-cassette major version line).
+ * Patterns are stored without the `g` flag so the underlying RegExp objects
+ * are stateless and safe to use directly with `.test()` or `.exec()`. The
+ * redaction pipeline adds the `g` flag internally when iterating matches.
  *
- * Each rule's regex MUST have the `g` flag so `String.prototype.matchAll`
- * finds every occurrence, not just the first. The pipeline uses
- * `String.prototype.replace` with the global regex which iterates all matches.
+ * See `RedactRule` in `./types.js` for the rule-name API stability contract.
  */
 
 export const BUNDLED_PATTERNS: readonly RedactRule[] = [
@@ -23,32 +21,32 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
   {
     name: 'github-pat-classic',
-    pattern: /ghp_[A-Za-z0-9]{36}/g,
+    pattern: /ghp_[A-Za-z0-9]{36}/,
     description: 'GitHub personal access token (classic)',
   },
   {
     name: 'github-pat-fine-grained',
-    pattern: /github_pat_[A-Za-z0-9_]{82}/g,
+    pattern: /github_pat_[A-Za-z0-9_]{82}/,
     description: 'GitHub fine-grained personal access token',
   },
   {
     name: 'github-oauth',
-    pattern: /gho_[A-Za-z0-9]{36}/g,
+    pattern: /gho_[A-Za-z0-9]{36}/,
     description: 'GitHub OAuth access token',
   },
   {
     name: 'github-user-to-server',
-    pattern: /ghu_[A-Za-z0-9]{36}/g,
+    pattern: /ghu_[A-Za-z0-9]{36}/,
     description: 'GitHub user-to-server token',
   },
   {
     name: 'github-server-to-server',
-    pattern: /ghs_[A-Za-z0-9]{36}/g,
+    pattern: /ghs_[A-Za-z0-9]{36}/,
     description: 'GitHub server-to-server token',
   },
   {
     name: 'github-refresh',
-    pattern: /ghr_[A-Za-z0-9]{36}/g,
+    pattern: /ghr_[A-Za-z0-9]{36}/,
     description: 'GitHub refresh token',
   },
 
@@ -56,7 +54,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
   {
     name: 'aws-access-key-id',
-    pattern: /(AKIA|ASIA|AROA|AIDA|AGPA|ANPA|ANVA|APKA|ABIA|ACCA)[A-Z0-9]{16}/g,
+    pattern: /(AKIA|ASIA|AROA|AIDA|AGPA|ANPA|ANVA|APKA|ABIA|ACCA)[A-Z0-9]{16}/,
     description: 'AWS Access Key ID (all documented prefix variants)',
   },
 
@@ -64,23 +62,23 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://stripe.com/docs/keys
   {
     name: 'stripe-secret-live',
-    pattern: /sk_live_[A-Za-z0-9]{24,}/g,
+    pattern: /sk_live_[A-Za-z0-9]{24,}/,
     description:
       'Stripe live secret key. Also matches Clerk and other providers using the sk_live_ prefix shape; all such keys ARE secrets, so the redaction is correct even when the provider name is misleading.',
   },
   {
     name: 'stripe-secret-test',
-    pattern: /sk_test_[A-Za-z0-9]{24,}/g,
+    pattern: /sk_test_[A-Za-z0-9]{24,}/,
     description: 'Stripe test secret key (or any sk_test_ prefix variant)',
   },
   {
     name: 'stripe-restricted-live',
-    pattern: /rk_live_[A-Za-z0-9]{24,}/g,
+    pattern: /rk_live_[A-Za-z0-9]{24,}/,
     description: 'Stripe restricted live key',
   },
   {
     name: 'stripe-restricted-test',
-    pattern: /rk_test_[A-Za-z0-9]{24,}/g,
+    pattern: /rk_test_[A-Za-z0-9]{24,}/,
     description: 'Stripe restricted test key',
   },
 
@@ -91,7 +89,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // and tag them as openai-api-key in placeholders.
   {
     name: 'anthropic-api-key',
-    pattern: /sk-ant-(api03|sid01|admin01)-[A-Za-z0-9_-]{80,}/g,
+    pattern: /sk-ant-(api03|sid01|admin01)-[A-Za-z0-9_-]{80,}/,
     description: 'Anthropic API key (api03, sid01, admin01 variants)',
   },
 
@@ -99,7 +97,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://platform.openai.com/docs/api-reference/authentication
   {
     name: 'openai-api-key',
-    pattern: /sk-(proj-|svcacct-|admin-)?[A-Za-z0-9_-]{40,}/g,
+    pattern: /sk-(proj-|svcacct-|admin-)?[A-Za-z0-9_-]{40,}/,
     description: 'OpenAI API key (sk-, sk-proj-, sk-svcacct-, sk-admin- variants)',
   },
 
@@ -107,7 +105,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://cloud.google.com/api-keys/docs/overview
   {
     name: 'google-api-key',
-    pattern: /AIza[A-Za-z0-9_-]{35}/g,
+    pattern: /AIza[A-Za-z0-9_-]{35}/,
     description: 'Google API key',
   },
 
@@ -115,12 +113,12 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://api.slack.com/authentication/token-types
   {
     name: 'slack-token',
-    pattern: /xox[baprso]-[A-Za-z0-9-]{10,}/g,
+    pattern: /xox[baprso]-[A-Za-z0-9-]{10,}/,
     description: 'Slack token (bot, app, user, refresh, OAuth: xox[baprso]- prefix family)',
   },
   {
     name: 'slack-webhook-url',
-    pattern: /https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/[A-Za-z0-9]+/g,
+    pattern: /https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/[A-Za-z0-9]+/,
     description: 'Slack incoming webhook URL (path-bearer credential)',
   },
 
@@ -128,7 +126,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://docs.gitlab.com/ee/security/token_overview.html
   {
     name: 'gitlab-pat',
-    pattern: /glpat-[A-Za-z0-9_-]{20}/g,
+    pattern: /glpat-[A-Za-z0-9_-]{20}/,
     description: 'GitLab personal access token',
   },
 
@@ -136,7 +134,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://docs.npmjs.com/about-access-tokens
   {
     name: 'npm-token',
-    pattern: /npm_[A-Za-z0-9]{36}/g,
+    pattern: /npm_[A-Za-z0-9]{36}/,
     description: 'npm publish token',
   },
 
@@ -144,7 +142,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://docs.digitalocean.com/reference/api/create-personal-access-token/
   {
     name: 'digitalocean-pat',
-    pattern: /dop_v1_[A-Fa-f0-9]{64}/g,
+    pattern: /dop_v1_[A-Fa-f0-9]{64}/,
     description: 'DigitalOcean personal access token v1',
   },
 
@@ -152,7 +150,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://docs.sendgrid.com/api-reference/api-keys/create-api-keys
   {
     name: 'sendgrid-api-key',
-    pattern: /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g,
+    pattern: /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/,
     description: 'SendGrid API key',
   },
 
@@ -160,7 +158,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://documentation.mailgun.com/en/latest/api-intro.html#authentication
   {
     name: 'mailgun-api-key',
-    pattern: /key-[a-f0-9]{32}/g,
+    pattern: /key-[a-f0-9]{32}/,
     description: 'Mailgun API key',
   },
 
@@ -168,7 +166,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://huggingface.co/docs/hub/security-tokens
   {
     name: 'huggingface-token',
-    pattern: /hf_[A-Za-z0-9]{34}/g,
+    pattern: /hf_[A-Za-z0-9]{34}/,
     description: 'Hugging Face access token',
   },
 
@@ -176,7 +174,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://pypi.org/help/#apitoken
   {
     name: 'pypi-token',
-    pattern: /pypi-AgE[A-Za-z0-9_-]{50,}/g,
+    pattern: /pypi-AgE[A-Za-z0-9_-]{50,}/,
     description: 'PyPI API token (pypi-AgE prefix is documented base64 header)',
   },
 
@@ -184,7 +182,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://discord.com/developers/docs/reference#authentication
   {
     name: 'discord-bot-token',
-    pattern: /[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}/g,
+    pattern: /[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}/,
     description: 'Discord bot token (M or N prefix, three-segment base64)',
   },
 
@@ -192,7 +190,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // https://developer.squareup.com/docs/build-basics/access-tokens
   {
     name: 'square-production-token',
-    pattern: /EAAA[A-Za-z0-9_-]{60,}/g,
+    pattern: /EAAA[A-Za-z0-9_-]{60,}/,
     description: 'Square production access token',
   },
 ] as const

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -1,5 +1,6 @@
+import { ShellCassetteError } from './errors.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
-import type { RedactConfig, RedactionEntry, RedactSource } from './types.js'
+import type { RedactConfig, RedactionEntry, RedactRule, RedactSource } from './types.js'
 
 export type RedactInput = {
   source: RedactSource
@@ -27,13 +28,24 @@ export type RedactOutput = {
 // Module-level cache: build g-flagged copies once at module load.
 // BUNDLED_PATTERNS stores patterns without the g flag (stateless, safe for .test()/.exec()).
 // The pipeline adds the g flag here so String.prototype.replace iterates all matches.
-// `r.pattern as RegExp`: the preceding .filter narrows to RegExp, but the
-// narrowing does not propagate into .map's callback. The cast is safe.
+
+// Bundled patterns are RegExp-only by contract (see redact-patterns.ts and the
+// structural test in tests/unit/redact-patterns.test.ts). Validate at module
+// load so a future function-typed addition fails fast and visibly (rather than
+// being silently filtered out).
+for (const rule of BUNDLED_PATTERNS) {
+  if (!(rule.pattern instanceof RegExp)) {
+    throw new ShellCassetteError(
+      `bundled rule "${rule.name}" has a non-RegExp pattern; bundle is RegExp-only (internal bug; should be unreachable)`,
+    )
+  }
+}
+
 const G_FLAGGED_BUNDLE: { name: string; pattern: RegExp }[] = BUNDLED_PATTERNS.filter(
-  (r) => r.pattern instanceof RegExp,
+  (r): r is RedactRule & { pattern: RegExp } => r.pattern instanceof RegExp,
 ).map((r) => ({
   name: r.name,
-  pattern: new RegExp((r.pattern as RegExp).source, `${(r.pattern as RegExp).flags}g`),
+  pattern: new RegExp(r.pattern.source, `${r.pattern.flags}g`),
 }))
 
 const PATH_OR_WHITESPACE_REGEX = /[/\\: ]/
@@ -97,7 +109,8 @@ export function runPipeline(
         output = transformed
       }
     } else {
-      // Normalize: ensure g flag is set so all matches are replaced
+      // User-supplied regex may omit the g flag; pipeline requires it for
+      // String.prototype.replace to iterate all matches in a value.
       const gPattern = rule.pattern.flags.includes('g')
         ? rule.pattern
         : new RegExp(rule.pattern.source, `${rule.pattern.flags}g`)
@@ -105,11 +118,11 @@ export function runPipeline(
     }
   }
 
-  if (
-    output === value &&
-    output.length > config.warnLengthThreshold &&
-    !(config.warnPathHeuristic && PATH_OR_WHITESPACE_REGEX.test(output))
-  ) {
+  const noRuleFired = output === value
+  const exceedsThreshold = output.length > config.warnLengthThreshold
+  const suppressedByHeuristic = config.warnPathHeuristic && PATH_OR_WHITESPACE_REGEX.test(output)
+
+  if (noRuleFired && exceedsThreshold && !suppressedByHeuristic) {
     warnings.push(
       `${input.source} value (${output.length} chars) exceeds threshold ${config.warnLengthThreshold} ` +
         `and contains no path/whitespace characters; may be a credential not in any rule. ` +
@@ -118,6 +131,12 @@ export function runPipeline(
   }
 
   return { output, entries, warnings }
+}
+
+function formatPlaceholder(source: RedactSource, ruleName: string, count?: number): string {
+  return count === undefined
+    ? `<redacted:${source}:${ruleName}>`
+    : `<redacted:${source}:${ruleName}:${count}>`
 }
 
 function applyRegexRule(
@@ -133,32 +152,18 @@ function applyRegexRule(
   const result = text.replace(pattern, () => {
     count++
     if (options.counted) {
-      return buildCountedPlaceholder(source, ruleName, options.counters)
+      const key = `${source}:${ruleName}`
+      const next = (options.counters.get(key) ?? 0) + 1
+      options.counters.set(key, next)
+      return formatPlaceholder(source, ruleName, next)
     }
-    return buildStrippedPlaceholder(source, ruleName)
+    return formatPlaceholder(source, ruleName)
   })
   if (count > 0) {
     entries.push({ rule: ruleName, source, count })
   }
   return result
 }
-
-function buildCountedPlaceholder(
-  source: RedactSource,
-  ruleName: string,
-  counters: Map<string, number>,
-): string {
-  const key = `${source}:${ruleName}`
-  const next = (counters.get(key) ?? 0) + 1
-  counters.set(key, next)
-  return `<redacted:${source}:${ruleName}:${next}>`
-}
-
-function buildStrippedPlaceholder(source: RedactSource, ruleName: string): string {
-  return `<redacted:${source}:${ruleName}>`
-}
-
-const COUNTER_REGEX = /<redacted:([^:>]+):([^:>]+):(\d+)>/g
 
 /**
  * Replace counter-tagged placeholders with their counter-stripped form.
@@ -167,5 +172,5 @@ const COUNTER_REGEX = /<redacted:([^:>]+):([^:>]+):(\d+)>/g
  * in stripped mode. Stripped placeholders pass through unchanged.
  */
 export function stripCounter(s: string): string {
-  return s.replace(COUNTER_REGEX, '<redacted:$1:$2>')
+  return s.replace(/<redacted:([^:>]+):([^:>]+):(\d+)>/g, '<redacted:$1:$2>')
 }

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -6,6 +6,16 @@ export type RedactInput = {
   value: string
 }
 
+/**
+ * Discriminated union over counter mode. Restructured from the spec's
+ * `{ counted: boolean; counters?: Map<string, number> }` shape so the
+ * unreachable state `counted: true && counters: undefined` cannot be
+ * expressed; callers in counted mode must supply the counters Map.
+ *
+ * Per `.claude/rules/error_handling.md` "Internal Invariants": restructure
+ * types so unreachable states can't be expressed in preference to runtime
+ * non-null assertions.
+ */
 export type RedactOptions = { counted: false } | { counted: true; counters: Map<string, number> }
 
 export type RedactOutput = {
@@ -17,6 +27,8 @@ export type RedactOutput = {
 // Module-level cache: build g-flagged copies once at module load.
 // BUNDLED_PATTERNS stores patterns without the g flag (stateless, safe for .test()/.exec()).
 // The pipeline adds the g flag here so String.prototype.replace iterates all matches.
+// `r.pattern as RegExp`: the preceding .filter narrows to RegExp, but the
+// narrowing does not propagate into .map's callback. The cast is safe.
 const G_FLAGGED_BUNDLE: { name: string; pattern: RegExp }[] = BUNDLED_PATTERNS.filter(
   (r) => r.pattern instanceof RegExp,
 ).map((r) => ({
@@ -26,6 +38,34 @@ const G_FLAGGED_BUNDLE: { name: string; pattern: RegExp }[] = BUNDLED_PATTERNS.f
 
 const PATH_OR_WHITESPACE_REGEX = /[/\\: ]/
 
+/**
+ * Apply the redact pipeline to a single value.
+ *
+ * Phases run in this fixed order:
+ *
+ *   1. Suppress: if any regex in `config.suppressPatterns` matches the input
+ *      value, the value is exempt from all subsequent phases (short-circuit).
+ *      Use case: project-wide fake-token fixtures.
+ *   2. Bundled patterns: when `config.bundledPatterns` is true, every rule in
+ *      `BUNDLED_PATTERNS` (with the `g` flag added by the pipeline) runs against
+ *      the working value. Each match is replaced by a placeholder.
+ *   3. Custom patterns: each rule in `config.customPatterns` runs after bundled.
+ *      Regex patterns are normalized so the `g` flag is set; function patterns
+ *      are called once and counted as one match if they transform.
+ *   4. Length warning: fires only when the output is identity-equal to the
+ *      input (no rule fired) AND output length exceeds
+ *      `config.warnLengthThreshold` AND (`warnPathHeuristic` is false OR the
+ *      value contains no `/`, `\`, `:`, or space). Surfaces a candidate
+ *      credential not caught by any rule.
+ *
+ * Output mode is set by `options.counted`:
+ *   - `true`: emit `<redacted:source:rule:N>` placeholders. Counter is per
+ *     `(source, rule)` pair, drawn from `options.counters`. Used at record time
+ *     so cassette content has stable, greppable provenance.
+ *   - `false`: emit `<redacted:source:rule>` placeholders (no counter). Used at
+ *     canonicalize / match time so cassette args containing counter-tagged
+ *     placeholders deep-equal against fresh-call args.
+ */
 export function runPipeline(
   input: RedactInput,
   config: Readonly<RedactConfig>,

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -47,6 +47,22 @@ export function runPipeline(
     }
   }
 
+  for (const rule of config.customPatterns) {
+    if (typeof rule.pattern === 'function') {
+      const transformed = rule.pattern(output)
+      if (transformed !== output) {
+        entries.push({ rule: rule.name, source: input.source, count: 1 })
+        output = transformed
+      }
+    } else {
+      // Normalize: ensure g flag is set so all matches are replaced
+      const gPattern = rule.pattern.flags.includes('g')
+        ? rule.pattern
+        : new RegExp(rule.pattern.source, `${rule.pattern.flags}g`)
+      output = applyRegexRule(output, rule.name, gPattern, input.source, options, entries)
+    }
+  }
+
   return { output, entries, warnings }
 }
 

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -24,6 +24,8 @@ const G_FLAGGED_BUNDLE: { name: string; pattern: RegExp }[] = BUNDLED_PATTERNS.f
   pattern: new RegExp((r.pattern as RegExp).source, `${(r.pattern as RegExp).flags}g`),
 }))
 
+const PATH_OR_WHITESPACE_REGEX = /[/\\: ]/
+
 export function runPipeline(
   input: RedactInput,
   config: Readonly<RedactConfig>,
@@ -61,6 +63,18 @@ export function runPipeline(
         : new RegExp(rule.pattern.source, `${rule.pattern.flags}g`)
       output = applyRegexRule(output, rule.name, gPattern, input.source, options, entries)
     }
+  }
+
+  if (
+    output === value &&
+    output.length > config.warnLengthThreshold &&
+    !(config.warnPathHeuristic && PATH_OR_WHITESPACE_REGEX.test(output))
+  ) {
+    warnings.push(
+      `${input.source} value (${output.length} chars) exceeds threshold ${config.warnLengthThreshold} ` +
+        `and contains no path/whitespace characters; may be a credential not in any rule. ` +
+        `Review or add a pattern to config.redact.customPatterns.`,
+    )
   }
 
   return { output, entries, warnings }

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -1,3 +1,4 @@
+import { BUNDLED_PATTERNS } from './redact-patterns.js'
 import type { RedactConfig, RedactionEntry, RedactSource } from './types.js'
 
 export type RedactInput = {
@@ -5,16 +6,23 @@ export type RedactInput = {
   value: string
 }
 
-export type RedactOptions = {
-  counted: boolean
-  counters?: Map<string, number>
-}
+export type RedactOptions = { counted: false } | { counted: true; counters: Map<string, number> }
 
 export type RedactOutput = {
   output: string
   entries: RedactionEntry[]
   warnings: string[]
 }
+
+// Module-level cache: build g-flagged copies once at module load.
+// BUNDLED_PATTERNS stores patterns without the g flag (stateless, safe for .test()/.exec()).
+// The pipeline adds the g flag here so String.prototype.replace iterates all matches.
+const G_FLAGGED_BUNDLE: { name: string; pattern: RegExp }[] = BUNDLED_PATTERNS.filter(
+  (r) => r.pattern instanceof RegExp,
+).map((r) => ({
+  name: r.name,
+  pattern: new RegExp((r.pattern as RegExp).source, `${(r.pattern as RegExp).flags}g`),
+}))
 
 export function runPipeline(
   input: RedactInput,
@@ -31,7 +39,53 @@ export function runPipeline(
     }
   }
 
-  return { output: value, entries, warnings }
+  let output = value
+
+  if (config.bundledPatterns) {
+    for (const rule of G_FLAGGED_BUNDLE) {
+      output = applyRegexRule(output, rule.name, rule.pattern, input.source, options, entries)
+    }
+  }
+
+  return { output, entries, warnings }
+}
+
+function applyRegexRule(
+  text: string,
+  ruleName: string,
+  pattern: RegExp,
+  source: RedactSource,
+  options: RedactOptions,
+  entries: RedactionEntry[],
+): string {
+  let count = 0
+  // pattern is guaranteed to have g flag (caller ensures it)
+  const result = text.replace(pattern, () => {
+    count++
+    if (options.counted) {
+      return buildCountedPlaceholder(source, ruleName, options.counters)
+    }
+    return buildStrippedPlaceholder(source, ruleName)
+  })
+  if (count > 0) {
+    entries.push({ rule: ruleName, source, count })
+  }
+  return result
+}
+
+function buildCountedPlaceholder(
+  source: RedactSource,
+  ruleName: string,
+  counters: Map<string, number>,
+): string {
+  const key = `${source}:${ruleName}`
+  const next = (counters.get(key) ?? 0) + 1
+  counters.set(key, next)
+  return `<redacted:${source}:${ruleName}:${next}>`
+}
+
+function buildStrippedPlaceholder(source: RedactSource, ruleName: string): string {
+  return `<redacted:${source}:${ruleName}>`
 }
 
 export function stripCounter(s: string): string {

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -1,0 +1,39 @@
+import type { RedactConfig, RedactionEntry, RedactSource } from './types.js'
+
+export type RedactInput = {
+  source: RedactSource
+  value: string
+}
+
+export type RedactOptions = {
+  counted: boolean
+  counters?: Map<string, number>
+}
+
+export type RedactOutput = {
+  output: string
+  entries: RedactionEntry[]
+  warnings: string[]
+}
+
+export function runPipeline(
+  input: RedactInput,
+  config: Readonly<RedactConfig>,
+  options: RedactOptions,
+): RedactOutput {
+  const { value } = input
+  const entries: RedactionEntry[] = []
+  const warnings: string[] = []
+
+  for (const sup of config.suppressPatterns) {
+    if (sup.test(value)) {
+      return { output: value, entries, warnings }
+    }
+  }
+
+  return { output: value, entries, warnings }
+}
+
+export function stripCounter(s: string): string {
+  return s
+}

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -118,6 +118,14 @@ function buildStrippedPlaceholder(source: RedactSource, ruleName: string): strin
   return `<redacted:${source}:${ruleName}>`
 }
 
+const COUNTER_REGEX = /<redacted:([^:>]+):([^:>]+):(\d+)>/g
+
+/**
+ * Replace counter-tagged placeholders with their counter-stripped form.
+ * Used by the canonicalize pipeline at match time so cassette args containing
+ * counter-tagged placeholders deep-equal against fresh-call args canonicalized
+ * in stripped mode. Stripped placeholders pass through unchanged.
+ */
 export function stripCounter(s: string): string {
-  return s
+  return s.replace(COUNTER_REGEX, '<redacted:$1:$2>')
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,14 +44,10 @@ export type RedactRule = {
    */
   name: string
   /**
-   * Either a global regex (most rules) or a transform function (for advanced
-   * cases where the user wants full control over the replacement). Regex rules
-   * use `String.prototype.matchAll` semantics; the regex MUST have the `g` flag.
-   * Note: the `g` flag carries `lastIndex` state. Callers must use
-   * `String.prototype.replace` (stateless) or construct a fresh
-   * `new RegExp(re.source, re.flags)` copy before `.test()` or `.exec()`;
-   * direct `.test()` on the stored object will silently misfire on alternating
-   * calls.
+   * Regex for shape detection or a transform function for advanced cases where
+   * the user wants full control over the replacement. The pipeline normalizes
+   * regex patterns by ensuring the `g` flag is set at call time, so user-supplied
+   * regex may be supplied with or without the `g` flag.
    */
   pattern: RegExp | ((s: string) => string)
   /**

--- a/tests/unit/redact-patterns.test.ts
+++ b/tests/unit/redact-patterns.test.ts
@@ -18,14 +18,14 @@ describe('BUNDLED_PATTERNS', () => {
     }
   })
 
-  test('all regex patterns have the global flag', () => {
+  test('no regex patterns have the global flag (pipeline applies g internally)', () => {
     for (const rule of BUNDLED_PATTERNS) {
       if (!(rule.pattern instanceof RegExp)) {
         throw new Error(
           `bundled rule ${rule.name} has a function pattern; bundle currently expects RegExp only`,
         )
       }
-      expect(rule.pattern.flags).toContain('g')
+      expect(rule.pattern.flags).not.toContain('g')
     }
   })
 })

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, test } from 'vitest'
+import { runPipeline, stripCounter } from '../../src/redact-pipeline.js'
+import type { RedactConfig } from '../../src/types.js'
+
+const baseConfig: RedactConfig = {
+  bundledPatterns: false,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+}
+
+// ---------------------------------------------------------------------------
+// Task 7: suppress short-circuit
+// ---------------------------------------------------------------------------
+
+describe('redact-pipeline: suppress short-circuit', () => {
+  test('suppress regex match exempts the value from all rules', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      suppressPatterns: [/^FAKE_/],
+    }
+    const result = runPipeline(
+      { source: 'env', value: 'FAKE_ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      config,
+      { counted: false },
+    )
+    expect(result.output).toBe('FAKE_ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(result.entries).toEqual([])
+    expect(result.warnings).toEqual([])
+  })
+
+  test('value not matching any suppress regex falls through unchanged when no rules apply', () => {
+    const config: RedactConfig = { ...baseConfig, suppressPatterns: [/^FAKE_/] }
+    const result = runPipeline({ source: 'env', value: 'normal-value' }, config, { counted: false })
+    expect(result.output).toBe('normal-value')
+    expect(result.entries).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 8: bundled pattern application
+// ---------------------------------------------------------------------------
+
+describe('redact-pipeline: bundled patterns', () => {
+  test('bundle disabled: no rules apply even when value matches a bundled pattern', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: false }
+    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
+    expect(result.output).toBe(value)
+    expect(result.entries).toEqual([])
+  })
+
+  test('bundle enabled, stripped mode: replaces match with stripped placeholder', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const value = 'token: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 end'
+    const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
+    expect(result.output).toBe('token: <redacted:stdout:github-pat-classic> end')
+    expect(result.entries).toEqual([{ rule: 'github-pat-classic', source: 'stdout', count: 1 }])
+  })
+
+  test('bundle enabled, multiple matches in one value: each replaced; count reflects all', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const t1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const t2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+    const value = `a ${t1} b ${t2} c`
+    const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
+    expect(result.output).toBe(
+      'a <redacted:stdout:github-pat-classic> b <redacted:stdout:github-pat-classic> c',
+    )
+    expect(result.entries).toEqual([{ rule: 'github-pat-classic', source: 'stdout', count: 2 }])
+  })
+
+  test('bundle enabled, no match: output unchanged, no entries', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const result = runPipeline({ source: 'stdout', value: 'hello world' }, config, {
+      counted: false,
+    })
+    expect(result.output).toBe('hello world')
+    expect(result.entries).toEqual([])
+  })
+
+  test('all 25 bundled rules are wired into the pipeline (smoke check)', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const result = runPipeline({ source: 'env', value: `AIza${'a'.repeat(35)}` }, config, {
+      counted: false,
+    })
+    expect(result.output).toBe('<redacted:env:google-api-key>')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 9: custom rule application
+// ---------------------------------------------------------------------------
+
+describe('redact-pipeline: custom rules', () => {
+  test('regex custom rule (no g flag) applies after bundle and is normalized', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      customPatterns: [{ name: 'my-secret', pattern: /SECRET-[A-Z0-9]+/ }],
+    }
+    const result = runPipeline(
+      { source: 'stdout', value: 'before SECRET-ABC123 after SECRET-XYZ789 end' },
+      config,
+      { counted: false },
+    )
+    expect(result.output).toBe(
+      'before <redacted:stdout:my-secret> after <redacted:stdout:my-secret> end',
+    )
+    expect(result.entries).toEqual([{ rule: 'my-secret', source: 'stdout', count: 2 }])
+  })
+
+  test('regex custom rule (with g flag) works the same', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      customPatterns: [{ name: 'my-secret', pattern: /SECRET-[A-Z0-9]+/g }],
+    }
+    const result = runPipeline(
+      { source: 'stdout', value: 'before SECRET-ABC123 after SECRET-XYZ789 end' },
+      config,
+      { counted: false },
+    )
+    expect(result.output).toBe(
+      'before <redacted:stdout:my-secret> after <redacted:stdout:my-secret> end',
+    )
+    expect(result.entries).toEqual([{ rule: 'my-secret', source: 'stdout', count: 2 }])
+  })
+
+  test('function custom rule receives the value and returns the replacement', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      customPatterns: [{ name: 'uppercase', pattern: (s: string) => s.toUpperCase() }],
+    }
+    const result = runPipeline({ source: 'env', value: 'hello world' }, config, { counted: false })
+    expect(result.output).toBe('HELLO WORLD')
+    expect(result.entries).toEqual([{ rule: 'uppercase', source: 'env', count: 1 }])
+  })
+
+  test('function rule that does not transform: count stays 0, no entry', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      customPatterns: [{ name: 'noop', pattern: (s: string) => s }],
+    }
+    const result = runPipeline({ source: 'env', value: 'unchanged' }, config, { counted: false })
+    expect(result.output).toBe('unchanged')
+    expect(result.entries).toEqual([])
+  })
+
+  test('bundle and custom can both fire on the same value', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: true,
+      customPatterns: [{ name: 'my-fake', pattern: /TEST_TOKEN_[A-Z0-9]+/ }],
+    }
+    const value = 'gh: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 / fake: TEST_TOKEN_ABC'
+    const result = runPipeline({ source: 'args', value }, config, { counted: false })
+    expect(result.output).toContain('<redacted:args:github-pat-classic>')
+    expect(result.output).toContain('<redacted:args:my-fake>')
+    expect(result.entries).toEqual([
+      { rule: 'github-pat-classic', source: 'args', count: 1 },
+      { rule: 'my-fake', source: 'args', count: 1 },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 10: length warning with path heuristic
+// ---------------------------------------------------------------------------
+
+describe('redact-pipeline: length warning', () => {
+  test('value > threshold + no path/whitespace + no rule fired: warning emitted', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: true,
+    }
+    const value = 'a'.repeat(50)
+    const result = runPipeline({ source: 'env', value }, config, { counted: false })
+    expect(result.warnings.length).toBe(1)
+    expect(result.warnings[0]).toContain('env')
+    expect(result.warnings[0]).toContain('50')
+  })
+
+  test('value at exactly threshold: no warning', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: true,
+    }
+    const result = runPipeline({ source: 'env', value: 'a'.repeat(40) }, config, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('value > threshold + contains slash: path heuristic suppresses warning', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: true,
+    }
+    const value = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java-very-long'
+    const result = runPipeline({ source: 'env', value }, config, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('value > threshold + contains backslash: path heuristic suppresses', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: true,
+    }
+    const value = 'C:\\Users\\steve\\AppData\\Local\\Temp\\very-long-filename.txt'
+    const result = runPipeline({ source: 'env', value }, config, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('value > threshold + contains colon: path heuristic suppresses', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: true,
+    }
+    const value = 'host:port:database:longish-connection-string-config'
+    const result = runPipeline({ source: 'env', value }, config, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('value > threshold + contains space: path heuristic suppresses', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: true,
+    }
+    const value = 'this is a long config string that contains spaces and is over 40 chars'
+    const result = runPipeline({ source: 'env', value }, config, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('warnPathHeuristic disabled: long path-like values DO warn', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      warnLengthThreshold: 40,
+      warnPathHeuristic: false,
+    }
+    const value = '/usr/lib/jvm/java-17-openjdk-amd64-very-long-path'
+    const result = runPipeline({ source: 'env', value }, config, { counted: false })
+    expect(result.warnings.length).toBe(1)
+  })
+
+  test('value redacted by a rule: NO length warning', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: true,
+      warnLengthThreshold: 10,
+      warnPathHeuristic: true,
+    }
+    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Task 11: counter management + stripCounter
+// ---------------------------------------------------------------------------
+
+describe('redact-pipeline: counter management', () => {
+  test('counted mode increments per emission within a session', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const counters = new Map<string, number>()
+    const value1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const value2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+
+    const r1 = runPipeline({ source: 'env', value: value1 }, config, { counted: true, counters })
+    expect(r1.output).toBe('<redacted:env:github-pat-classic:1>')
+
+    const r2 = runPipeline({ source: 'env', value: value2 }, config, { counted: true, counters })
+    expect(r2.output).toBe('<redacted:env:github-pat-classic:2>')
+  })
+
+  test('counter scope is per (source, rule)', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const counters = new Map<string, number>()
+    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+
+    const r1 = runPipeline({ source: 'env', value }, config, { counted: true, counters })
+    expect(r1.output).toBe('<redacted:env:github-pat-classic:1>')
+
+    const r2 = runPipeline({ source: 'stdout', value }, config, { counted: true, counters })
+    expect(r2.output).toBe('<redacted:stdout:github-pat-classic:1>')
+
+    const aws = 'AKIA0123456789ABCDEF'
+    const r3 = runPipeline({ source: 'env', value: aws }, config, { counted: true, counters })
+    expect(r3.output).toBe('<redacted:env:aws-access-key-id:1>')
+  })
+
+  test('multiple matches in single value increment counter for each', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const counters = new Map<string, number>()
+    const t1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const t2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+    const value = `${t1} and ${t2}`
+    const result = runPipeline({ source: 'stdout', value }, config, { counted: true, counters })
+    expect(result.output).toBe(
+      '<redacted:stdout:github-pat-classic:1> and <redacted:stdout:github-pat-classic:2>',
+    )
+  })
+
+  test('stripped mode produces same output regardless of counter state', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const r1 = runPipeline({ source: 'args', value }, config, { counted: false })
+    const r2 = runPipeline({ source: 'args', value }, config, { counted: false })
+    expect(r1.output).toBe(r2.output)
+    expect(r1.output).toBe('<redacted:args:github-pat-classic>')
+  })
+})
+
+describe('stripCounter', () => {
+  test('removes :N from a single placeholder', () => {
+    expect(stripCounter('<redacted:env:github-pat-classic:1>')).toBe(
+      '<redacted:env:github-pat-classic>',
+    )
+  })
+
+  test('removes :N from multiple placeholders in one string', () => {
+    const input =
+      'a <redacted:stdout:github-pat-classic:1> b <redacted:stdout:github-pat-classic:2> c'
+    expect(stripCounter(input)).toBe(
+      'a <redacted:stdout:github-pat-classic> b <redacted:stdout:github-pat-classic> c',
+    )
+  })
+
+  test('leaves non-placeholder text alone', () => {
+    expect(stripCounter('hello world')).toBe('hello world')
+    expect(stripCounter('Bearer ghp_real')).toBe('Bearer ghp_real')
+  })
+
+  test('leaves stripped placeholders unchanged', () => {
+    expect(stripCounter('<redacted:env:rule>')).toBe('<redacted:env:rule>')
+  })
+})

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -11,10 +11,6 @@ const baseConfig: RedactConfig = {
   warnPathHeuristic: true,
 }
 
-// ---------------------------------------------------------------------------
-// Task 7: suppress short-circuit
-// ---------------------------------------------------------------------------
-
 describe('redact-pipeline: suppress short-circuit', () => {
   test('suppress regex match exempts the value from all rules', () => {
     const config: RedactConfig = {
@@ -38,10 +34,6 @@ describe('redact-pipeline: suppress short-circuit', () => {
     expect(result.entries).toEqual([])
   })
 })
-
-// ---------------------------------------------------------------------------
-// Task 8: bundled pattern application
-// ---------------------------------------------------------------------------
 
 describe('redact-pipeline: bundled patterns', () => {
   test('bundle disabled: no rules apply even when value matches a bundled pattern', () => {
@@ -81,18 +73,58 @@ describe('redact-pipeline: bundled patterns', () => {
     expect(result.entries).toEqual([])
   })
 
-  test('all 25 bundled rules are wired into the pipeline (smoke check)', () => {
+  test('bundled rule fires when bundle enabled (smoke check, single rule)', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const result = runPipeline({ source: 'env', value: `AIza${'a'.repeat(35)}` }, config, {
       counted: false,
     })
     expect(result.output).toBe('<redacted:env:google-api-key>')
   })
-})
 
-// ---------------------------------------------------------------------------
-// Task 9: custom rule application
-// ---------------------------------------------------------------------------
+  test('all 25 bundled rules are wired into the pipeline (per-rule smoke)', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    // For each bundled rule, construct a sample value matching its pattern
+    // and verify the pipeline produces the corresponding placeholder.
+    const samples: { name: string; value: string }[] = [
+      { name: 'github-pat-classic', value: `ghp_${'a'.repeat(36)}` },
+      { name: 'github-pat-fine-grained', value: `github_pat_${'A'.repeat(82)}` },
+      { name: 'github-oauth', value: `gho_${'a'.repeat(36)}` },
+      { name: 'github-user-to-server', value: `ghu_${'a'.repeat(36)}` },
+      { name: 'github-server-to-server', value: `ghs_${'a'.repeat(36)}` },
+      { name: 'github-refresh', value: `ghr_${'a'.repeat(36)}` },
+      { name: 'aws-access-key-id', value: 'AKIA0123456789ABCDEF' },
+      { name: 'stripe-secret-live', value: `sk_live_${'a'.repeat(24)}` },
+      { name: 'stripe-secret-test', value: `sk_test_${'a'.repeat(24)}` },
+      { name: 'stripe-restricted-live', value: `rk_live_${'a'.repeat(24)}` },
+      { name: 'stripe-restricted-test', value: `rk_test_${'a'.repeat(24)}` },
+      { name: 'anthropic-api-key', value: `sk-ant-api03-${'a'.repeat(80)}` },
+      { name: 'openai-api-key', value: `sk-${'a'.repeat(48)}` },
+      { name: 'google-api-key', value: `AIza${'a'.repeat(35)}` },
+      { name: 'slack-token', value: 'xoxb-1234567890' },
+      {
+        name: 'slack-webhook-url',
+        value: 'https://hooks.slack.com/services/T0AB12CDE/B0FG34HIJ/0123456789ABCDEF',
+      },
+      { name: 'gitlab-pat', value: `glpat-${'a'.repeat(20)}` },
+      { name: 'npm-token', value: `npm_${'a'.repeat(36)}` },
+      { name: 'digitalocean-pat', value: `dop_v1_${'0'.repeat(64)}` },
+      { name: 'sendgrid-api-key', value: `SG.${'a'.repeat(22)}.${'a'.repeat(43)}` },
+      { name: 'mailgun-api-key', value: `key-${'0'.repeat(32)}` },
+      { name: 'huggingface-token', value: `hf_${'a'.repeat(34)}` },
+      { name: 'pypi-token', value: `pypi-AgE${'a'.repeat(50)}` },
+      { name: 'discord-bot-token', value: `M${'a'.repeat(23)}.${'a'.repeat(6)}.${'a'.repeat(27)}` },
+      { name: 'square-production-token', value: `EAAA${'a'.repeat(60)}` },
+    ]
+    expect(samples.length).toBe(25)
+    for (const sample of samples) {
+      const result = runPipeline({ source: 'stdout', value: sample.value }, config, {
+        counted: false,
+      })
+      expect(result.output).toBe(`<redacted:stdout:${sample.name}>`)
+      expect(result.entries.some((e) => e.rule === sample.name)).toBe(true)
+    }
+  })
+})
 
 describe('redact-pipeline: custom rules', () => {
   test('regex custom rule (no g flag) applies after bundle and is normalized', () => {
@@ -167,10 +199,6 @@ describe('redact-pipeline: custom rules', () => {
     ])
   })
 })
-
-// ---------------------------------------------------------------------------
-// Task 10: length warning with path heuristic
-// ---------------------------------------------------------------------------
 
 describe('redact-pipeline: length warning', () => {
   test('value > threshold + no path/whitespace + no rule fired: warning emitted', () => {
@@ -271,10 +299,6 @@ describe('redact-pipeline: length warning', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Task 11: counter management + stripCounter
-// ---------------------------------------------------------------------------
-
 describe('redact-pipeline: counter management', () => {
   test('counted mode increments per emission within a session', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
@@ -324,6 +348,24 @@ describe('redact-pipeline: counter management', () => {
     const r2 = runPipeline({ source: 'args', value }, config, { counted: false })
     expect(r1.output).toBe(r2.output)
     expect(r1.output).toBe('<redacted:args:github-pat-classic>')
+  })
+
+  test('function custom rules in counted mode return whatever the function produces (no placeholder)', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      bundledPatterns: false,
+      customPatterns: [{ name: 'shouty', pattern: (s: string) => s.toUpperCase() }],
+    }
+    const counters = new Map<string, number>()
+    const result = runPipeline({ source: 'env', value: 'hello' }, config, {
+      counted: true,
+      counters,
+    })
+    // Function rules bypass the placeholder mechanism; the function's return value
+    // is the output. Counter map is not touched (counters scope only the placeholder path).
+    expect(result.output).toBe('HELLO')
+    expect(result.entries).toEqual([{ rule: 'shouty', source: 'env', count: 1 }])
+    expect(counters.size).toBe(0)
   })
 })
 


### PR DESCRIPTION
## What Changed

- Drops the `g` flag from `BUNDLED_PATTERNS` regex; pipeline applies internally.
- Adds `src/redact-pipeline.ts` with 4-phase pipeline: suppress, bundled, custom, length warning.
- Exports `runPipeline`, `stripCounter` for consumption by the recorder and canonicalize integration.
- 28 new pipeline tests, all gates green.

## Architecture

`runPipeline(input, config, options)` runs four phases in order:

1. Suppress short-circuits if any `suppressPatterns` regex matches.
2. Bundled patterns apply (uses module-level `G_FLAGGED_BUNDLE` cache built once at module load).
3. Custom rules apply (regex normalized for `g` flag; functions called with full transform control).
4. Length warning fires only when no rule fired AND value > threshold AND fails path heuristic.

Two output modes via `options.counted`:

- `true`: counter-tagged placeholders `<redacted:source:rule:N>` for cassette storage.
- `false`: counter-stripped `<redacted:source:rule>` for canonicalize-time matching.

## Notes

- `BUNDLED_PATTERNS` patterns are stateless (no `g` flag stored). Pipeline owns the `g`-flag invariant. Eliminates latent `lastIndex` hazard for users importing `BUNDLED_PATTERNS` directly.
- `RedactOptions` restructured from spec's nominal `{ counted: boolean; counters?: Map }` to a discriminated union. Counters are required when `counted: true`; the unreachable state is unrepresentable. Per `error_handling.md` "restructure types" rule. JSDoc documents the deviation.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (288 passed, 1 pre-existing skip; +28 new tests vs main)
- [x] `npm run build` produces clean dist/