### PR TITLE
feat: add Config.redact composed field

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,14 +12,11 @@ export type Config = {
    * @deprecated Use Config.redact.envKeys. This field is kept for v0.3
    * backward compatibility through v0.4 and will be removed in v0.5
    * (when v0.4 M6 ships and the recorder/redact.ts rewrite no longer needs it).
-   * mergeWithDefaults populates both this field and Config.redact.envKeys with
-   * the same value so existing callers keep working.
    */
   redactEnvKeys: string[]
   /**
-   * v0.4 composed redaction config. Bundled patterns, custom rules, suppress
-   * list, env-key extension, length warning tuning. See RedactConfig in
-   * src/types.ts for field-level docs.
+   * v0.4 composed redaction config: bundled patterns, custom rules, suppress
+   * list, env-key extension, length warning tuning.
    */
   redact: RedactConfig
 }
@@ -74,11 +71,22 @@ export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Co
   return Object.freeze({
     canonicalize: input?.canonicalize ?? DEFAULT_CONFIG.canonicalize,
     cassetteDir: input?.cassetteDir ?? DEFAULT_CONFIG.cassetteDir,
-    redactEnvKeys: [...resolvedEnvKeys],
+    // Config.redactEnvKeys is typed string[] for v0.3 API compat but the
+    // underlying array is the frozen readonly array from resolvedRedact.envKeys.
+    // The cast widens the type; runtime mutability is still locked by Object.freeze.
+    redactEnvKeys: resolvedRedact.envKeys as string[],
     redact: Object.freeze(resolvedRedact),
   })
 }
 
