### PR TITLE
feat: bump cassette schema to v2 (recordedBy + redactions metadata)

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -22,5 +22,6 @@ export function record(
   session.newRecordings.push({
     call: { ...call, env: redacted },
     result,
+    redactions: [],
   })
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -10,10 +10,7 @@ const REVIEW_WARNING =
   'option parity). Run `shell-cassette scan <path>` to verify before committing. ' +
   'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md'
 
-export function serialize(
-  file: CassetteFile,
-  recordedBy: { name: string; version: string } | null = null,
-): string {
+export function serialize(file: CassetteFile): string {
   validateBeforeSerialize(file)
   // Build object in canonical key order for stable diffs.
   // _warning is an additive optional field meant for code-review eyeballs:
@@ -23,7 +20,7 @@ export function serialize(
   const ordered = {
     version: SCHEMA_VERSION,
     _warning: REVIEW_WARNING,
-    _recorded_by: recordedBy,
+    _recorded_by: file.recordedBy,
     recordings: file.recordings.map(orderRecording),
   }
   return `${JSON.stringify(ordered, null, 2)}\n`

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,14 +1,19 @@
 import { BinaryOutputError, CassetteCorruptError } from './errors.js'
-import type { CassetteFile, Recording } from './types.js'
+import type { CassetteFile, Recording, RedactionEntry } from './types.js'
 
-const SCHEMA_VERSION = 1
+const SCHEMA_VERSION = 2
 
 const REVIEW_WARNING =
-  'REVIEW BEFORE COMMITTING. shell-cassette redacts curated env-key values; ' +
-  'it does NOT redact stdout, stderr, args, or env vars with non-curated names. ' +
-  'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md#what-shell-cassette-does-not-redact'
+  'REVIEW BEFORE COMMITTING. shell-cassette redacts bundled credential patterns + ' +
+  'curated env-key values + your custom rules. It does NOT redact: AWS Secret Access Keys, ' +
+  'JWTs (without opt-in), encoded credentials, binary output, cwd, stdin (until v0.5 ships ' +
+  'option parity). Run `shell-cassette scan <path>` to verify before committing. ' +
+  'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md'
 
-export function serialize(file: CassetteFile): string {
+export function serialize(
+  file: CassetteFile,
+  recordedBy: { name: string; version: string } | null = null,
+): string {
   validateBeforeSerialize(file)
   // Build object in canonical key order for stable diffs.
   // _warning is an additive optional field meant for code-review eyeballs:
@@ -16,8 +21,9 @@ export function serialize(file: CassetteFile): string {
   // even if they never saw the stderr log when it was recorded.
   // Underscore prefix marks it as metadata (deserialize ignores unknown fields).
   const ordered = {
-    version: file.version,
+    version: SCHEMA_VERSION,
     _warning: REVIEW_WARNING,
+    _recorded_by: recordedBy,
     recordings: file.recordings.map(orderRecording),
   }
   return `${JSON.stringify(ordered, null, 2)}\n`
@@ -41,6 +47,7 @@ function orderRecording(rec: Recording) {
       durationMs: rec.result.durationMs,
       aborted: rec.result.aborted,
     },
+    _redactions: rec.redactions,
   }
 }
 
@@ -88,39 +95,49 @@ export function deserialize(text: string): CassetteFile {
   if (!('version' in obj)) {
     throw new CassetteCorruptError('cassette missing `version` field')
   }
-  if (obj.version !== SCHEMA_VERSION) {
+  const version = obj.version
+  if (version !== 1 && version !== 2) {
     throw new CassetteCorruptError(
-      `cassette version ${obj.version} unknown; expected ${SCHEMA_VERSION}. Delete and re-record.`,
+      `cassette version ${version} unknown; expected 1 or 2. ` +
+        `If recorded with a newer shell-cassette, upgrade. Otherwise delete and re-record.`,
     )
   }
   if (!Array.isArray(obj.recordings)) {
     throw new CassetteCorruptError('cassette `recordings` must be an array')
   }
 
-  const recordings = (obj.recordings as LegacyRecording[]).map(normalizeLegacyRecording)
+  const recordings = (obj.recordings as LegacyRecording[]).map(normalizeRecording)
+  const recordedBy =
+    version === 2 && obj._recorded_by && typeof obj._recorded_by === 'object'
+      ? (obj._recorded_by as { name: string; version: string })
+      : null
+
   return {
-    version: SCHEMA_VERSION,
+    version: version as 1 | 2,
+    recordedBy,
     recordings,
   }
 }
 
-// On disk, `allLines` and `aborted` may be absent (cassettes recorded before
-// either field existed). Both default during normalization: allLines → null,
-// aborted → false. New optional fields go here, not as a schema bump.
-type LegacyRecording = Omit<Recording, 'result'> & {
+// On disk, `allLines`, `aborted`, and `_redactions` may be absent (cassettes
+// recorded before those fields existed). All default during normalization.
+type LegacyRecording = {
+  call: Recording['call']
   result: Omit<Recording['result'], 'allLines' | 'aborted'> & {
     allLines?: string[] | null
     aborted?: boolean
   }
+  _redactions?: RedactionEntry[]
 }
 
-function normalizeLegacyRecording(rec: LegacyRecording): Recording {
+function normalizeRecording(rec: LegacyRecording): Recording {
   return {
-    ...rec,
+    call: rec.call,
     result: {
       ...rec.result,
       allLines: rec.result.allLines ?? null,
       aborted: rec.result.aborted ?? false,
     },
+    redactions: rec._redactions ?? [],
   }
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -10,6 +10,16 @@ const REVIEW_WARNING =
   'option parity). Run `shell-cassette scan <path>` to verify before committing. ' +
   'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md'
 
+/**
+ * Serialize a CassetteFile to JSON. Always emits SCHEMA_VERSION (currently 2)
+ * regardless of `file.version` — serialize is upgrade-on-write. A v1 cassette
+ * passed in is materialized as v2 on disk; deserialize handles the inverse
+ * by accepting v1 input and normalizing missing fields.
+ *
+ * `file.recordedBy` is the single source of truth for the cassette's recorder
+ * identity. Production callers populate it with { name, version } from
+ * package.json; tools constructing cassettes manually may set it to null.
+ */
 export function serialize(file: CassetteFile): string {
   validateBeforeSerialize(file)
   // Build object in canonical key order for stable diffs.
@@ -104,9 +114,15 @@ export function deserialize(text: string): CassetteFile {
   }
 
   const recordings = (obj.recordings as LegacyRecording[]).map(normalizeRecording)
-  const recordedBy =
+  const recordedByObj =
     version === 2 && obj._recorded_by && typeof obj._recorded_by === 'object'
-      ? (obj._recorded_by as { name: string; version: string })
+      ? (obj._recorded_by as Record<string, unknown>)
+      : null
+  const recordedBy =
+    recordedByObj &&
+    typeof recordedByObj.name === 'string' &&
+    typeof recordedByObj.version === 'string'
+      ? { name: recordedByObj.name, version: recordedByObj.version }
       : null
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,10 +25,23 @@ export type Result = {
 export type Recording = {
   call: Call
   result: Result
+  /**
+   * Per-recording redaction summary. v2 schema. v1 cassettes load with `[]`.
+   * Aggregated by (rule, source) at record time. Used by CLI tooling
+   * (scan, show, re-redact) for header summaries and counter ceiling
+   * computation without walking the body.
+   */
+  redactions: RedactionEntry[]
 }
 
 export type CassetteFile = {
-  version: 1
+  version: 1 | 2
+  /**
+   * Top-level metadata: which shell-cassette version recorded this cassette.
+   * v0.4+ writes `{ name, version }`; loaded as `null` for v1 cassettes that
+   * predate the field.
+   */
+  recordedBy: { name: string; version: string } | null
   recordings: Recording[]
 }
 

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { writeCassetteFile } from './io.js'
 import { defaultCanonicalize } from './matcher.js'
 import { serialize } from './serialize.js'
@@ -9,6 +11,15 @@ import {
 } from './state.js'
 import { summarizeSession } from './summary.js'
 import type { Canonicalize, CassetteFile, CassetteSession, UseCassetteOptions } from './types.js'
+
+const PACKAGE_VERSION = (
+  JSON.parse(
+    readFileSync(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json'),
+      'utf8',
+    ),
+  ) as { version: string }
+).version
 
 // Public overloads
 export function useCassette<T>(cassettePath: string, fn: () => Promise<T>): Promise<T>
@@ -62,7 +73,7 @@ async function persistSession(session: CassetteSession): Promise<void> {
   const existingRecordings = session.loadedFile?.recordings ?? []
   const merged: CassetteFile = {
     version: 2,
-    recordedBy: null,
+    recordedBy: { name: 'shell-cassette', version: PACKAGE_VERSION },
     recordings: [...existingRecordings, ...session.newRecordings],
   }
   const json = serialize(merged)

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -61,7 +61,8 @@ async function persistSession(session: CassetteSession): Promise<void> {
 
   const existingRecordings = session.loadedFile?.recordings ?? []
   const merged: CassetteFile = {
-    version: 1,
+    version: 2,
+    recordedBy: null,
     recordings: [...existingRecordings, ...session.newRecordings],
   }
   const json = serialize(merged)

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { writeCassetteFile } from './io.js'
 import { defaultCanonicalize } from './matcher.js'
 import { serialize } from './serialize.js'
@@ -11,15 +9,7 @@ import {
 } from './state.js'
 import { summarizeSession } from './summary.js'
 import type { Canonicalize, CassetteFile, CassetteSession, UseCassetteOptions } from './types.js'
-
-const PACKAGE_VERSION = (
-  JSON.parse(
-    readFileSync(
-      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json'),
-      'utf8',
-    ),
-  ) as { version: string }
-).version
+import { RECORDED_BY } from './version.js'
 
 // Public overloads
 export function useCassette<T>(cassettePath: string, fn: () => Promise<T>): Promise<T>
@@ -73,7 +63,7 @@ async function persistSession(session: CassetteSession): Promise<void> {
   const existingRecordings = session.loadedFile?.recordings ?? []
   const merged: CassetteFile = {
     version: 2,
-    recordedBy: { name: 'shell-cassette', version: PACKAGE_VERSION },
+    recordedBy: RECORDED_BY,
     recordings: [...existingRecordings, ...session.newRecordings],
   }
   const json = serialize(merged)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Static `import ... from '../package.json' with { type: 'json' }` would widen
+// tsconfig's rootDir past src/. readFileSync sidesteps the compiler constraint
+// and pays only one synchronous disk read at module init (cached by Node's
+// module loader for any second importer).
+const pkg = JSON.parse(
+  readFileSync(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json'),
+    'utf8',
+  ),
+) as { name: string; version: string }
+
+export const PACKAGE_NAME: string = pkg.name
+export const PACKAGE_VERSION: string = pkg.version
+
+/**
+ * Identifying tuple written to `_recorded_by` on every cassette this version
+ * of shell-cassette emits. Read from package.json once at module init.
+ */
+export const RECORDED_BY: { readonly name: string; readonly version: string } = Object.freeze({
+  name: PACKAGE_NAME,
+  version: PACKAGE_VERSION,
+})

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -11,6 +11,9 @@
 //
 // See docs/vitest-plugin.md for details.
 
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { getConfig } from './config.js'
 import { ConcurrencyError, MissingPeerDependencyError } from './errors.js'
 import { writeCassetteFile } from './io.js'
@@ -26,6 +29,15 @@ import {
 import { summarizeSession } from './summary.js'
 import type { CassetteSession } from './types.js'
 import { wrapRegistrationError } from './vitest-error.js'
+
+const PACKAGE_VERSION = (
+  JSON.parse(
+    readFileSync(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json'),
+      'utf8',
+    ),
+  ) as { version: string }
+).version
 
 // Resolve vitest via dynamic import so we can wrap "Cannot find module" with
 // an actionable error. Top-level await means consumers importing
@@ -91,7 +103,7 @@ try {
       const existingRecordings = session.loadedFile?.recordings ?? []
       const merged = {
         version: 2 as const,
-        recordedBy: null,
+        recordedBy: { name: 'shell-cassette', version: PACKAGE_VERSION },
         recordings: [...existingRecordings, ...session.newRecordings],
       }
       await writeCassetteFile(session.path, serialize(merged))

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -11,9 +11,6 @@
 //
 // See docs/vitest-plugin.md for details.
 
-import { readFileSync } from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { getConfig } from './config.js'
 import { ConcurrencyError, MissingPeerDependencyError } from './errors.js'
 import { writeCassetteFile } from './io.js'
@@ -28,16 +25,8 @@ import {
 } from './state.js'
 import { summarizeSession } from './summary.js'
 import type { CassetteSession } from './types.js'
+import { RECORDED_BY } from './version.js'
 import { wrapRegistrationError } from './vitest-error.js'
-
-const PACKAGE_VERSION = (
-  JSON.parse(
-    readFileSync(
-      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json'),
-      'utf8',
-    ),
-  ) as { version: string }
-).version
 
 // Resolve vitest via dynamic import so we can wrap "Cannot find module" with
 // an actionable error. Top-level await means consumers importing
@@ -103,7 +92,7 @@ try {
       const existingRecordings = session.loadedFile?.recordings ?? []
       const merged = {
         version: 2 as const,
-        recordedBy: { name: 'shell-cassette', version: PACKAGE_VERSION },
+        recordedBy: RECORDED_BY,
         recordings: [...existingRecordings, ...session.newRecordings],
       }
       await writeCassetteFile(session.path, serialize(merged))

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -90,7 +90,8 @@ try {
     if (session && session.newRecordings.length > 0) {
       const existingRecordings = session.loadedFile?.recordings ?? []
       const merged = {
-        version: 1 as const,
+        version: 2 as const,
+        recordedBy: null,
         recordings: [...existingRecordings, ...session.newRecordings],
       }
       await writeCassetteFile(session.path, serialize(merged))

--- a/tests/error-path/canonicalize-limits.test.ts
+++ b/tests/error-path/canonicalize-limits.test.ts
@@ -14,6 +14,7 @@ import { useCassette } from '../../src/use-cassette.js'
 function makeCassette(args: string[]): CassetteFile {
   return {
     version: 1,
+    recordedBy: null,
     recordings: [
       {
         call: {
@@ -32,6 +33,7 @@ function makeCassette(args: string[]): CassetteFile {
           durationMs: 1,
           aborted: false,
         },
+        redactions: [],
       },
     ],
   }

--- a/tests/error-path/tinyexec-errors.test.ts
+++ b/tests/error-path/tinyexec-errors.test.ts
@@ -61,14 +61,14 @@ describe('tinyexec error paths', () => {
   })
 
   test('ReplayMissError when cassette empty in replay mode', async () => {
-    setActiveCassette(makeSession({ loadedFile: { version: 1, recordings: [] } }))
+    setActiveCassette(makeSession({ loadedFile: { version: 1, recordedBy: null, recordings: [] } }))
     process.env.SHELL_CASSETTE_MODE = 'replay'
 
     await expect(x('echo', ['unrecorded'])).rejects.toBeInstanceOf(ReplayMissError)
   })
 
   test('ReplayMissError message includes the call signature', async () => {
-    setActiveCassette(makeSession({ loadedFile: { version: 1, recordings: [] } }))
+    setActiveCassette(makeSession({ loadedFile: { version: 1, recordedBy: null, recordings: [] } }))
     process.env.SHELL_CASSETTE_MODE = 'replay'
 
     try {

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -13,7 +13,7 @@ export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteS
     name: 'test',
     path: '/tmp/test.json',
     scopeDefault: 'auto',
-    loadedFile: { version: 1, recordedBy: null, recordings: [] },
+    loadedFile: { version: 2, recordedBy: null, recordings: [] },
     matcher: null,
     canonicalize,
     newRecordings: [],

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -13,7 +13,7 @@ export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteS
     name: 'test',
     path: '/tmp/test.json',
     scopeDefault: 'auto',
-    loadedFile: { version: 1, recordings: [] },
+    loadedFile: { version: 1, recordedBy: null, recordings: [] },
     matcher: null,
     canonicalize,
     newRecordings: [],

--- a/tests/integration/use-cassette.test.ts
+++ b/tests/integration/use-cassette.test.ts
@@ -39,7 +39,7 @@ describe('useCassette', () => {
 
       const content = await readFile(cassettePath, 'utf8')
       const parsed = JSON.parse(content)
-      expect(parsed.version).toBe(1)
+      expect(parsed.version).toBe(2)
       expect(parsed.recordings).toHaveLength(1)
       expect(parsed.recordings[0].call.command).toBe('node')
     } finally {

--- a/tests/integration/wrapper-tinyexec.test.ts
+++ b/tests/integration/wrapper-tinyexec.test.ts
@@ -49,7 +49,7 @@ describe('tinyexec integration', () => {
 
     const content = await readFile(cassettePath, 'utf8')
     const parsed = JSON.parse(content)
-    expect(parsed.version).toBe(1)
+    expect(parsed.version).toBe(2)
     expect(parsed.recordings).toHaveLength(1)
     expect(parsed.recordings[0].call.command).toBe('echo')
     expect(parsed.recordings[0].result.stdoutLines).toEqual(['recorded-output'])
@@ -60,6 +60,7 @@ describe('tinyexec integration', () => {
 
     const cassetteJson = serialize({
       version: 1,
+      recordedBy: null,
       recordings: [
         {
           call: { command: 'echo', args: ['canned'], cwd: null, env: {}, stdin: null },
@@ -72,6 +73,7 @@ describe('tinyexec integration', () => {
             durationMs: 0,
             aborted: false,
           },
+          redactions: [],
         },
       ],
     })
@@ -110,6 +112,7 @@ describe('tinyexec integration', () => {
 
     const cassetteJson = serialize({
       version: 1,
+      recordedBy: null,
       recordings: [
         {
           call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
@@ -122,6 +125,7 @@ describe('tinyexec integration', () => {
             durationMs: 0,
             aborted: false,
           },
+          redactions: [],
         },
       ],
     })

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -97,7 +97,7 @@ describe('wrapped execa', () => {
 
       await writeCassetteFile(
         cassettePath,
-        serialize({ version: 1, recordings: recordSession.newRecordings }),
+        serialize({ version: 2, recordedBy: null, recordings: recordSession.newRecordings }),
       )
 
       // Replay

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -37,7 +37,7 @@ const dummyResult: Result = {
   aborted: false,
 }
 
-const recOf = (call: Call): Recording => ({ call, result: dummyResult })
+const recOf = (call: Call): Recording => ({ call, result: dummyResult, redactions: [] })
 
 describe('normalizeTmpPath properties', () => {
   test('idempotence: normalizeTmpPath(normalizeTmpPath(s)) === normalizeTmpPath(s)', () => {

--- a/tests/property/serialize.property.test.ts
+++ b/tests/property/serialize.property.test.ts
@@ -53,13 +53,41 @@ const genResult: fc.Arbitrary<Result> = fc.record({
   aborted: fc.boolean(),
 })
 
+const genRedactionEntry = fc.record({
+  rule: fc.string({ minLength: 1, maxLength: 20 }).filter((s) => s.trim().length > 0),
+  source: fc.constantFrom(
+    'env' as const,
+    'args' as const,
+    'stdout' as const,
+    'stderr' as const,
+    'allLines' as const,
+  ),
+  count: fc.integer({ min: 1, max: 10 }),
+})
+
 const genRecording: fc.Arbitrary<Recording> = fc.record({
   call: genCall,
   result: genResult,
+  redactions: fc.array(genRedactionEntry, { maxLength: 3 }),
 })
 
+const genSemver = fc
+  .tuple(
+    fc.integer({ min: 0, max: 9 }),
+    fc.integer({ min: 0, max: 9 }),
+    fc.integer({ min: 0, max: 9 }),
+  )
+  .map(([major, minor, patch]) => `${major}.${minor}.${patch}`)
+
 const genCassetteFile: fc.Arbitrary<CassetteFile> = fc.record({
-  version: fc.constant(1 as const),
+  version: fc.constant(2 as const),
+  recordedBy: fc.option(
+    fc.record({
+      name: fc.constant('shell-cassette'),
+      version: genSemver,
+    }),
+    { nil: null },
+  ),
   recordings: fc.array(genRecording, { maxLength: 5 }),
 })
 

--- a/tests/property/serialize.property.test.ts
+++ b/tests/property/serialize.property.test.ts
@@ -71,6 +71,9 @@ const genRecording: fc.Arbitrary<Recording> = fc.record({
   redactions: fc.array(genRedactionEntry, { maxLength: 3 }),
 })
 
+// fc.tuple(int, int, int).map(([M, m, p]) => `${M}.${m}.${p}`) generates
+// semver strings directly. Earlier versions used fc.string().filter() which
+// rejected ~99% of generations and caused test runs to hit the 60s timeout.
 const genSemver = fc
   .tuple(
     fc.integer({ min: 0, max: 9 }),

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -22,6 +22,7 @@ const recordingOf = (command: string, args: string[], stdout = ''): Recording =>
     durationMs: 1,
     aborted: false,
   },
+  redactions: [],
 })
 
 describe('defaultCanonicalize', () => {

--- a/tests/unit/serialize-v2.test.ts
+++ b/tests/unit/serialize-v2.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'vitest'
+import { CassetteCorruptError } from '../../src/errors.js'
+import { deserialize, serialize } from '../../src/serialize.js'
+import type { CassetteFile } from '../../src/types.js'
+
+const minimalV2: CassetteFile = {
+  version: 2,
+  recordedBy: { name: 'shell-cassette', version: '0.4.0' },
+  recordings: [
+    {
+      call: { command: 'node', args: ['-v'], cwd: null, env: {}, stdin: null },
+      result: {
+        stdoutLines: ['v18.0.0'],
+        stderrLines: [],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 100,
+        aborted: false,
+      },
+      redactions: [],
+    },
+  ],
+}
+
+describe('serialize v2', () => {
+  test('emits version: 2 in JSON', () => {
+    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    const parsed = JSON.parse(out) as Record<string, unknown>
+    expect(parsed.version).toBe(2)
+  })
+
+  test('emits _recorded_by from arg', () => {
+    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    const parsed = JSON.parse(out) as Record<string, unknown>
+    expect(parsed._recorded_by).toEqual({ name: 'shell-cassette', version: '0.4.0' })
+  })
+
+  test('emits null _recorded_by when not provided', () => {
+    const out = serialize(minimalV2)
+    const parsed = JSON.parse(out) as Record<string, unknown>
+    expect(parsed._recorded_by).toBe(null)
+  })
+
+  test('emits per-recording _redactions array', () => {
+    const baseRecording = minimalV2.recordings[0]
+    if (!baseRecording) throw new Error('minimalV2 must have at least one recording')
+    const file: CassetteFile = {
+      ...minimalV2,
+      recordings: [
+        {
+          ...baseRecording,
+          redactions: [{ rule: 'github-pat-classic', source: 'env', count: 1 }],
+        },
+      ],
+    }
+    const out = serialize(file, { name: 'shell-cassette', version: '0.4.0' })
+    const parsed = JSON.parse(out) as { recordings: Array<{ _redactions: unknown }> }
+    expect(parsed.recordings[0]?._redactions).toEqual([
+      { rule: 'github-pat-classic', source: 'env', count: 1 },
+    ])
+  })
+
+  test('emits trailing newline', () => {
+    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    expect(out.endsWith('\n')).toBe(true)
+  })
+})
+
+describe('deserialize v2', () => {
+  test('round-trip preserves all fields', () => {
+    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    const parsed = deserialize(out)
+    expect(parsed).toEqual(minimalV2)
+  })
+
+  test('handles missing _recorded_by (loads as null)', () => {
+    const json = JSON.stringify({
+      version: 2,
+      recordings: [],
+    })
+    const parsed = deserialize(json)
+    expect(parsed.recordedBy).toBe(null)
+  })
+
+  test('handles missing per-recording _redactions (loads as [])', () => {
+    const json = JSON.stringify({
+      version: 2,
+      recordings: [
+        {
+          call: { command: 'node', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+        },
+      ],
+    })
+    const parsed = deserialize(json)
+    expect(parsed.recordings[0]?.redactions).toEqual([])
+  })
+})
+
+describe('deserialize v1 (forward compat)', () => {
+  test('v1 cassette loads with recordedBy: null and redactions: []', () => {
+    const json = JSON.stringify({
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'node', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+        },
+      ],
+    })
+    const parsed = deserialize(json)
+    expect(parsed.version).toBe(1)
+    expect(parsed.recordedBy).toBe(null)
+    expect(parsed.recordings[0]?.redactions).toEqual([])
+  })
+
+  test('v1 cassette without aborted/allLines fields normalizes correctly', () => {
+    const json = JSON.stringify({
+      version: 1,
+      recordings: [
+        {
+          call: { command: 'node', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+          },
+        },
+      ],
+    })
+    const parsed = deserialize(json)
+    expect(parsed.recordings[0]?.result.aborted).toBe(false)
+    expect(parsed.recordings[0]?.result.allLines).toBe(null)
+  })
+})
+
+describe('deserialize: version rejection', () => {
+  test('version 3 throws CassetteCorruptError', () => {
+    const json = JSON.stringify({ version: 3, recordings: [] })
+    expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+  })
+
+  test('version 0 throws CassetteCorruptError', () => {
+    const json = JSON.stringify({ version: 0, recordings: [] })
+    expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+  })
+
+  test('version "1" (string) throws CassetteCorruptError (must be numeric)', () => {
+    const json = JSON.stringify({ version: '1', recordings: [] })
+    expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+  })
+
+  test('missing version field throws CassetteCorruptError', () => {
+    const json = JSON.stringify({ recordings: [] })
+    expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+  })
+
+  test('malformed JSON throws CassetteCorruptError', () => {
+    expect(() => deserialize('{not valid')).toThrow(CassetteCorruptError)
+  })
+
+  test('version 3 error message instructs to upgrade', () => {
+    const json = JSON.stringify({ version: 3, recordings: [] })
+    expect(() => deserialize(json)).toThrow(/upgrade/)
+  })
+})

--- a/tests/unit/serialize-v2.test.ts
+++ b/tests/unit/serialize-v2.test.ts
@@ -25,19 +25,19 @@ const minimalV2: CassetteFile = {
 
 describe('serialize v2', () => {
   test('emits version: 2 in JSON', () => {
-    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    const out = serialize(minimalV2)
     const parsed = JSON.parse(out) as Record<string, unknown>
     expect(parsed.version).toBe(2)
   })
 
-  test('emits _recorded_by from arg', () => {
-    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+  test('emits _recorded_by from file.recordedBy', () => {
+    const out = serialize(minimalV2)
     const parsed = JSON.parse(out) as Record<string, unknown>
     expect(parsed._recorded_by).toEqual({ name: 'shell-cassette', version: '0.4.0' })
   })
 
-  test('emits null _recorded_by when not provided', () => {
-    const out = serialize(minimalV2)
+  test('emits null _recorded_by when file.recordedBy is null', () => {
+    const out = serialize({ ...minimalV2, recordedBy: null })
     const parsed = JSON.parse(out) as Record<string, unknown>
     expect(parsed._recorded_by).toBe(null)
   })
@@ -54,7 +54,7 @@ describe('serialize v2', () => {
         },
       ],
     }
-    const out = serialize(file, { name: 'shell-cassette', version: '0.4.0' })
+    const out = serialize(file)
     const parsed = JSON.parse(out) as { recordings: Array<{ _redactions: unknown }> }
     expect(parsed.recordings[0]?._redactions).toEqual([
       { rule: 'github-pat-classic', source: 'env', count: 1 },
@@ -62,14 +62,14 @@ describe('serialize v2', () => {
   })
 
   test('emits trailing newline', () => {
-    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    const out = serialize(minimalV2)
     expect(out.endsWith('\n')).toBe(true)
   })
 })
 
 describe('deserialize v2', () => {
   test('round-trip preserves all fields', () => {
-    const out = serialize(minimalV2, { name: 'shell-cassette', version: '0.4.0' })
+    const out = serialize(minimalV2)
     const parsed = deserialize(out)
     expect(parsed).toEqual(minimalV2)
   })

--- a/tests/unit/serialize-v2.test.ts
+++ b/tests/unit/serialize-v2.test.ts
@@ -68,6 +68,16 @@ describe('serialize v2', () => {
 })
 
 describe('deserialize v2', () => {
+  test('rejects malformed _recorded_by (non-string name/version) and loads as null', () => {
+    const json = JSON.stringify({
+      version: 2,
+      _recorded_by: { name: 123, version: null },
+      recordings: [],
+    })
+    const parsed = deserialize(json)
+    expect(parsed.recordedBy).toBe(null)
+  })
+
   test('round-trip preserves all fields', () => {
     const out = serialize(minimalV2)
     const parsed = deserialize(out)

--- a/tests/unit/serialize.test.ts
+++ b/tests/unit/serialize.test.ts
@@ -37,7 +37,8 @@ describe('deserialize', () => {
 describe('serialize', () => {
   test('round-trip for single recording', () => {
     const file: CassetteFile = {
-      version: 1,
+      version: 2,
+      recordedBy: null,
       recordings: [
         {
           call: {
@@ -56,6 +57,7 @@ describe('serialize', () => {
             durationMs: 5,
             aborted: false,
           },
+          redactions: [],
         },
       ],
     }
@@ -66,16 +68,18 @@ describe('serialize', () => {
 
   test('output uses 2-space indent and canonical key order', () => {
     const file: CassetteFile = {
-      version: 1,
+      version: 2,
+      recordedBy: null,
       recordings: [],
     }
     const json = serialize(file)
-    expect(json.startsWith('{\n  "version": 1')).toBe(true)
+    expect(json.startsWith('{\n  "version": 2')).toBe(true)
   })
 
   test('preserves trailing newline via empty string at end of stdoutLines', () => {
     const file: CassetteFile = {
-      version: 1,
+      version: 2,
+      recordedBy: null,
       recordings: [
         {
           call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
@@ -88,6 +92,7 @@ describe('serialize', () => {
             durationMs: 1,
             aborted: false,
           },
+          redactions: [],
         },
       ],
     }
@@ -97,7 +102,8 @@ describe('serialize', () => {
 
   test('round-trip preserves aborted: true', () => {
     const file: CassetteFile = {
-      version: 1,
+      version: 2,
+      recordedBy: null,
       recordings: [
         {
           call: { command: 'sleep', args: ['10'], cwd: null, env: {}, stdin: null },
@@ -110,6 +116,7 @@ describe('serialize', () => {
             durationMs: 42,
             aborted: true,
           },
+          redactions: [],
         },
       ],
     }
@@ -141,7 +148,8 @@ describe('serialize', () => {
 
   test('round-trip preserves allLines when populated', () => {
     const file: CassetteFile = {
-      version: 1,
+      version: 2,
+      recordedBy: null,
       recordings: [
         {
           call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
@@ -154,6 +162,7 @@ describe('serialize', () => {
             durationMs: 1,
             aborted: false,
           },
+          redactions: [],
         },
       ],
     }
@@ -163,7 +172,8 @@ describe('serialize', () => {
 
   test('throws BinaryOutputError if attempting to serialize non-string in stdoutLines', () => {
     const bad = {
-      version: 1,
+      version: 2,
+      recordedBy: null,
       recordings: [
         {
           call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
@@ -176,6 +186,7 @@ describe('serialize', () => {
             durationMs: 1,
             aborted: false,
           },
+          redactions: [],
         },
       ],
     } as CassetteFile

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -114,9 +114,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: true,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -157,9 +158,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -186,9 +188,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -208,9 +211,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -231,9 +235,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -254,9 +259,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -277,9 +283,10 @@ describe('tinyexec adapter', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -141,9 +141,10 @@ describe('runWrapped (envelope)', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -157,7 +158,7 @@ describe('runWrapped (envelope)', () => {
 
   test('replay path throws ReplayMissError when no match', async () => {
     const session = makeSession({
-      loadedFile: { version: 1, recordings: [] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [] },
     })
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
@@ -215,10 +216,11 @@ describe('runWrapped (envelope)', () => {
         durationMs: 0,
         aborted: false,
       },
+      redactions: [],
     }
     const session = makeSession({
       scopeDefault: 'auto',
-      loadedFile: { version: 1, recordings: [recording] },
+      loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
     setActiveCassette(session)
     // ack intentionally NOT set


### PR DESCRIPTION
## What Changed

- Bumps cassette schema from v1 to v2: top-level `_recorded_by: { name, version } | null` and per-recording `_redactions: RedactionEntry[]`.
- `deserialize()` accepts both v1 and v2; rejects v3+, v0, non-numeric, missing version, malformed JSON with `CassetteCorruptError`.
- v1 cassettes load with `recordedBy: null` and `redactions: []` (forward compat preserved).
- Production callers populate `recordedBy` with the live shell-cassette package version at write time.

## Type changes

- `CassetteFile.version`: `1` to `1 | 2`.
- `CassetteFile.recordedBy`: new required field (`{ name, version } | null`).
- `Recording.redactions`: new required field (`RedactionEntry[]`).
- ~30 test sites updated mechanically with the new fields.

## Notes

`serialize()` reads `recordedBy` from `file.recordedBy` only. Single source of truth on the cassette object. Round-trip preservation is automatic; the re-redact subcommand doesn't have to thread the field manually. Cassettes ship with real `recordedBy` populated, not always-null placeholder.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (343 passed, 1 pre-existing skip; +16 new tests vs main from `serialize-v2.test.ts`)
- [x] `npm run build` produces clean dist/