### PR TITLE
feat(redact): wire redaction pipeline into recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ shell-cassette does **NOT** redact:
 
 - stdout / stderr content
 - command args
-- env vars with non-curated names (`STRIPE_KEY`, `OPENAI_KEY`, etc.; extend via `redactEnvKeys` config)
+- env vars with non-curated names (`STRIPE_KEY`, `OPENAI_KEY`, etc.; extend via `redact.envKeys` config)
 - paths in cwd
 
 **Always review cassettes before committing.** Pattern-based detection for stdout/stderr/args (GitHub PATs, AWS keys, Stripe keys, etc.) isn't built yet. Review by eye.
@@ -189,7 +189,9 @@ export default {
   cassetteDir: '__cassettes__',
 
   // Adds to the curated env-key redaction list (substring, case-insensitive)
-  redactEnvKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+  redact: {
+    envKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+  },
 
   // Custom canonicalize fn (default: defaultCanonicalize, command exact +
   // args with absolute mkdtemp paths normalized to <tmp>; cwd, env, stdin

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,7 +157,9 @@ Add the env var name to your `shell-cassette.config.js`:
 
 ```js
 export default {
-  redactEnvKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+  redact: {
+    envKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+  },
 }
 ```
 

--- a/src/ack.ts
+++ b/src/ack.ts
@@ -5,7 +5,7 @@ const HELP_TEXT = `refusing to record without redaction acknowledgment.
 shell-cassette v0.1 redacts env var values when KEY matches:
   TOKEN, SECRET, PASSWORD, PASSWD, APIKEY, API_KEY, CREDENTIAL,
   PRIVATE_KEY, AUTH_TOKEN, BEARER_TOKEN, JWT
-(extensible via shell-cassette.config.{js,mjs} \`redactEnvKeys\`)
+(extensible via shell-cassette.config.{js,mjs} \`redact.envKeys\`)
 
 It does NOT redact:
   - stdout / stderr content

--- a/src/ack.ts
+++ b/src/ack.ts
@@ -1,11 +1,12 @@
 import { AckRequiredError } from './errors.js'
+import { BUNDLED_PATTERNS } from './redact-patterns.js'
 
 const HELP_TEXT = `shell-cassette is about to RECORD subprocess calls into a cassette file.
 
 What gets redacted (default ON):
   * Curated env-key values (TOKEN, SECRET, PASSWORD, JWT, etc., case-insensitive substring)
   * User-extended env-key list (config.redact.envKeys)
-  * 25 bundled credential patterns (GitHub, AWS access key ID, Stripe, OpenAI, Anthropic,
+  * ${BUNDLED_PATTERNS.length} bundled credential patterns (GitHub, AWS access key ID, Stripe, OpenAI, Anthropic,
     Google API, Slack, GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI,
     Discord, Square) across env values, args, stdout, stderr, allLines
   * User-supplied custom rules (config.redact.customPatterns)

--- a/src/ack.ts
+++ b/src/ack.ts
@@ -1,22 +1,28 @@
 import { AckRequiredError } from './errors.js'
 
-const HELP_TEXT = `refusing to record without redaction acknowledgment.
+const HELP_TEXT = `shell-cassette is about to RECORD subprocess calls into a cassette file.
 
-shell-cassette v0.1 redacts env var values when KEY matches:
-  TOKEN, SECRET, PASSWORD, PASSWD, APIKEY, API_KEY, CREDENTIAL,
-  PRIVATE_KEY, AUTH_TOKEN, BEARER_TOKEN, JWT
-(extensible via shell-cassette.config.{js,mjs} \`redact.envKeys\`)
+What gets redacted (default ON):
+  * Curated env-key values (TOKEN, SECRET, PASSWORD, JWT, etc., case-insensitive substring)
+  * User-extended env-key list (config.redact.envKeys)
+  * 25 bundled credential patterns (GitHub, AWS access key ID, Stripe, OpenAI, Anthropic,
+    Google API, Slack, GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI,
+    Discord, Square) across env values, args, stdout, stderr, allLines
+  * User-supplied custom rules (config.redact.customPatterns)
 
-It does NOT redact:
-  - stdout / stderr content
-  - command args (e.g., --token=xyz)
-  - env vars with non-curated names (e.g., STRIPE_KEY, OPENAI_KEY,
-    DATABASE_URL) unless added via config
-  - paths in cwd
+What does NOT get redacted (residual risk):
+  * Credentials without a documented format (AWS Secret Access Keys, generic 32-hex tokens,
+    Heroku/Datadog/Twilio tokens, internal/proprietary secrets); caught only by length warning
+  * JWTs (many are non-secret public tokens; opt-in via custom rule if your JWTs are bearer-shaped)
+  * Encoded credentials (Authorization: Basic base64, base64-encoded YAML/JSON secrets)
+  * Binary output (BinaryOutputError prevents recording)
+  * cwd values
+  * Subprocess stdin (not captured until v0.5)
 
-ALWAYS review cassettes before committing.
+Verify before committing:  shell-cassette scan <path>
+Migrate when bundle expands: shell-cassette re-redact <path>
 
-To proceed: set SHELL_CASSETTE_ACK_REDACTION=true.`
+Set SHELL_CASSETTE_ACK_REDACTION=true to acknowledge and proceed.`
 
 export function requireAckGate(): void {
   if (process.env.SHELL_CASSETTE_ACK_REDACTION !== 'true') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,12 +9,6 @@ export type Config = {
   canonicalize: Canonicalize
   cassetteDir: string
   /**
-   * @deprecated Use Config.redact.envKeys. This field is kept for v0.3
-   * backward compatibility through v0.4 and will be removed in v0.5
-   * (when v0.4 M6 ships and the recorder/redact.ts rewrite no longer needs it).
-   */
-  redactEnvKeys: string[]
-  /**
    * v0.4 composed redaction config: bundled patterns, custom rules, suppress
    * list, env-key extension, length warning tuning.
    */
@@ -24,7 +18,6 @@ export type Config = {
 export type PartialConfig = {
   canonicalize?: Canonicalize
   cassetteDir?: string
-  redactEnvKeys?: string[]
   redact?: Partial<RedactConfig>
 }
 
@@ -42,18 +35,11 @@ const DEFAULT_REDACT: Readonly<RedactConfig> = Object.freeze({
 export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
   canonicalize: defaultCanonicalize,
   cassetteDir: '__cassettes__',
-  redactEnvKeys: [] as string[],
   redact: DEFAULT_REDACT,
 })
 
 export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Config> {
   const userRedact: Partial<RedactConfig> = input?.redact ?? {}
-  const userRedactEnvKeys = input?.redactEnvKeys
-
-  // Resolve envKeys: redact.envKeys takes precedence over deprecated redactEnvKeys.
-  // Both Config.redactEnvKeys and Config.redact.envKeys end up with the same value
-  // so deprecated and new callers see consistent data.
-  const resolvedEnvKeys = userRedact.envKeys ?? userRedactEnvKeys ?? DEFAULT_REDACT.envKeys
 
   const resolvedRedact: RedactConfig = {
     bundledPatterns: userRedact.bundledPatterns ?? DEFAULT_REDACT.bundledPatterns,
@@ -63,7 +49,7 @@ export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Co
     suppressPatterns: userRedact.suppressPatterns
       ? Object.freeze([...userRedact.suppressPatterns])
       : DEFAULT_REDACT.suppressPatterns,
-    envKeys: Object.freeze([...resolvedEnvKeys]),
+    envKeys: userRedact.envKeys ? Object.freeze([...userRedact.envKeys]) : DEFAULT_REDACT.envKeys,
     warnLengthThreshold: userRedact.warnLengthThreshold ?? DEFAULT_REDACT.warnLengthThreshold,
     warnPathHeuristic: userRedact.warnPathHeuristic ?? DEFAULT_REDACT.warnPathHeuristic,
   }
@@ -71,10 +57,6 @@ export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Co
   return Object.freeze({
     canonicalize: input?.canonicalize ?? DEFAULT_CONFIG.canonicalize,
     cassetteDir: input?.cassetteDir ?? DEFAULT_CONFIG.cassetteDir,
-    // Config.redactEnvKeys is typed string[] for v0.3 API compat but the
-    // underlying array is the frozen readonly array from resolvedRedact.envKeys.
-    // The cast widens the type; runtime mutability is still locked by Object.freeze.
-    redactEnvKeys: resolvedRedact.envKeys as string[],
     redact: Object.freeze(resolvedRedact),
   })
 }
@@ -177,14 +159,6 @@ export function validateConfig(input: unknown): asserts input is PartialConfig {
   }
   if ('canonicalize' in obj && typeof obj.canonicalize !== 'function') {
     throw new CassetteConfigError('config.canonicalize must be a function (call) => Partial<Call>')
-  }
-  if ('redactEnvKeys' in obj) {
-    if (!Array.isArray(obj.redactEnvKeys)) {
-      throw new CassetteConfigError('config.redactEnvKeys must be an array of strings')
-    }
-    if (!obj.redactEnvKeys.every((k) => typeof k === 'string')) {
-      throw new CassetteConfigError('config.redactEnvKeys items must all be strings')
-    }
   }
   if ('redact' in obj) {
     validateRedact(obj.redact)

--- a/src/curated-env-keys.ts
+++ b/src/curated-env-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * Curated env-key substring list. Case-insensitive. Inherited from v0.2/v0.3
+ * behavior for backward compatibility.
+ *
+ * v0.4 keeps the curated list and lets users extend via Config.redact.envKeys
+ * (substring match, also case-insensitive). The substring match is intentionally
+ * loose: GITHUB_TOKEN, MY_TOKEN_VAR, and TOKENIZER_PATH all match TOKEN. The
+ * cosmetic-vs-catastrophic tradeoff (false-positive redaction is annoying;
+ * missed credential is dangerous) favors keeping the loose match. False
+ * positives can be suppressed via Config.redact.suppressPatterns.
+ */
+export const CURATED_ENV_KEYS = [
+  'TOKEN',
+  'SECRET',
+  'PASSWORD',
+  'PASSWD',
+  'APIKEY',
+  'API_KEY',
+  'CREDENTIAL',
+  'PRIVATE_KEY',
+  'AUTH_TOKEN',
+  'BEARER_TOKEN',
+  'JWT',
+] as const

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1,14 +1,8 @@
 import { CURATED_ENV_KEYS } from './curated-env-keys.js'
 import { log } from './log.js'
 import { redact } from './redact.js'
-import type {
-  Call,
-  CassetteSession,
-  Recording,
-  RedactionEntry,
-  RedactSource,
-  Result,
-} from './types.js'
+import { aggregateEntries, ENV_KEY_MATCH_RULE, formatPlaceholder } from './redact-pipeline.js'
+import type { Call, CassetteSession, Recording, RedactSource, Result } from './types.js'
 
 export function record(call: Call, result: Result, session: CassetteSession): void {
   if (!session.redactEnabled) {
@@ -39,11 +33,11 @@ function redactCall(call: Call, session: CassetteSession): Call {
   for (const [key, value] of Object.entries(call.env)) {
     if (matchesEnvKeyList(key, session.redactConfig.envKeys)) {
       // Curated key match: whole value is sensitive; use the env-key-match rule.
-      const counterKey = 'env:env-key-match'
+      const counterKey = `env:${ENV_KEY_MATCH_RULE}`
       const next = (session.redactCounters.get(counterKey) ?? 0) + 1
       session.redactCounters.set(counterKey, next)
-      env[key] = `<redacted:env:env-key-match:${next}>`
-      session.redactionEntries.push({ rule: 'env-key-match', source: 'env', count: 1 })
+      env[key] = formatPlaceholder('env', ENV_KEY_MATCH_RULE, next)
+      session.redactionEntries.push({ rule: ENV_KEY_MATCH_RULE, source: 'env', count: 1 })
       log(`redacted env var ${key} → ${session.path}`)
     } else {
       // Value-based: run through the pipeline for pattern-based detection.
@@ -98,20 +92,6 @@ function matchesEnvKeyList(key: string, userKeys: readonly string[]): boolean {
     if (upper.includes(k.toUpperCase())) return true
   }
   return false
-}
-
-function aggregateEntries(entries: readonly RedactionEntry[]): RedactionEntry[] {
-  const map = new Map<string, RedactionEntry>()
-  for (const e of entries) {
-    const mapKey = `${e.source}:${e.rule}`
-    const existing = map.get(mapKey)
-    if (existing) {
-      existing.count += e.count
-    } else {
-      map.set(mapKey, { ...e })
-    }
-  }
-  return [...map.values()]
 }
 
 // Re-export Recording type for callers that previously imported it from here.

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1,27 +1,118 @@
+import { CURATED_ENV_KEYS } from './curated-env-keys.js'
 import { log } from './log.js'
-import { type RedactConfig, redactEnv } from './redact.js'
-import type { Call, CassetteSession, Result } from './types.js'
+import { redact } from './redact.js'
+import type {
+  Call,
+  CassetteSession,
+  Recording,
+  RedactionEntry,
+  RedactSource,
+  Result,
+} from './types.js'
 
-export function record(
-  call: Call,
-  result: Result,
-  session: CassetteSession,
-  config: RedactConfig,
-): void {
-  const { redacted, redactedKeys, warnings } = redactEnv(call.env, config)
+export function record(call: Call, result: Result, session: CassetteSession): void {
+  if (!session.redactEnabled) {
+    // Per-cassette override: bypass the redact pipeline entirely.
+    session.newRecordings.push({ call, result, redactions: [] })
+    return
+  }
 
-  for (const key of redactedKeys) {
-    log(`redacted env var ${key} → ${session.path}`)
-    session.redactedKeys.push(key)
-  }
-  for (const warning of warnings) {
-    log(warning)
-    session.warnings.push(warning)
-  }
+  // Snapshot redactionEntries length to identify entries added during this
+  // single capture.
+  const before = session.redactionEntries.length
+
+  const redactedCall = redactCall(call, session)
+  const redactedResult = redactResult(result, session)
+
+  const recordingEntries = session.redactionEntries.slice(before)
+  const aggregated = aggregateEntries(recordingEntries)
 
   session.newRecordings.push({
-    call: { ...call, env: redacted },
-    result,
-    redactions: [],
+    call: redactedCall,
+    result: redactedResult,
+    redactions: aggregated,
   })
 }
+
+function redactCall(call: Call, session: CassetteSession): Call {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(call.env)) {
+    if (matchesEnvKeyList(key, session.redactConfig.envKeys)) {
+      // Curated key match: whole value is sensitive; use the env-key-match rule.
+      const counterKey = 'env:env-key-match'
+      const next = (session.redactCounters.get(counterKey) ?? 0) + 1
+      session.redactCounters.set(counterKey, next)
+      env[key] = `<redacted:env:env-key-match:${next}>`
+      session.redactionEntries.push({ rule: 'env-key-match', source: 'env', count: 1 })
+      log(`redacted env var ${key} → ${session.path}`)
+    } else {
+      // Value-based: run through the pipeline for pattern-based detection.
+      const r = redact({ source: 'env', value }, session.redactConfig, {
+        counted: true,
+        counters: session.redactCounters,
+      })
+      env[key] = r.output
+      session.redactionEntries.push(...r.entries)
+      session.warnings.push(...r.warnings)
+    }
+  }
+
+  const args = call.args.map((arg) => {
+    const r = redact({ source: 'args', value: arg }, session.redactConfig, {
+      counted: true,
+      counters: session.redactCounters,
+    })
+    session.redactionEntries.push(...r.entries)
+    session.warnings.push(...r.warnings)
+    return r.output
+  })
+
+  return { ...call, env, args }
+}
+
+function redactResult(result: Result, session: CassetteSession): Result {
+  return {
+    ...result,
+    stdoutLines: result.stdoutLines.map((line) => redactLine('stdout', line, session)),
+    stderrLines: result.stderrLines.map((line) => redactLine('stderr', line, session)),
+    allLines: result.allLines?.map((line) => redactLine('allLines', line, session)) ?? null,
+  }
+}
+
+function redactLine(source: RedactSource, line: string, session: CassetteSession): string {
+  const r = redact({ source, value: line }, session.redactConfig, {
+    counted: true,
+    counters: session.redactCounters,
+  })
+  session.redactionEntries.push(...r.entries)
+  session.warnings.push(...r.warnings)
+  return r.output
+}
+
+function matchesEnvKeyList(key: string, userKeys: readonly string[]): boolean {
+  const upper = key.toUpperCase()
+  for (const k of CURATED_ENV_KEYS) {
+    if (upper.includes(k.toUpperCase())) return true
+  }
+  for (const k of userKeys) {
+    if (upper.includes(k.toUpperCase())) return true
+  }
+  return false
+}
+
+function aggregateEntries(entries: readonly RedactionEntry[]): RedactionEntry[] {
+  const map = new Map<string, RedactionEntry>()
+  for (const e of entries) {
+    const mapKey = `${e.source}:${e.rule}`
+    const existing = map.get(mapKey)
+    if (existing) {
+      existing.count += e.count
+    } else {
+      map.set(mapKey, { ...e })
+    }
+  }
+  return [...map.values()]
+}
+
+// Re-export Recording type for callers that previously imported it from here.
+export type { Recording }

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -204,12 +204,14 @@ const COUNTER_PLACEHOLDER_REGEX = /<redacted:([^:>]+):([^:>]+):(\d+)>/g
 export function seedCountersFromCassette(cassette: CassetteFile): Map<string, number> {
   const counters = new Map<string, number>()
 
-  // Source 1: per-recording redactions metadata
+  // Source 1: per-recording _redactions metadata. Each entry.count is the
+  // number of placeholder occurrences within that single recording. The
+  // cassette-wide ceiling is the SUM across recordings — counters are
+  // monotonic and per-(source, rule) globally.
   for (const rec of cassette.recordings) {
     for (const entry of rec.redactions) {
       const key = `${entry.source}:${entry.rule}`
-      const existing = counters.get(key) ?? 0
-      counters.set(key, Math.max(existing, entry.count))
+      counters.set(key, (counters.get(key) ?? 0) + entry.count)
     }
   }
 

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -1,6 +1,12 @@
 import { ShellCassetteError } from './errors.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
-import type { RedactConfig, RedactionEntry, RedactRule, RedactSource } from './types.js'
+import type {
+  CassetteFile,
+  RedactConfig,
+  RedactionEntry,
+  RedactRule,
+  RedactSource,
+} from './types.js'
 
 export type RedactInput = {
   source: RedactSource
@@ -173,4 +179,70 @@ function applyRegexRule(
  */
 export function stripCounter(s: string): string {
   return s.replace(/<redacted:([^:>]+):([^:>]+):(\d+)>/g, '<redacted:$1:$2>')
+}
+
+// Pattern is module-private; a fresh RegExp is constructed per call to
+// walkStringsForPlaceholders so lastIndex never leaks between iterations.
+const COUNTER_PLACEHOLDER_REGEX = /<redacted:([^:>]+):([^:>]+):(\d+)>/g
+
+/**
+ * Build a counter map seeded from existing placeholders in a loaded cassette.
+ *
+ * Two sources are walked:
+ *   1. Each recording's `redactions` metadata: (rule, source, count) triples
+ *      contribute to the per-(source, rule) counter ceiling.
+ *   2. Every value (env, args, stdout, stderr, allLines) is scanned for
+ *      counter-tagged placeholders. The maximum N seen for each
+ *      (source, rule) pair becomes the ceiling. This catches hand-edited
+ *      cassettes where the metadata is stale or out-of-sync with the body.
+ *
+ * The returned Map is the seed for `CassetteSession.redactCounters`. New
+ * placeholders emitted during auto-additive appends start at
+ * `max(seeded) + 1` per (source, rule), continuing the existing counter
+ * sequence.
+ */
+export function seedCountersFromCassette(cassette: CassetteFile): Map<string, number> {
+  const counters = new Map<string, number>()
+
+  // Source 1: per-recording redactions metadata
+  for (const rec of cassette.recordings) {
+    for (const entry of rec.redactions) {
+      const key = `${entry.source}:${entry.rule}`
+      const existing = counters.get(key) ?? 0
+      counters.set(key, Math.max(existing, entry.count))
+    }
+  }
+
+  // Source 2: walk every string value for counter-tagged placeholders
+  for (const rec of cassette.recordings) {
+    walkStringsForPlaceholders(rec, (source, rule, n) => {
+      const key = `${source}:${rule}`
+      const existing = counters.get(key) ?? 0
+      if (n > existing) counters.set(key, n)
+    })
+  }
+
+  return counters
+}
+
+function walkStringsForPlaceholders(
+  rec: CassetteFile['recordings'][number],
+  visit: (source: string, rule: string, n: number) => void,
+): void {
+  const values = [
+    ...Object.values(rec.call.env),
+    ...rec.call.args,
+    ...rec.result.stdoutLines,
+    ...rec.result.stderrLines,
+    ...(rec.result.allLines ?? []),
+  ]
+  for (const value of values) {
+    // Construct a fresh RegExp each iteration to avoid lastIndex state leaking.
+    const re = new RegExp(COUNTER_PLACEHOLDER_REGEX.source, COUNTER_PLACEHOLDER_REGEX.flags)
+    for (const m of value.matchAll(re)) {
+      // Groups 1-3 are always present given the pattern shape; non-null safe.
+      // biome-ignore lint/style/noNonNullAssertion: regex groups are structural
+      visit(m[1]!, m[2]!, parseInt(m[3]!, 10))
+    }
+  }
 }

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -139,7 +139,7 @@ export function runPipeline(
   return { output, entries, warnings }
 }
 
-function formatPlaceholder(source: RedactSource, ruleName: string, count?: number): string {
+export function formatPlaceholder(source: RedactSource, ruleName: string, count?: number): string {
   return count === undefined
     ? `<redacted:${source}:${ruleName}>`
     : `<redacted:${source}:${ruleName}:${count}>`
@@ -171,6 +171,11 @@ function applyRegexRule(
   return result
 }
 
+// Single source of truth for the counter-placeholder pattern. Both
+// stripCounter and walkStringsForPlaceholders construct g-flagged RegExp
+// instances from this string so lastIndex state never leaks between callers.
+const COUNTER_PLACEHOLDER_PATTERN = '<redacted:([^:>]+):([^:>]+):(\\d+)>'
+
 /**
  * Replace counter-tagged placeholders with their counter-stripped form.
  * Used by the canonicalize pipeline at match time so cassette args containing
@@ -178,12 +183,8 @@ function applyRegexRule(
  * in stripped mode. Stripped placeholders pass through unchanged.
  */
 export function stripCounter(s: string): string {
-  return s.replace(/<redacted:([^:>]+):([^:>]+):(\d+)>/g, '<redacted:$1:$2>')
+  return s.replace(new RegExp(COUNTER_PLACEHOLDER_PATTERN, 'g'), '<redacted:$1:$2>')
 }
-
-// Pattern is module-private; a fresh RegExp is constructed per call to
-// walkStringsForPlaceholders so lastIndex never leaks between iterations.
-const COUNTER_PLACEHOLDER_REGEX = /<redacted:([^:>]+):([^:>]+):(\d+)>/g
 
 /**
  * Build a counter map seeded from existing placeholders in a loaded cassette.
@@ -231,6 +232,10 @@ function walkStringsForPlaceholders(
   rec: CassetteFile['recordings'][number],
   visit: (source: string, rule: string, n: number) => void,
 ): void {
+  // Construct the regex once per function call. String.prototype.matchAll
+  // does not mutate the pattern's lastIndex, so reusing re across multiple
+  // matchAll calls is safe.
+  const re = new RegExp(COUNTER_PLACEHOLDER_PATTERN, 'g')
   const values = [
     ...Object.values(rec.call.env),
     ...rec.call.args,
@@ -239,12 +244,38 @@ function walkStringsForPlaceholders(
     ...(rec.result.allLines ?? []),
   ]
   for (const value of values) {
-    // Construct a fresh RegExp each iteration to avoid lastIndex state leaking.
-    const re = new RegExp(COUNTER_PLACEHOLDER_REGEX.source, COUNTER_PLACEHOLDER_REGEX.flags)
     for (const m of value.matchAll(re)) {
       // Groups 1-3 are always present given the pattern shape; non-null safe.
       // biome-ignore lint/style/noNonNullAssertion: regex groups are structural
       visit(m[1]!, m[2]!, parseInt(m[3]!, 10))
     }
   }
+}
+
+/**
+ * Synthetic rule name for the recorder's curated env-key-match path
+ * (env values whose key name matches the CURATED_ENV_KEYS or user-supplied
+ * envKeys list). Not in BUNDLED_PATTERNS — the env-key pathway bypasses the
+ * regex pipeline since the whole value is sensitive.
+ */
+export const ENV_KEY_MATCH_RULE = 'env-key-match'
+
+/**
+ * Collapse a flat array of RedactionEntry into one entry per (source, rule)
+ * by summing counts. Used at record time to produce per-recording redaction
+ * metadata, and by re-redact (M11) to rebuild metadata after re-applying
+ * rules.
+ */
+export function aggregateEntries(entries: readonly RedactionEntry[]): RedactionEntry[] {
+  const map = new Map<string, RedactionEntry>()
+  for (const e of entries) {
+    const key = `${e.source}:${e.rule}`
+    const existing = map.get(key)
+    if (existing) {
+      existing.count += e.count
+    } else {
+      map.set(key, { ...e })
+    }
+  }
+  return [...map.values()]
 }

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,51 +1,36 @@
-const LONG_VALUE_THRESHOLD = 100
+import { BUNDLED_PATTERNS as _BUNDLED } from './redact-patterns.js'
+import { type RedactOptions, type RedactOutput, runPipeline } from './redact-pipeline.js'
+import type { RedactConfig, RedactionEntry, RedactRule, RedactSource } from './types.js'
 
-export const CURATED_KEYS = [
-  'TOKEN',
-  'SECRET',
-  'PASSWORD',
-  'PASSWD',
-  'APIKEY',
-  'API_KEY',
-  'CREDENTIAL',
-  'PRIVATE_KEY',
-  'AUTH_TOKEN',
-  'BEARER_TOKEN',
-  'JWT',
-] as const
+export const BUNDLED_PATTERNS: readonly RedactRule[] = _BUNDLED
 
-export type RedactConfig = {
-  redactEnvKeys: string[]
+export type RedactInput = {
+  source: RedactSource
+  value: string
 }
 
-export type RedactResult = {
-  redacted: Record<string, string>
-  redactedKeys: string[]
-  warnings: string[]
+export type { RedactOptions, RedactOutput }
+
+/**
+ * Apply the redact pipeline to a single value.
+ *
+ * The recorder calls this at record time with `counted: true` to produce
+ * counter-tagged placeholders persisted to the cassette. The canonicalize
+ * pipeline calls this at match time with `counted: false` so deep-equal
+ * works across cassette args containing redacted credentials.
+ *
+ * Custom rules in `config.customPatterns` may use either a global regex
+ * (matched via String.prototype.replace) or a transform function (called
+ * once with the input value, returning the replacement). Suppress patterns
+ * checked first; bundled patterns next; custom patterns last; length warning
+ * fires only when no rule fired.
+ */
+export function redact(
+  input: RedactInput,
+  config: Readonly<RedactConfig>,
+  options: RedactOptions,
+): RedactOutput {
+  return runPipeline(input, config, options)
 }
 
-export function redactEnv(env: Record<string, string>, config: RedactConfig): RedactResult {
-  const allKeys = [...CURATED_KEYS, ...config.redactEnvKeys]
-  const redacted: Record<string, string> = {}
-  const redactedKeys: string[] = []
-  const warnings: string[] = []
-
-  for (const [key, value] of Object.entries(env)) {
-    const upper = key.toUpperCase()
-    const isSensitive = allKeys.some((k) => upper.includes(k.toUpperCase()))
-
-    if (isSensitive) {
-      redacted[key] = '<redacted>'
-      redactedKeys.push(key)
-    } else {
-      redacted[key] = value
-      if (value.length > LONG_VALUE_THRESHOLD) {
-        warnings.push(
-          `${key}: long value (${value.length} chars), not in curated/configured list - may contain a credential. shell-cassette matches by key name only, not value pattern. Review cassette, or add ${key} to config.redactEnvKeys.`,
-        )
-      }
-    }
-  }
-
-  return { redacted, redactedKeys, warnings }
-}
+export type { RedactConfig, RedactionEntry, RedactRule, RedactSource }

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -11,7 +11,7 @@ import type { CassetteSession } from './types.js'
  */
 export function summarizeSession(session: CassetteSession): void {
   const recCount = session.newRecordings.length
-  const redCount = session.redactedKeys.length
+  const redCount = session.redactionEntries.reduce((sum, e) => sum + e.count, 0)
   const warnCount = session.warnings.length
 
   if (recCount === 0 && redCount === 0 && warnCount === 0) {
@@ -24,10 +24,10 @@ export function summarizeSession(session: CassetteSession): void {
       `${warnCount} warning${warnCount === 1 ? '' : 's'}): ${session.path}`,
   )
 
-  for (const key of session.redactedKeys) {
-    log(`  redacted: ${key}`)
+  for (const entry of session.redactionEntries) {
+    log(`  redacted: ${entry.source}:${entry.rule} (${entry.count})`)
   }
   for (const warning of session.warnings) {
-    log(`  ⚠️  ${warning}`)
+    log(`  warning: ${warning}`)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,10 +138,29 @@ export type CassetteSession = {
   loadedFile: CassetteFile | null
   matcher: MatcherStateLike | null // built lazily; defined in matcher.ts
   canonicalize: Canonicalize
+  /**
+   * Frozen redaction config for this session. Loaded from Config.redact.
+   * Per-cassette override of redact: false is wired via redactEnabled.
+   */
+  redactConfig: Readonly<RedactConfig>
+  /**
+   * When false (set via useCassette({ redact: false })), the recorder
+   * bypasses the redact pipeline. Default true.
+   */
+  redactEnabled: boolean
+  /**
+   * Mutable counter map: key is `${source}:${rule}`. Incremented on each
+   * placeholder emission during recording. Seeded from existing cassette
+   * placeholders on cassette load (so auto-additive appends continue from
+   * the existing ceiling).
+   */
+  redactCounters: Map<string, number>
+  /**
+   * Accumulated across all redact() calls in this session. Used for summary
+   * logging at session end.
+   */
+  redactionEntries: RedactionEntry[]
   newRecordings: Recording[]
-  // Accumulated across record() calls in this scope. Emitted as an
-  // end-of-run summary by the vitest plugin and useCassette finally.
-  redactedKeys: string[]
   warnings: string[]
 }
 

--- a/src/use-cassette.ts
+++ b/src/use-cassette.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { getConfig } from './config.js'
 import { writeCassetteFile } from './io.js'
 import { defaultCanonicalize } from './matcher.js'
 import { serialize } from './serialize.js'
@@ -32,6 +33,7 @@ export async function useCassette<T>(
   const absolutePath = path.resolve(cassettePath)
   registerSessionPath(absolutePath, `useCassette(${cassettePath})`)
   try {
+    const config = getConfig()
     const session: CassetteSession = {
       name: path.basename(cassettePath),
       path: absolutePath,
@@ -39,8 +41,11 @@ export async function useCassette<T>(
       loadedFile: null,
       matcher: null,
       canonicalize,
+      redactConfig: config.redact,
+      redactEnabled: options.redact !== false,
+      redactCounters: new Map(),
+      redactionEntries: [],
       newRecordings: [],
-      redactedKeys: [],
       warnings: [],
     }
 

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -79,8 +79,11 @@ try {
       loadedFile: null,
       matcher: null,
       canonicalize: config.canonicalize,
+      redactConfig: config.redact,
+      redactEnabled: true,
+      redactCounters: new Map(),
+      redactionEntries: [],
       newRecordings: [],
-      redactedKeys: [],
       warnings: [],
     }
     setActiveCassette(session)

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -5,6 +5,7 @@ import { loadCassette } from './loader.js'
 import { MatcherState } from './matcher.js'
 import { resolveMode } from './mode.js'
 import { record } from './recorder.js'
+import { seedCountersFromCassette } from './redact-pipeline.js'
 import { getActiveCassette } from './state.js'
 import type { Call, CassetteSession, MatcherStateLike, Recording, Result } from './types.js'
 
@@ -56,7 +57,17 @@ export async function runWrapped<Opts, ResultShape>(
   }
 
   if (session.loadedFile === null) {
-    session.loadedFile = await loadCassette(session.path)
+    const file = await loadCassette(session.path)
+    if (file !== null) {
+      session.loadedFile = file
+      // Seed redact counters from existing cassette placeholders so
+      // auto-additive appends continue from the existing per-(source, rule)
+      // ceiling. Spec Q5 + counter rebuild on cassette load.
+      const seeded = seedCountersFromCassette(file)
+      for (const [k, v] of seeded) {
+        session.redactCounters.set(k, v)
+      }
+    }
     session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], session.canonicalize)
   }
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,5 +1,5 @@
 import { requireAckGate } from './ack.js'
-import { type Config, getConfig } from './config.js'
+
 import { NoActiveSessionError, ReplayMissError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { MatcherState } from './matcher.js'
@@ -55,7 +55,6 @@ export async function runWrapped<Opts, ResultShape>(
     return hooks.realCall(file, args, options)
   }
 
-  const config = getConfig()
   if (session.loadedFile === null) {
     session.loadedFile = await loadCassette(session.path)
     session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], session.canonicalize)
@@ -115,10 +114,10 @@ export async function runWrapped<Opts, ResultShape>(
   const start = performance.now()
   try {
     const result = await hooks.realCall(file, args, options)
-    captureAndRecord(call, result, performance.now() - start, hooks, session, config)
+    captureAndRecord(call, result, performance.now() - start, hooks, session)
     return result
   } catch (err) {
-    captureAndRecord(call, err, performance.now() - start, hooks, session, config)
+    captureAndRecord(call, err, performance.now() - start, hooks, session)
     throw err
   }
 }
@@ -129,10 +128,9 @@ function captureAndRecord<Opts, ResultShape>(
   durationMs: number,
   hooks: RunnerHooks<Opts, ResultShape>,
   session: CassetteSession,
-  config: Config,
 ): void {
   const result = hooks.captureResult(raw, durationMs)
-  record(call, result, session, config)
+  record(call, result, session)
 }
 
 function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -33,10 +33,10 @@ describe('loadConfigFromDir', () => {
   test('loads .mjs config file', async () => {
     await writeFile(
       path.join(tmp, 'shell-cassette.config.mjs'),
-      `export default { redactEnvKeys: ['STRIPE_KEY'] }`,
+      `export default { redact: { envKeys: ['STRIPE_KEY'] } }`,
     )
     const config = await loadConfigFromDir(tmp)
-    expect(config.redactEnvKeys).toEqual(['STRIPE_KEY'])
+    expect(config.redact.envKeys).toEqual(['STRIPE_KEY'])
   })
 
   test('throws CassetteConfigError on syntax error in config', async () => {

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -16,8 +16,11 @@ export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteS
     loadedFile: { version: 2, recordedBy: null, recordings: [] },
     matcher: null,
     canonicalize,
+    redactConfig: DEFAULT_CONFIG.redact,
+    redactEnabled: true,
+    redactCounters: new Map(),
+    redactionEntries: [],
     newRecordings: [],
-    redactedKeys: [],
     warnings: [],
     ...overrides,
   }

--- a/tests/integration/recorder-redact.test.ts
+++ b/tests/integration/recorder-redact.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { DEFAULT_CONFIG } from '../../src/config.js'
 import { record } from '../../src/recorder.js'
+import { seedCountersFromCassette } from '../../src/redact-pipeline.js'
 import type { Call, CassetteSession, Result } from '../../src/types.js'
 
 function makeSession(): CassetteSession {
@@ -137,6 +138,54 @@ describe('recorder applies redaction across all 5 sources', () => {
     // Counter continues from where it left off; second recording gets :2
     expect(session.newRecordings[0]?.call.args[0]).toBe('<redacted:args:github-pat-classic:1>')
     expect(session.newRecordings[1]?.call.args[0]).toBe('<redacted:args:github-pat-classic:2>')
+  })
+
+  test('counters continue from existing cassette ceiling on auto-additive append', () => {
+    const session = makeSession()
+    // Simulate a pre-loaded cassette with a placeholder counter of :3
+    session.loadedFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: ['Bearer <redacted:args:github-pat-classic:3>'],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          redactions: [{ rule: 'github-pat-classic', source: 'args', count: 3 }],
+        },
+      ],
+    }
+    // Seed counters (in production done by wrapper.ts on cassette load)
+    const seeded = seedCountersFromCassette(session.loadedFile)
+    for (const [k, v] of seeded) {
+      session.redactCounters.set(k, v)
+    }
+
+    // Record a new call with a fresh PAT; counter should continue at :4
+    const call: Call = {
+      command: 'curl',
+      args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    record(call, benignResult, session)
+    expect(session.newRecordings[0]?.call.args[0]).toBe(
+      'Bearer <redacted:args:github-pat-classic:4>',
+    )
   })
 
   test('redactEnabled: false bypasses pipeline', () => {

--- a/tests/integration/recorder-redact.test.ts
+++ b/tests/integration/recorder-redact.test.ts
@@ -1,25 +1,8 @@
 import { describe, expect, test } from 'vitest'
-import { DEFAULT_CONFIG } from '../../src/config.js'
 import { record } from '../../src/recorder.js'
 import { seedCountersFromCassette } from '../../src/redact-pipeline.js'
-import type { Call, CassetteSession, Result } from '../../src/types.js'
-
-function makeSession(): CassetteSession {
-  return {
-    name: 'test',
-    path: '/tmp/test.json',
-    scopeDefault: 'auto',
-    loadedFile: null,
-    matcher: null,
-    canonicalize: DEFAULT_CONFIG.canonicalize,
-    redactConfig: DEFAULT_CONFIG.redact,
-    redactEnabled: true,
-    redactCounters: new Map(),
-    redactionEntries: [],
-    newRecordings: [],
-    warnings: [],
-  }
-}
+import type { Call, Result } from '../../src/types.js'
+import { makeSession } from '../helpers/session.js'
 
 const benignResult: Result = {
   stdoutLines: [],

--- a/tests/integration/recorder-redact.test.ts
+++ b/tests/integration/recorder-redact.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import { record } from '../../src/recorder.js'
+import type { Call, CassetteSession, Result } from '../../src/types.js'
+
+function makeSession(): CassetteSession {
+  return {
+    name: 'test',
+    path: '/tmp/test.json',
+    scopeDefault: 'auto',
+    loadedFile: null,
+    matcher: null,
+    canonicalize: DEFAULT_CONFIG.canonicalize,
+    redactConfig: DEFAULT_CONFIG.redact,
+    redactEnabled: true,
+    redactCounters: new Map(),
+    redactionEntries: [],
+    newRecordings: [],
+    warnings: [],
+  }
+}
+
+const benignResult: Result = {
+  stdoutLines: [],
+  stderrLines: [],
+  allLines: null,
+  exitCode: 0,
+  signal: null,
+  durationMs: 100,
+  aborted: false,
+}
+
+describe('recorder applies redaction across all 5 sources', () => {
+  test('env value with curated env-key match is redacted via env-key rule', () => {
+    const session = makeSession()
+    const call: Call = {
+      command: 'curl',
+      args: [],
+      cwd: null,
+      env: { GH_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      stdin: null,
+    }
+    record(call, benignResult, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.call.env.GH_TOKEN).toBe('<redacted:env:env-key-match:1>')
+  })
+
+  test('env value with no curated key match but bundled pattern: redacted by pattern', () => {
+    const session = makeSession()
+    const call: Call = {
+      command: 'curl',
+      args: [],
+      cwd: null,
+      env: { CONFIG_BLOB: 'prefix ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 suffix' },
+      stdin: null,
+    }
+    record(call, benignResult, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.call.env.CONFIG_BLOB).toBe('prefix <redacted:env:github-pat-classic:1> suffix')
+  })
+
+  test('args containing credential is redacted with counter', () => {
+    const session = makeSession()
+    const call: Call = {
+      command: 'curl',
+      args: ['-H', 'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    record(call, benignResult, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.call.args[1]).toBe('Authorization: Bearer <redacted:args:github-pat-classic:1>')
+  })
+
+  test('stdout lines containing credentials are redacted', () => {
+    const session = makeSession()
+    const result: Result = {
+      ...benignResult,
+      stdoutLines: ['line 1', 'token: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890', 'line 3'],
+    }
+    record({ command: 'gh', args: [], cwd: null, env: {}, stdin: null }, result, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.result.stdoutLines[1]).toBe('token: <redacted:stdout:github-pat-classic:1>')
+  })
+
+  test('stderr and allLines also redacted', () => {
+    const session = makeSession()
+    const result: Result = {
+      ...benignResult,
+      stderrLines: ['warn: AKIA0123456789ABCDEF'],
+      allLines: ['stdout-then-stderr: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+    }
+    record({ command: 'gh', args: [], cwd: null, env: {}, stdin: null }, result, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.result.stderrLines[0]).toBe('warn: <redacted:stderr:aws-access-key-id:1>')
+    expect(stored?.result.allLines?.[0]).toBe(
+      'stdout-then-stderr: <redacted:allLines:github-pat-classic:1>',
+    )
+  })
+
+  test('redactions on recording aggregated per (source, rule)', () => {
+    const session = makeSession()
+    const call: Call = {
+      command: 'curl',
+      args: [
+        'Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+        'Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321',
+      ],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    record(call, benignResult, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.redactions).toEqual([{ rule: 'github-pat-classic', source: 'args', count: 2 }])
+  })
+
+  test('counters are shared across multiple record() calls in a session', () => {
+    const session = makeSession()
+    const call1: Call = {
+      command: 'curl',
+      args: ['ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const call2: Call = {
+      command: 'curl',
+      args: ['ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    record(call1, benignResult, session)
+    record(call2, benignResult, session)
+    // Counter continues from where it left off; second recording gets :2
+    expect(session.newRecordings[0]?.call.args[0]).toBe('<redacted:args:github-pat-classic:1>')
+    expect(session.newRecordings[1]?.call.args[0]).toBe('<redacted:args:github-pat-classic:2>')
+  })
+
+  test('redactEnabled: false bypasses pipeline', () => {
+    const session = makeSession()
+    session.redactEnabled = false
+    const call: Call = {
+      command: 'curl',
+      args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: { GH_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      stdin: null,
+    }
+    record(call, benignResult, session)
+    const stored = session.newRecordings[0]
+    expect(stored?.call.args[0]).toBe('Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(stored?.call.env.GH_TOKEN).toBe('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(stored?.redactions).toEqual([])
+  })
+})

--- a/tests/security/ack-gate.test.ts
+++ b/tests/security/ack-gate.test.ts
@@ -43,7 +43,62 @@ describe('requireAckGate', () => {
       const msg = (e as Error).message
       expect(msg).toContain('SHELL_CASSETTE_ACK_REDACTION')
       expect(msg).toContain('TOKEN')
-      expect(msg).toContain('stdout')
+      expect(msg).toContain('config.redact.envKeys')
+    }
+  })
+
+  test('ack message lists 25 bundled credential patterns coverage', () => {
+    try {
+      requireAckGate()
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain('25 bundled credential patterns')
+      expect(msg).toContain('GitHub')
+      expect(msg).toContain('AWS access key ID')
+      expect(msg).toContain('Stripe')
+      expect(msg).toContain('OpenAI')
+      expect(msg).toContain('Anthropic')
+    }
+  })
+
+  test('ack message names residual risks', () => {
+    try {
+      requireAckGate()
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain('AWS Secret Access Keys')
+      expect(msg).toContain('JWTs')
+      expect(msg).toContain('cwd values')
+      expect(msg).toContain('stdin')
+    }
+  })
+
+  test('ack message references scan and re-redact CLIs', () => {
+    try {
+      requireAckGate()
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain('shell-cassette scan')
+      expect(msg).toContain('shell-cassette re-redact')
+    }
+  })
+
+  test('ack message references config.redact.envKeys (not deprecated redactEnvKeys)', () => {
+    try {
+      requireAckGate()
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain('config.redact.envKeys')
+      expect(msg).not.toContain('redactEnvKeys')
+    }
+  })
+
+  test('ack message references config.redact.customPatterns', () => {
+    try {
+      requireAckGate()
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain('config.redact.customPatterns')
     }
   })
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -7,10 +7,6 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.cassetteDir).toBe('__cassettes__')
   })
 
-  test('has empty redactEnvKeys', () => {
-    expect(DEFAULT_CONFIG.redactEnvKeys).toEqual([])
-  })
-
   test('default canonicalize returns command + args', () => {
     const call = { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null } as const
     expect(DEFAULT_CONFIG.canonicalize(call)).toEqual({ command: 'git', args: ['status'] })
@@ -33,11 +29,6 @@ describe('mergeWithDefaults', () => {
     expect(result.cassetteDir).toBe('cassettes')
   })
 
-  test('overrides redactEnvKeys', () => {
-    const result = mergeWithDefaults({ redactEnvKeys: ['STRIPE_KEY'] })
-    expect(result.redactEnvKeys).toEqual(['STRIPE_KEY'])
-  })
-
   test('result is frozen', () => {
     const result = mergeWithDefaults({})
     expect(Object.isFrozen(result)).toBe(true)
@@ -57,11 +48,6 @@ describe('validateConfig', () => {
 
   test('throws if cassetteDir is not string', () => {
     expect(() => validateConfig({ cassetteDir: 42 })).toThrow(CassetteConfigError)
-  })
-
-  test('throws if redactEnvKeys is not array of strings', () => {
-    expect(() => validateConfig({ redactEnvKeys: 'foo' })).toThrow(CassetteConfigError)
-    expect(() => validateConfig({ redactEnvKeys: [1, 2] })).toThrow(CassetteConfigError)
   })
 
   test('throws if canonicalize is not function', () => {
@@ -90,22 +76,6 @@ describe('Config defaults: redact field', () => {
 })
 
 describe('mergeWithDefaults: redact field', () => {
-  test('user-provided redact.envKeys takes precedence over redactEnvKeys', () => {
-    const merged = mergeWithDefaults({
-      redact: { envKeys: ['FROM_REDACT'] },
-      redactEnvKeys: ['FROM_FLAT'],
-    })
-    expect(merged.redact.envKeys).toEqual(['FROM_REDACT'])
-    // Both fields stay in sync; deprecated field reflects the resolved value.
-    expect(merged.redactEnvKeys).toEqual(['FROM_REDACT'])
-  })
-
-  test('user-provided redactEnvKeys without redact.envKeys: both fields populated', () => {
-    const merged = mergeWithDefaults({ redactEnvKeys: ['STRIPE_KEY'] })
-    expect(merged.redactEnvKeys).toEqual(['STRIPE_KEY'])
-    expect(merged.redact.envKeys).toEqual(['STRIPE_KEY'])
-  })
-
   test('user-provided redact: { bundledPatterns: false }: only that field overridden', () => {
     const merged = mergeWithDefaults({ redact: { bundledPatterns: false } })
     expect(merged.redact.bundledPatterns).toBe(false)

--- a/tests/unit/recorder.test.ts
+++ b/tests/unit/recorder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
 import { record } from '../../src/recorder.js'
 import type { Call, CassetteSession, Result } from '../../src/types.js'
 
@@ -8,8 +9,12 @@ const baseSession = (): CassetteSession => ({
   scopeDefault: 'auto',
   loadedFile: null,
   matcher: null,
+  canonicalize: DEFAULT_CONFIG.canonicalize,
+  redactConfig: DEFAULT_CONFIG.redact,
+  redactEnabled: true,
+  redactCounters: new Map(),
+  redactionEntries: [],
   newRecordings: [],
-  redactedKeys: [],
   warnings: [],
 })
 
@@ -34,16 +39,25 @@ const resultOf = (): Result => ({
 describe('record', () => {
   test('appends a recording to session.newRecordings', () => {
     const session = baseSession()
-    record(callOf(), resultOf(), session, { redactEnvKeys: [] })
+    record(callOf(), resultOf(), session)
     expect(session.newRecordings).toHaveLength(1)
     expect(session.newRecordings[0]?.call.command).toBe('git')
   })
 
-  test('redacts env in the appended recording', () => {
+  test('redacts env in the appended recording via env-key-match rule', () => {
     const session = baseSession()
     const call = callOf({ MY_TOKEN: 'secret', SAFE: 'public' })
-    record(call, resultOf(), session, { redactEnvKeys: [] })
-    expect(session.newRecordings[0]?.call.env.MY_TOKEN).toBe('<redacted>')
+    record(call, resultOf(), session)
+    expect(session.newRecordings[0]?.call.env.MY_TOKEN).toBe('<redacted:env:env-key-match:1>')
     expect(session.newRecordings[0]?.call.env.SAFE).toBe('public')
+  })
+
+  test('redactEnabled: false bypasses pipeline', () => {
+    const session = baseSession()
+    session.redactEnabled = false
+    const call = callOf({ MY_TOKEN: 'secret' })
+    record(call, resultOf(), session)
+    expect(session.newRecordings[0]?.call.env.MY_TOKEN).toBe('secret')
+    expect(session.newRecordings[0]?.redactions).toEqual([])
   })
 })

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -516,16 +516,42 @@ describe('seedCountersFromCassette', () => {
     expect(counters.get('allLines:r')).toBe(5)
   })
 
-  test('multiple recordings: max across all is the ceiling', () => {
+  test('multiple recordings: counts accumulate (sum) across recordings', () => {
     const cassette: CassetteFile = {
       version: 2,
       recordedBy: null,
       recordings: [
-        { ...emptyRec(), redactions: [{ rule: 'r', source: 'env', count: 2 }] },
-        { ...emptyRec(), redactions: [{ rule: 'r', source: 'env', count: 5 }] },
+        {
+          call: { command: 'curl', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          redactions: [{ rule: 'r', source: 'env', count: 2 }],
+        },
+        {
+          call: { command: 'curl', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          redactions: [{ rule: 'r', source: 'env', count: 5 }],
+        },
       ],
     }
     const counters = seedCountersFromCassette(cassette)
-    expect(counters.get('env:r')).toBe(5)
+    // rec1 count=2 (placeholders :1, :2) + rec2 count=5 (placeholders :3..:7)
+    // Sum = 7. Next emission should produce :8.
+    expect(counters.get('env:r')).toBe(7)
   })
 })

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { runPipeline, stripCounter } from '../../src/redact-pipeline.js'
-import type { RedactConfig } from '../../src/types.js'
+import { runPipeline, seedCountersFromCassette, stripCounter } from '../../src/redact-pipeline.js'
+import type { CassetteFile, RedactConfig } from '../../src/types.js'
 
 const baseConfig: RedactConfig = {
   bundledPatterns: false,
@@ -391,5 +391,141 @@ describe('stripCounter', () => {
 
   test('leaves stripped placeholders unchanged', () => {
     expect(stripCounter('<redacted:env:rule>')).toBe('<redacted:env:rule>')
+  })
+})
+
+const emptyRec = (): CassetteFile['recordings'][number] => ({
+  call: { command: 'curl', args: [], cwd: null, env: {}, stdin: null },
+  result: {
+    stdoutLines: [],
+    stderrLines: [],
+    allLines: null,
+    exitCode: 0,
+    signal: null,
+    durationMs: 0,
+    aborted: false,
+  },
+  redactions: [],
+})
+
+describe('seedCountersFromCassette', () => {
+  test('returns empty map for cassette with no recordings', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: { name: 'shell-cassette', version: '0.4.0' },
+      recordings: [],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.size).toBe(0)
+  })
+
+  test('seeds from per-recording redactions metadata', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          ...emptyRec(),
+          redactions: [
+            { rule: 'github-pat-classic', source: 'env', count: 3 },
+            { rule: 'aws-access-key-id', source: 'args', count: 1 },
+          ],
+        },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.get('env:github-pat-classic')).toBe(3)
+    expect(counters.get('args:aws-access-key-id')).toBe(1)
+  })
+
+  test('seeds from placeholder counters in body when metadata is stale', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          ...emptyRec(),
+          call: {
+            command: 'curl',
+            args: ['Bearer <redacted:args:github-pat-classic:5>'],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+        },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.get('args:github-pat-classic')).toBe(5)
+  })
+
+  test('takes max when both metadata and body contribute', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          ...emptyRec(),
+          call: {
+            command: 'curl',
+            args: ['<redacted:args:github-pat-classic:7>'],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+          redactions: [{ rule: 'github-pat-classic', source: 'args', count: 4 }],
+        },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    // Body has :7, metadata has :4. Max wins.
+    expect(counters.get('args:github-pat-classic')).toBe(7)
+  })
+
+  test('walks all 5 sources in body', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          ...emptyRec(),
+          call: {
+            command: 'curl',
+            args: ['<redacted:args:r:1>'],
+            cwd: null,
+            env: { FOO: '<redacted:env:r:2>' },
+            stdin: null,
+          },
+          result: {
+            stdoutLines: ['<redacted:stdout:r:3>'],
+            stderrLines: ['<redacted:stderr:r:4>'],
+            allLines: ['<redacted:allLines:r:5>'],
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+        },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.get('args:r')).toBe(1)
+    expect(counters.get('env:r')).toBe(2)
+    expect(counters.get('stdout:r')).toBe(3)
+    expect(counters.get('stderr:r')).toBe(4)
+    expect(counters.get('allLines:r')).toBe(5)
+  })
+
+  test('multiple recordings: max across all is the ceiling', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        { ...emptyRec(), redactions: [{ rule: 'r', source: 'env', count: 2 }] },
+        { ...emptyRec(), redactions: [{ rule: 'r', source: 'env', count: 5 }] },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.get('env:r')).toBe(5)
   })
 })

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -1,117 +1,52 @@
 import { describe, expect, test } from 'vitest'
-import { CURATED_KEYS, redactEnv } from '../../src/redact.js'
+import { BUNDLED_PATTERNS, redact } from '../../src/redact.js'
+import type { RedactConfig } from '../../src/types.js'
 
-const defaultConfig = { redactEnvKeys: [] as string[] }
+const baseConfig: RedactConfig = {
+  bundledPatterns: false,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+}
 
-describe('redactEnv (curated list)', () => {
-  test('redacts TOKEN, SECRET, PASSWORD, JWT keys', () => {
-    const env = {
-      MY_TOKEN: 'abc',
-      USER_SECRET: 'def',
-      DB_PASSWORD: 'ghi',
-      JWT_KEY: 'jkl',
-      SAFE_VAR: 'public',
-    }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.redacted.MY_TOKEN).toBe('<redacted>')
-    expect(result.redacted.USER_SECRET).toBe('<redacted>')
-    expect(result.redacted.DB_PASSWORD).toBe('<redacted>')
-    expect(result.redacted.JWT_KEY).toBe('<redacted>')
-    expect(result.redacted.SAFE_VAR).toBe('public')
-    expect(result.redactedKeys).toEqual(
-      expect.arrayContaining(['MY_TOKEN', 'USER_SECRET', 'DB_PASSWORD', 'JWT_KEY']),
+describe('public redact() wraps pipeline', () => {
+  test('bundledPatterns: false — input unchanged for credential-shaped value', () => {
+    const r = redact(
+      { source: 'env', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      baseConfig,
+      { counted: false },
     )
+    expect(r.output).toBe('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(r.entries).toEqual([])
+    expect(r.warnings).toEqual([])
   })
 
-  test('case-insensitive substring match', () => {
-    const env = { my_token_value: 'abc', SeCrEt: 'def' }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.redacted.my_token_value).toBe('<redacted>')
-    expect(result.redacted.SeCrEt).toBe('<redacted>')
+  test('counted: false — emits placeholder without counter', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const r = redact({ source: 'env', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' }, config, {
+      counted: false,
+    })
+    expect(r.output).toBe('<redacted:env:github-pat-classic>')
   })
 
-  test('does not redact PUBLIC_KEY (curated has PRIVATE_KEY only)', () => {
-    const env = { PUBLIC_KEY: 'pubdata', PRIVATE_KEY: 'privdata' }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.redacted.PUBLIC_KEY).toBe('pubdata')
-    expect(result.redacted.PRIVATE_KEY).toBe('<redacted>')
+  test('counted: true — increments counter and returns counted placeholder', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const counters = new Map<string, number>()
+    const r = redact({ source: 'env', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' }, config, {
+      counted: true,
+      counters,
+    })
+    expect(r.output).toBe('<redacted:env:github-pat-classic:1>')
+    expect(counters.get('env:github-pat-classic')).toBe(1)
   })
 
-  test('does not redact bare KEY-suffix names like STRIPE_KEY (documented gap)', () => {
-    const env = { STRIPE_KEY: 'sk_live_xyz', OPENAI_KEY: 'sk-abc' }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.redacted.STRIPE_KEY).toBe('sk_live_xyz')
-    expect(result.redacted.OPENAI_KEY).toBe('sk-abc')
-  })
-})
-
-describe('redactEnv (user-extended via config)', () => {
-  test('config.redactEnvKeys adds to curated list', () => {
-    const env = { STRIPE_KEY: 'sk_live_xyz', NORMAL: 'safe' }
-    const result = redactEnv(env, { redactEnvKeys: ['STRIPE_KEY'] })
-    expect(result.redacted.STRIPE_KEY).toBe('<redacted>')
-    expect(result.redacted.NORMAL).toBe('safe')
-  })
-
-  test('config keys are case-insensitive substring like curated', () => {
-    const env = { my_stripe_key: 'sk', X: 'safe' }
-    const result = redactEnv(env, { redactEnvKeys: ['STRIPE'] })
-    expect(result.redacted.my_stripe_key).toBe('<redacted>')
-  })
-
-  test('curated still applies when user adds extras', () => {
-    const env = { TOKEN: 'a', STRIPE_KEY: 'b' }
-    const result = redactEnv(env, { redactEnvKeys: ['STRIPE'] })
-    expect(result.redacted.TOKEN).toBe('<redacted>')
-    expect(result.redacted.STRIPE_KEY).toBe('<redacted>')
-  })
-})
-
-describe('redactEnv (length warnings)', () => {
-  test('emits warning for unredacted env value > 100 chars', () => {
-    const env = { LONG_VAR: 'a'.repeat(150) }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.warnings.length).toBe(1)
-    expect(result.warnings[0]).toContain('LONG_VAR')
-    expect(result.warnings[0]).toContain('150')
-  })
-
-  test('no warning at exactly 100 chars', () => {
-    const env = { VAR: 'a'.repeat(100) }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.warnings.length).toBe(0)
-  })
-
-  test('warning at 101 chars', () => {
-    const env = { VAR: 'a'.repeat(101) }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.warnings.length).toBe(1)
-  })
-
-  test('no warning for redacted long values', () => {
-    const env = { GH_TOKEN: 'a'.repeat(150) }
-    const result = redactEnv(env, defaultConfig)
-    expect(result.warnings.length).toBe(0)
-  })
-})
-
-describe('CURATED_KEYS exposed for testing/inspection', () => {
-  test('contains expected items', () => {
-    const expected = [
-      'TOKEN',
-      'SECRET',
-      'PASSWORD',
-      'PASSWD',
-      'APIKEY',
-      'API_KEY',
-      'CREDENTIAL',
-      'PRIVATE_KEY',
-      'AUTH_TOKEN',
-      'BEARER_TOKEN',
-      'JWT',
-    ]
-    for (const key of expected) {
-      expect(CURATED_KEYS).toContain(key)
-    }
+  test('BUNDLED_PATTERNS exports 25 rules with stable names', () => {
+    expect(BUNDLED_PATTERNS.length).toBe(25)
+    const names = BUNDLED_PATTERNS.map((r) => r.name)
+    expect(names).toContain('github-pat-classic')
+    expect(names).toContain('aws-access-key-id')
+    expect(names).toContain('openai-api-key')
   })
 })

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -257,9 +257,9 @@ describe('runWrapped (envelope)', () => {
       expect(e).toBeInstanceOf(AckRequiredError)
       const msg = (e as Error).message
       // Positive assertion: explicit-record path returns the unmodified ack
-      // help text from src/ack.ts, which starts with "refusing to record".
+      // help text from src/ack.ts, which starts with "shell-cassette is about".
       // Augmented messages instead start with "auto mode:".
-      expect(msg.startsWith('refusing to record')).toBe(true)
+      expect(msg.startsWith('shell-cassette is about')).toBe(true)
       expect(msg).toContain('SHELL_CASSETTE_ACK_REDACTION')
     } finally {
       expect(realCall).not.toHaveBeenCalled()


### PR DESCRIPTION
## What Changed

- Recorder applies redact pipeline across env, args, stdout, stderr, allLines.
- `CassetteSession` type updated (drops `redactedKeys`, adds `redactConfig`, `redactEnabled`, `redactCounters`, `redactionEntries`).
- Full rewrite of `src/redact.ts` (drops the older `redactEnv`/`RedactConfig`/`RedactResult`/`LONG_VALUE_THRESHOLD`/`CURATED_KEYS`).
- Extracted `CURATED_ENV_KEYS` to `src/curated-env-keys.ts`.
- Removed deprecated `Config.redactEnvKeys` field.
- Ack-gate message rewritten: the previous message would have shipped factually wrong (it said "doesn't redact stdout/stderr/args" while the new pipeline does redact those).

## Counter seeding

Implements `seedCountersFromCassette()` and wires it into the lazy cassette load. Without this, auto-additive appends would produce counter collisions (a fresh `:1` against an existing `:1`). Two sources walked:

- Per-recording `redactions` metadata.
- Regex scan of all 5 body fields for `<redacted:source:rule:N>` placeholders (handles hand-edited cassettes with stale metadata).

## Doc fixes

README and `troubleshooting.md` examples renamed `redactEnvKeys` to `redact.envKeys`. Full doc rewrite is in a later PR.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (352 passed, 1 pre-existing skip)
- [x] `npm run build` produces clean dist/