+/**
+ * Validates a single user-supplied RedactRule.
+ *
+ * `seenNames` must be a single Set shared across all calls for the same
+ * customPatterns array; the function adds each validated rule's name to it
+ * to detect duplicates within the array. Passing a fresh Set per call
+ * silently disables duplicate detection.
+ */
 function validateRule(rule: unknown, fieldPath: string, seenNames: Set<string>): void {
   if (typeof rule !== 'object' || rule === null) {
     throw new CassetteConfigError(`${fieldPath} must be an object`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,8 @@ export type PartialConfig = {
   redact?: Partial<RedactConfig>
 }
 
+// `Object.freeze([])` returns `readonly []` (TS narrows the empty literal).
+// Cast widens to the typed read-only arrays expected by RedactConfig fields.
 const DEFAULT_REDACT: Readonly<RedactConfig> = Object.freeze({
   bundledPatterns: true,
   customPatterns: Object.freeze([]) as readonly RedactRule[],
@@ -58,9 +60,13 @@ export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Co
 
   const resolvedRedact: RedactConfig = {
     bundledPatterns: userRedact.bundledPatterns ?? DEFAULT_REDACT.bundledPatterns,
-    customPatterns: userRedact.customPatterns ?? DEFAULT_REDACT.customPatterns,
-    suppressPatterns: userRedact.suppressPatterns ?? DEFAULT_REDACT.suppressPatterns,
-    envKeys: resolvedEnvKeys,
+    customPatterns: userRedact.customPatterns
+      ? Object.freeze([...userRedact.customPatterns])
+      : DEFAULT_REDACT.customPatterns,
+    suppressPatterns: userRedact.suppressPatterns
+      ? Object.freeze([...userRedact.suppressPatterns])
+      : DEFAULT_REDACT.suppressPatterns,
+    envKeys: Object.freeze([...resolvedEnvKeys]),
     warnLengthThreshold: userRedact.warnLengthThreshold ?? DEFAULT_REDACT.warnLengthThreshold,
     warnPathHeuristic: userRedact.warnPathHeuristic ?? DEFAULT_REDACT.warnPathHeuristic,
   }
@@ -128,8 +134,11 @@ function validateRedact(redact: unknown): void {
   }
 
   if (r.envKeys !== undefined) {
-    if (!Array.isArray(r.envKeys) || !r.envKeys.every((k) => typeof k === 'string')) {
-      throw new CassetteConfigError('config.redact.envKeys must be an array of strings')
+    if (!Array.isArray(r.envKeys)) {
+      throw new CassetteConfigError('config.redact.envKeys must be an array')
+    }
+    if (!r.envKeys.every((k) => typeof k === 'string')) {
+      throw new CassetteConfigError('config.redact.envKeys items must all be strings')
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,28 +3,149 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { CassetteConfigError } from './errors.js'
 import { defaultCanonicalize } from './matcher.js'
-import type { Canonicalize } from './types.js'
+import type { Canonicalize, RedactConfig, RedactRule } from './types.js'
 
 export type Config = {
   canonicalize: Canonicalize
   cassetteDir: string
+  /**
+   * @deprecated Use Config.redact.envKeys. This field is kept for v0.3
+   * backward compatibility through v0.4 and will be removed in v0.5
+   * (when v0.4 M6 ships and the recorder/redact.ts rewrite no longer needs it).
+   * mergeWithDefaults populates both this field and Config.redact.envKeys with
+   * the same value so existing callers keep working.
+   */
   redactEnvKeys: string[]
+  /**
+   * v0.4 composed redaction config. Bundled patterns, custom rules, suppress
+   * list, env-key extension, length warning tuning. See RedactConfig in
+   * src/types.ts for field-level docs.
+   */
+  redact: RedactConfig
 }
 
-export type PartialConfig = Partial<Config>
+export type PartialConfig = {
+  canonicalize?: Canonicalize
+  cassetteDir?: string
+  redactEnvKeys?: string[]
+  redact?: Partial<RedactConfig>
+}
+
+const DEFAULT_REDACT: Readonly<RedactConfig> = Object.freeze({
+  bundledPatterns: true,
+  customPatterns: Object.freeze([]) as readonly RedactRule[],
+  suppressPatterns: Object.freeze([]) as readonly RegExp[],
+  envKeys: Object.freeze([]) as readonly string[],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+})
 
 export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
   canonicalize: defaultCanonicalize,
   cassetteDir: '__cassettes__',
   redactEnvKeys: [] as string[],
+  redact: DEFAULT_REDACT,
 })
 
 export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Config> {
+  const userRedact: Partial<RedactConfig> = input?.redact ?? {}
+  const userRedactEnvKeys = input?.redactEnvKeys
+
+  // Resolve envKeys: redact.envKeys takes precedence over deprecated redactEnvKeys.
+  // Both Config.redactEnvKeys and Config.redact.envKeys end up with the same value
+  // so deprecated and new callers see consistent data.
+  const resolvedEnvKeys = userRedact.envKeys ?? userRedactEnvKeys ?? DEFAULT_REDACT.envKeys
+
+  const resolvedRedact: RedactConfig = {
+    bundledPatterns: userRedact.bundledPatterns ?? DEFAULT_REDACT.bundledPatterns,
+    customPatterns: userRedact.customPatterns ?? DEFAULT_REDACT.customPatterns,
+    suppressPatterns: userRedact.suppressPatterns ?? DEFAULT_REDACT.suppressPatterns,
+    envKeys: resolvedEnvKeys,
+    warnLengthThreshold: userRedact.warnLengthThreshold ?? DEFAULT_REDACT.warnLengthThreshold,
+    warnPathHeuristic: userRedact.warnPathHeuristic ?? DEFAULT_REDACT.warnPathHeuristic,
+  }
+
   return Object.freeze({
     canonicalize: input?.canonicalize ?? DEFAULT_CONFIG.canonicalize,
     cassetteDir: input?.cassetteDir ?? DEFAULT_CONFIG.cassetteDir,
-    redactEnvKeys: input?.redactEnvKeys ?? DEFAULT_CONFIG.redactEnvKeys,
+    redactEnvKeys: [...resolvedEnvKeys],
+    redact: Object.freeze(resolvedRedact),
   })
+}
+
+function validateRule(rule: unknown, fieldPath: string, seenNames: Set<string>): void {
+  if (typeof rule !== 'object' || rule === null) {
+    throw new CassetteConfigError(`${fieldPath} must be an object`)
+  }
+  const r = rule as Record<string, unknown>
+
+  if (typeof r.name !== 'string' || !/^[a-z][a-z0-9-]*$/.test(r.name)) {
+    throw new CassetteConfigError(`${fieldPath}.name must be a kebab-case string`)
+  }
+  if (seenNames.has(r.name)) {
+    throw new CassetteConfigError(`${fieldPath}.name '${r.name}' is duplicated`)
+  }
+  seenNames.add(r.name)
+
+  if (!(r.pattern instanceof RegExp) && typeof r.pattern !== 'function') {
+    throw new CassetteConfigError(`${fieldPath}.pattern must be a RegExp or function`)
+  }
+
+  if (r.description !== undefined && typeof r.description !== 'string') {
+    throw new CassetteConfigError(`${fieldPath}.description must be a string when provided`)
+  }
+}
+
+function validateRedact(redact: unknown): void {
+  if (typeof redact !== 'object' || redact === null) {
+    throw new CassetteConfigError('config.redact must be an object')
+  }
+  const r = redact as Record<string, unknown>
+
+  if (r.bundledPatterns !== undefined && typeof r.bundledPatterns !== 'boolean') {
+    throw new CassetteConfigError('config.redact.bundledPatterns must be boolean')
+  }
+
+  if (r.customPatterns !== undefined) {
+    if (!Array.isArray(r.customPatterns)) {
+      throw new CassetteConfigError('config.redact.customPatterns must be an array')
+    }
+    const seenNames = new Set<string>()
+    r.customPatterns.forEach((rule, i) => {
+      validateRule(rule, `config.redact.customPatterns[${i}]`, seenNames)
+    })
+  }
+
+  if (r.suppressPatterns !== undefined) {
+    if (!Array.isArray(r.suppressPatterns)) {
+      throw new CassetteConfigError('config.redact.suppressPatterns must be an array')
+    }
+    r.suppressPatterns.forEach((p, i) => {
+      if (!(p instanceof RegExp)) {
+        throw new CassetteConfigError(`config.redact.suppressPatterns[${i}] must be a RegExp`)
+      }
+    })
+  }
+
+  if (r.envKeys !== undefined) {
+    if (!Array.isArray(r.envKeys) || !r.envKeys.every((k) => typeof k === 'string')) {
+      throw new CassetteConfigError('config.redact.envKeys must be an array of strings')
+    }
+  }
+
+  if (r.warnLengthThreshold !== undefined) {
+    if (
+      typeof r.warnLengthThreshold !== 'number' ||
+      !Number.isInteger(r.warnLengthThreshold) ||
+      r.warnLengthThreshold < 1
+    ) {
+      throw new CassetteConfigError('config.redact.warnLengthThreshold must be a positive integer')
+    }
+  }
+
+  if (r.warnPathHeuristic !== undefined && typeof r.warnPathHeuristic !== 'boolean') {
+    throw new CassetteConfigError('config.redact.warnPathHeuristic must be boolean')
+  }
 }
 
 export function validateConfig(input: unknown): asserts input is PartialConfig {
@@ -47,6 +168,9 @@ export function validateConfig(input: unknown): asserts input is PartialConfig {
     if (!obj.redactEnvKeys.every((k) => typeof k === 'string')) {
       throw new CassetteConfigError('config.redactEnvKeys items must all be strings')
     }
+  }
+  if ('redact' in obj) {
+    validateRedact(obj.redact)
   }
 }
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -68,3 +68,202 @@ describe('validateConfig', () => {
     expect(() => validateConfig({ canonicalize: 'foo' })).toThrow(CassetteConfigError)
   })
 })
+
+describe('Config defaults: redact field', () => {
+  test('bundledPatterns defaults to true', () => {
+    expect(DEFAULT_CONFIG.redact.bundledPatterns).toBe(true)
+  })
+
+  test('warnLengthThreshold defaults to 40', () => {
+    expect(DEFAULT_CONFIG.redact.warnLengthThreshold).toBe(40)
+  })
+
+  test('warnPathHeuristic defaults to true', () => {
+    expect(DEFAULT_CONFIG.redact.warnPathHeuristic).toBe(true)
+  })
+
+  test('customPatterns, suppressPatterns, envKeys default to empty arrays', () => {
+    expect(DEFAULT_CONFIG.redact.customPatterns).toEqual([])
+    expect(DEFAULT_CONFIG.redact.suppressPatterns).toEqual([])
+    expect(DEFAULT_CONFIG.redact.envKeys).toEqual([])
+  })
+})
+
+describe('mergeWithDefaults: redact field', () => {
+  test('user-provided redact.envKeys takes precedence over redactEnvKeys', () => {
+    const merged = mergeWithDefaults({
+      redact: { envKeys: ['FROM_REDACT'] },
+      redactEnvKeys: ['FROM_FLAT'],
+    })
+    expect(merged.redact.envKeys).toEqual(['FROM_REDACT'])
+    // Both fields stay in sync; deprecated field reflects the resolved value.
+    expect(merged.redactEnvKeys).toEqual(['FROM_REDACT'])
+  })
+
+  test('user-provided redactEnvKeys without redact.envKeys: both fields populated', () => {
+    const merged = mergeWithDefaults({ redactEnvKeys: ['STRIPE_KEY'] })
+    expect(merged.redactEnvKeys).toEqual(['STRIPE_KEY'])
+    expect(merged.redact.envKeys).toEqual(['STRIPE_KEY'])
+  })
+
+  test('user-provided redact: { bundledPatterns: false }: only that field overridden', () => {
+    const merged = mergeWithDefaults({ redact: { bundledPatterns: false } })
+    expect(merged.redact.bundledPatterns).toBe(false)
+    expect(merged.redact.warnLengthThreshold).toBe(40)
+    expect(merged.redact.warnPathHeuristic).toBe(true)
+  })
+
+  test('custom rules pass through merge', () => {
+    const rule = { name: 'my-rule', pattern: /SECRET-[A-Z]+/ }
+    const merged = mergeWithDefaults({ redact: { customPatterns: [rule] } })
+    expect(merged.redact.customPatterns).toEqual([rule])
+  })
+
+  test('suppress patterns pass through merge', () => {
+    const sup = /^FAKE_/
+    const merged = mergeWithDefaults({ redact: { suppressPatterns: [sup] } })
+    expect(merged.redact.suppressPatterns).toEqual([sup])
+  })
+
+  test('warnLengthThreshold override', () => {
+    const merged = mergeWithDefaults({ redact: { warnLengthThreshold: 60 } })
+    expect(merged.redact.warnLengthThreshold).toBe(60)
+  })
+
+  test('warnPathHeuristic override', () => {
+    const merged = mergeWithDefaults({ redact: { warnPathHeuristic: false } })
+    expect(merged.redact.warnPathHeuristic).toBe(false)
+  })
+
+  test('returned redact object is frozen', () => {
+    const merged = mergeWithDefaults({ redact: { bundledPatterns: false } })
+    expect(Object.isFrozen(merged.redact)).toBe(true)
+  })
+})
+
+describe('validateConfig: redact field', () => {
+  test('accepts a custom rule with a regex (no g flag required)', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [{ name: 'my-rule', pattern: /SECRET-[A-Z]+/ }],
+        },
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts a custom rule with a g-flagged regex', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [{ name: 'my-rule', pattern: /SECRET-[A-Z]+/g }],
+        },
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts a custom rule with a function pattern', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [{ name: 'my-fn', pattern: (s: string) => s.toUpperCase() }],
+        },
+      }),
+    ).not.toThrow()
+  })
+
+  test('rejects custom rule with non-kebab-case name', () => {
+    expect(() =>
+      validateConfig({
+        redact: { customPatterns: [{ name: 'BadName', pattern: /A/ }] },
+      }),
+    ).toThrow(/kebab-case/)
+  })
+
+  test('rejects custom rule with empty name', () => {
+    expect(() =>
+      validateConfig({
+        redact: { customPatterns: [{ name: '', pattern: /A/ }] },
+      }),
+    ).toThrow(CassetteConfigError)
+  })
+
+  test('rejects duplicate custom rule names', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [
+            { name: 'dupe', pattern: /A/ },
+            { name: 'dupe', pattern: /B/ },
+          ],
+        },
+      }),
+    ).toThrow(/duplicated/)
+  })
+
+  test('rejects custom rule with neither RegExp nor function pattern', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [{ name: 'bad', pattern: 'not-a-regex' as unknown as RegExp }],
+        },
+      }),
+    ).toThrow(/RegExp or function/)
+  })
+
+  test('rejects suppress entries that are not RegExp', () => {
+    expect(() =>
+      validateConfig({
+        redact: { suppressPatterns: ['not-a-regex' as unknown as RegExp] },
+      }),
+    ).toThrow(/RegExp/)
+  })
+
+  test('rejects negative warnLengthThreshold', () => {
+    expect(() => validateConfig({ redact: { warnLengthThreshold: -1 } })).toThrow(
+      /positive integer/,
+    )
+  })
+
+  test('rejects zero warnLengthThreshold', () => {
+    expect(() => validateConfig({ redact: { warnLengthThreshold: 0 } })).toThrow(/positive integer/)
+  })
+
+  test('rejects non-integer warnLengthThreshold', () => {
+    expect(() => validateConfig({ redact: { warnLengthThreshold: 40.5 } })).toThrow(
+      /positive integer/,
+    )
+  })
+
+  test('rejects non-boolean bundledPatterns', () => {
+    expect(() => validateConfig({ redact: { bundledPatterns: 'yes' } })).toThrow(/boolean/)
+  })
+
+  test('rejects non-boolean warnPathHeuristic', () => {
+    expect(() => validateConfig({ redact: { warnPathHeuristic: 'yes' } })).toThrow(/boolean/)
+  })
+
+  test('rejects non-array customPatterns', () => {
+    expect(() => validateConfig({ redact: { customPatterns: 'foo' } })).toThrow(/array/)
+  })
+
+  test('rejects non-array suppressPatterns', () => {
+    expect(() => validateConfig({ redact: { suppressPatterns: 'foo' } })).toThrow(/array/)
+  })
+
+  test('rejects non-array envKeys', () => {
+    expect(() => validateConfig({ redact: { envKeys: 'foo' } })).toThrow(/array of strings/)
+  })
+
+  test('rejects envKeys with non-string entries', () => {
+    expect(() => validateConfig({ redact: { envKeys: [1, 2] } })).toThrow(/array of strings/)
+  })
+
+  test('rejects non-object redact', () => {
+    expect(() => validateConfig({ redact: 'foo' })).toThrow(/must be an object/)
+  })
+
+  test('user can opt out of bundle by setting bundledPatterns: false', () => {
+    expect(() => validateConfig({ redact: { bundledPatterns: false } })).not.toThrow()
+  })
+})

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -294,6 +294,8 @@ describe('validateConfig: redact field', () => {
 
   test('user can opt out of bundle by setting bundledPatterns: false', () => {
     expect(() => validateConfig({ redact: { bundledPatterns: false } })).not.toThrow()
+    const merged = mergeWithDefaults({ redact: { bundledPatterns: false } })
+    expect(merged.redact.bundledPatterns).toBe(false)
   })
 
   test('accepts custom rule with valid description', () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -139,6 +139,31 @@ describe('mergeWithDefaults: redact field', () => {
     const merged = mergeWithDefaults({ redact: { bundledPatterns: false } })
     expect(Object.isFrozen(merged.redact)).toBe(true)
   })
+
+  test('user-supplied customPatterns array is defensively copied and frozen', () => {
+    const userArray = [{ name: 'my-rule', pattern: /A/ }]
+    const merged = mergeWithDefaults({ redact: { customPatterns: userArray } })
+    expect(Object.isFrozen(merged.redact.customPatterns)).toBe(true)
+    // Mutating the original user array does NOT affect merged
+    userArray.push({ name: 'sneaky', pattern: /B/ })
+    expect(merged.redact.customPatterns.length).toBe(1)
+  })
+
+  test('user-supplied suppressPatterns array is defensively copied and frozen', () => {
+    const userArray = [/^FAKE_/]
+    const merged = mergeWithDefaults({ redact: { suppressPatterns: userArray } })
+    expect(Object.isFrozen(merged.redact.suppressPatterns)).toBe(true)
+    userArray.push(/^OTHER_/)
+    expect(merged.redact.suppressPatterns.length).toBe(1)
+  })
+
+  test('user-supplied envKeys array is defensively copied and frozen', () => {
+    const userArray = ['STRIPE_KEY']
+    const merged = mergeWithDefaults({ redact: { envKeys: userArray } })
+    expect(Object.isFrozen(merged.redact.envKeys)).toBe(true)
+    userArray.push('OPENAI_KEY')
+    expect(merged.redact.envKeys.length).toBe(1)
+  })
 })
 
 describe('validateConfig: redact field', () => {
@@ -252,11 +277,15 @@ describe('validateConfig: redact field', () => {
   })
 
   test('rejects non-array envKeys', () => {
-    expect(() => validateConfig({ redact: { envKeys: 'foo' } })).toThrow(/array of strings/)
+    expect(() => validateConfig({ redact: { envKeys: 'foo' } })).toThrow(
+      /envKeys must be an array$/,
+    )
   })
 
   test('rejects envKeys with non-string entries', () => {
-    expect(() => validateConfig({ redact: { envKeys: [1, 2] } })).toThrow(/array of strings/)
+    expect(() => validateConfig({ redact: { envKeys: [1, 2] } })).toThrow(
+      /items must all be strings/,
+    )
   })
 
   test('rejects non-object redact', () => {
@@ -265,5 +294,37 @@ describe('validateConfig: redact field', () => {
 
   test('user can opt out of bundle by setting bundledPatterns: false', () => {
     expect(() => validateConfig({ redact: { bundledPatterns: false } })).not.toThrow()
+  })
+
+  test('accepts custom rule with valid description', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [{ name: 'my-rule', pattern: /A/, description: 'matches A' }],
+        },
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts custom rule without description', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [{ name: 'my-rule', pattern: /A/ }],
+        },
+      }),
+    ).not.toThrow()
+  })
+
+  test('rejects custom rule with non-string description', () => {
+    expect(() =>
+      validateConfig({
+        redact: {
+          customPatterns: [
+            { name: 'my-rule', pattern: /A/, description: 123 as unknown as string },
+          ],
+        },
+      }),
+    ).toThrow(/description must be a string/)
   })
 })


### PR DESCRIPTION
## What Changed

- Adds `Config.redact: RedactConfig` composed field alongside existing deprecated `Config.redactEnvKeys`.
- `mergeWithDefaults` populates both fields consistently (`redact.envKeys` takes precedence; both fields stay in sync).
- `validateConfig` extended with `validateRedact` and `validateRule` helpers covering all 6 RedactConfig fields.
- 31 new tests across 3 describe blocks.

## Notes

- Two-fields-in-sync invariant: when user provides either `redactEnvKeys` (older style) or `redact: { envKeys }` (newer style), or both, `mergeWithDefaults` resolves to a single value used for both fields. Precedence: `redact.envKeys` > `redactEnvKeys` > default.
- Custom regex `g` flag NOT required: the pipeline normalizes regex to ensure `g` flag is set at call time. `validateRule` accepts custom regex with or without the `g` flag.
- Defensive freezing: user-supplied arrays (`customPatterns`, `suppressPatterns`, `envKeys`) are spread-copied and frozen during merge so mutations of the original user array don't affect the resolved Config.
- Deprecated `redactEnvKeys` stays through the recorder rewrite for backward compatibility. The deprecation JSDoc names the replacement.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (327 passed, 1 pre-existing skip; +37 new tests vs main)
- [x] `npm run build` produces clean dist/