### PR TITLE
feat(redact): canonicalize integration with redact pipeline

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,13 +1,31 @@
 import { log } from './log.js'
 import { normalizeTmpPath } from './normalize.js'
-import type { Call, Canonicalize, MatcherStateLike, Recording } from './types.js'
+import { runPipeline, stripCounter } from './redact-pipeline.js'
+import type { Call, Canonicalize, MatcherStateLike, Recording, RedactConfig } from './types.js'
 
 // cwd/env/stdin are omitted: their values vary per-machine and would break
 // cross-machine replay. Users who need them must opt in via custom canonicalize.
-export const defaultCanonicalize: Canonicalize = (call) => ({
-  command: call.command,
-  args: call.args.map(normalizeTmpPath),
-})
+export const defaultCanonicalize: Canonicalize = (call, opts) => {
+  const redactConfig = opts?.redactConfig
+  return {
+    command: call.command,
+    args: call.args.map((arg) => {
+      // 1. v0.3: normalize mkdtemp paths
+      const tmpNormalized = normalizeTmpPath(arg)
+      // 2. v0.4: strip counter from counter-tagged placeholders. Handles cassette
+      //    args during match-time canonicalization. Idempotent on stripped form.
+      const stripped = stripCounter(tmpNormalized)
+      // 3. v0.4: apply pipeline in stripped mode (no counter). For fresh-call args
+      //    containing raw credentials, this produces the same form as cassette args
+      //    after stripCounter. Both arms canonicalize to identical strings.
+      if (redactConfig) {
+        const r = runPipeline({ source: 'args', value: stripped }, redactConfig, { counted: false })
+        return r.output
+      }
+      return stripped
+    }),
+  }
+}
 
 export class MatcherState implements MatcherStateLike {
   private consumedIndices: Set<number> = new Set()
@@ -16,12 +34,15 @@ export class MatcherState implements MatcherStateLike {
   constructor(
     private readonly recordings: readonly Recording[],
     private readonly canonicalize: Canonicalize,
+    private readonly redactConfig?: Readonly<RedactConfig>,
   ) {
-    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call))
+    const opts = redactConfig ? { redactConfig } : undefined
+    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call, opts))
   }
 
   findMatch(call: Call): Recording | null {
-    const canonicalCall = this.canonicalize(call)
+    const opts = this.redactConfig ? { redactConfig: this.redactConfig } : undefined
+    const canonicalCall = this.canonicalize(call, opts)
     const candidates: { index: number; rec: Recording }[] = []
     for (let i = 0; i < this.recordings.length; i++) {
       if (this.consumedIndices.has(i)) continue

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,6 +1,7 @@
 import { log } from './log.js'
 import { normalizeTmpPath } from './normalize.js'
-import { runPipeline, stripCounter } from './redact-pipeline.js'
+import { redact } from './redact.js'
+import { stripCounter } from './redact-pipeline.js'
 import type { Call, Canonicalize, MatcherStateLike, Recording, RedactConfig } from './types.js'
 
 // cwd/env/stdin are omitted: their values vary per-machine and would break
@@ -23,8 +24,7 @@ export const defaultCanonicalize: Canonicalize = (call, opts) => {
       //    identical strings; stripped mode is the only mode that gives that
       //    invariant.
       if (redactConfig) {
-        return runPipeline({ source: 'args', value: stripped }, redactConfig, { counted: false })
-          .output
+        return redact({ source: 'args', value: stripped }, redactConfig, { counted: false }).output
       }
       return stripped
     }),

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -6,27 +6,24 @@ import type { Call, Canonicalize, MatcherStateLike, Recording, RedactConfig } fr
 
 // cwd/env/stdin are omitted: their values vary per-machine and would break
 // cross-machine replay. Users who need them must opt in via custom canonicalize.
-export const defaultCanonicalize: Canonicalize = (call, opts) => {
-  const redactConfig = opts?.redactConfig
+export const defaultCanonicalize: Canonicalize = (call, redactConfig) => {
   return {
     command: call.command,
     args: call.args.map((arg) => {
       // 1. v0.3: normalize mkdtemp paths
       const tmpNormalized = normalizeTmpPath(arg)
-      // 2. v0.4: strip counter from counter-tagged placeholders. Handles cassette
-      //    args during match-time canonicalization. Idempotent on stripped form.
+      // 2. v0.4: strip counter from any cassette-stored counter-tagged
+      //    placeholders. Idempotent: counter-stripped form passes through
+      //    unchanged.
       const stripped = stripCounter(tmpNormalized)
       // 3. v0.4: apply pipeline in stripped mode for fresh-call args
       //    containing raw credentials. counted: false is required because
       //    counted: true would emit `:N` suffixes driven by current-session
       //    counter state, which would differ from the stripped cassette form
       //    (where counters were stripped in step 2). Both arms must produce
-      //    identical strings; stripped mode is the only mode that gives that
-      //    invariant.
-      if (redactConfig) {
-        return redact({ source: 'args', value: stripped }, redactConfig, { counted: false }).output
-      }
-      return stripped
+      //    identical strings; stripped mode is the only mode that gives
+      //    that invariant.
+      return redact({ source: 'args', value: stripped }, redactConfig, { counted: false }).output
     }),
   }
 }
@@ -34,21 +31,17 @@ export const defaultCanonicalize: Canonicalize = (call, opts) => {
 export class MatcherState implements MatcherStateLike {
   private consumedIndices: Set<number> = new Set()
   private canonicalRecordings: ReadonlyArray<Partial<Call>>
-  // Hoisted to constructor: constant for the lifetime of this matcher instance.
-  // Previously allocated per findMatch call; now allocated once.
-  private readonly opts: { redactConfig: Readonly<RedactConfig> } | undefined
 
   constructor(
     private readonly recordings: readonly Recording[],
     private readonly canonicalize: Canonicalize,
-    redactConfig?: Readonly<RedactConfig>,
+    private readonly redactConfig: Readonly<RedactConfig>,
   ) {
-    this.opts = redactConfig ? { redactConfig } : undefined
-    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call, this.opts))
+    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call, redactConfig))
   }
 
   findMatch(call: Call): Recording | null {
-    const canonicalCall = this.canonicalize(call, this.opts)
+    const canonicalCall = this.canonicalize(call, this.redactConfig)
     const candidates: { index: number; rec: Recording }[] = []
     for (let i = 0; i < this.recordings.length; i++) {
       if (this.consumedIndices.has(i)) continue

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -15,12 +15,16 @@ export const defaultCanonicalize: Canonicalize = (call, opts) => {
       // 2. v0.4: strip counter from counter-tagged placeholders. Handles cassette
       //    args during match-time canonicalization. Idempotent on stripped form.
       const stripped = stripCounter(tmpNormalized)
-      // 3. v0.4: apply pipeline in stripped mode (no counter). For fresh-call args
-      //    containing raw credentials, this produces the same form as cassette args
-      //    after stripCounter. Both arms canonicalize to identical strings.
+      // 3. v0.4: apply pipeline in stripped mode for fresh-call args
+      //    containing raw credentials. counted: false is required because
+      //    counted: true would emit `:N` suffixes driven by current-session
+      //    counter state, which would differ from the stripped cassette form
+      //    (where counters were stripped in step 2). Both arms must produce
+      //    identical strings; stripped mode is the only mode that gives that
+      //    invariant.
       if (redactConfig) {
-        const r = runPipeline({ source: 'args', value: stripped }, redactConfig, { counted: false })
-        return r.output
+        return runPipeline({ source: 'args', value: stripped }, redactConfig, { counted: false })
+          .output
       }
       return stripped
     }),
@@ -30,19 +34,21 @@ export const defaultCanonicalize: Canonicalize = (call, opts) => {
 export class MatcherState implements MatcherStateLike {
   private consumedIndices: Set<number> = new Set()
   private canonicalRecordings: ReadonlyArray<Partial<Call>>
+  // Hoisted to constructor: constant for the lifetime of this matcher instance.
+  // Previously allocated per findMatch call; now allocated once.
+  private readonly opts: { redactConfig: Readonly<RedactConfig> } | undefined
 
   constructor(
     private readonly recordings: readonly Recording[],
     private readonly canonicalize: Canonicalize,
-    private readonly redactConfig?: Readonly<RedactConfig>,
+    redactConfig?: Readonly<RedactConfig>,
   ) {
-    const opts = redactConfig ? { redactConfig } : undefined
-    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call, opts))
+    this.opts = redactConfig ? { redactConfig } : undefined
+    this.canonicalRecordings = recordings.map((r) => canonicalize(r.call, this.opts))
   }
 
   findMatch(call: Call): Recording | null {
-    const opts = this.redactConfig ? { redactConfig: this.redactConfig } : undefined
-    const canonicalCall = this.canonicalize(call, opts)
+    const canonicalCall = this.canonicalize(call, this.opts)
     const candidates: { index: number; rec: Recording }[] = []
     for (let i = 0; i < this.recordings.length; i++) {
       if (this.consumedIndices.has(i)) continue

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -176,6 +176,11 @@ function applyRegexRule(
 // instances from this string so lastIndex state never leaks between callers.
 const COUNTER_PLACEHOLDER_PATTERN = '<redacted:([^:>]+):([^:>]+):(\\d+)>'
 
+// Hoisted to module level: String.prototype.replace resets lastIndex to 0
+// after completion (per ECMAScript spec), so reusing this regex across calls
+// is safe. Avoids one RegExp allocation per arg per findMatch call.
+const STRIP_COUNTER_REGEX = new RegExp(COUNTER_PLACEHOLDER_PATTERN, 'g')
+
 /**
  * Replace counter-tagged placeholders with their counter-stripped form.
  * Used by the canonicalize pipeline at match time so cassette args containing
@@ -183,7 +188,7 @@ const COUNTER_PLACEHOLDER_PATTERN = '<redacted:([^:>]+):([^:>]+):(\\d+)>'
  * in stripped mode. Stripped placeholders pass through unchanged.
  */
 export function stripCounter(s: string): string {
-  return s.replace(new RegExp(COUNTER_PLACEHOLDER_PATTERN, 'g'), '<redacted:$1:$2>')
+  return s.replace(STRIP_COUNTER_REGEX, '<redacted:$1:$2>')
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,10 @@ export type CassetteFile = {
   recordings: Recording[]
 }
 
-export type Canonicalize = (call: Call) => Partial<Call>
+export type Canonicalize = (
+  call: Call,
+  opts?: { redactConfig?: Readonly<RedactConfig> },
+) => Partial<Call>
 
 export type RedactSource = 'env' | 'args' | 'stdout' | 'stderr' | 'allLines'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,10 +45,7 @@ export type CassetteFile = {
   recordings: Recording[]
 }
 
-export type Canonicalize = (
-  call: Call,
-  opts?: { redactConfig?: Readonly<RedactConfig> },
-) => Partial<Call>
+export type Canonicalize = (call: Call, redactConfig: Readonly<RedactConfig>) => Partial<Call>
 
 export type RedactSource = 'env' | 'args' | 'stdout' | 'stderr' | 'allLines'
 

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -158,8 +158,7 @@ function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
 const REPLAY_MISS_DIAGNOSTIC_LIMIT = 10
 
 function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
-  const opts = session.redactConfig ? { redactConfig: session.redactConfig } : undefined
-  const canonical = session.canonicalize(call, opts)
+  const canonical = session.canonicalize(call, session.redactConfig)
   const recordings = session.loadedFile?.recordings ?? []
   const shown = recordings.slice(0, REPLAY_MISS_DIAGNOSTIC_LIMIT)
   const truncated =
@@ -170,8 +169,9 @@ function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissE
     ? shown.map((r) => formatCallSignature(r.call)).join('\n  - ') + truncated
     : '(none)'
   const recordedCanonical = shown.length
-    ? shown.map((r) => JSON.stringify(session.canonicalize(r.call, opts))).join('\n  - ') +
-      truncated
+    ? shown
+        .map((r) => JSON.stringify(session.canonicalize(r.call, session.redactConfig)))
+        .join('\n  - ') + truncated
     : '(none)'
   return new ReplayMissError(
     `no matching recording for \`${formatCallSignature(call)}\`

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -158,7 +158,8 @@ function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
 const REPLAY_MISS_DIAGNOSTIC_LIMIT = 10
 
 function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
-  const canonical = session.canonicalize(call)
+  const opts = session.redactConfig ? { redactConfig: session.redactConfig } : undefined
+  const canonical = session.canonicalize(call, opts)
   const recordings = session.loadedFile?.recordings ?? []
   const shown = recordings.slice(0, REPLAY_MISS_DIAGNOSTIC_LIMIT)
   const truncated =
@@ -169,7 +170,8 @@ function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissE
     ? shown.map((r) => formatCallSignature(r.call)).join('\n  - ') + truncated
     : '(none)'
   const recordedCanonical = shown.length
-    ? shown.map((r) => JSON.stringify(session.canonicalize(r.call))).join('\n  - ') + truncated
+    ? shown.map((r) => JSON.stringify(session.canonicalize(r.call, opts))).join('\n  - ') +
+      truncated
     : '(none)'
   return new ReplayMissError(
     `no matching recording for \`${formatCallSignature(call)}\`

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -68,7 +68,11 @@ export async function runWrapped<Opts, ResultShape>(
         session.redactCounters.set(k, v)
       }
     }
-    session.matcher = new MatcherState(session.loadedFile?.recordings ?? [], session.canonicalize)
+    session.matcher = new MatcherState(
+      session.loadedFile?.recordings ?? [],
+      session.canonicalize,
+      session.redactConfig,
+    )
   }
 
   const mode = resolveMode(

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,0 +1,39 @@
+import type { Call, Recording } from '../../src/types.js'
+
+/**
+ * Build a minimal Call with sensible defaults. Callers override only the fields
+ * they care about.
+ */
+export const callOf = (command: string, args: string[], extra: Partial<Call> = {}): Call => ({
+  command,
+  args,
+  cwd: null,
+  env: {},
+  stdin: null,
+  ...extra,
+})
+
+/**
+ * Build a minimal Recording. The `stdout` shorthand sets stdoutLines to
+ * [stdout, ''] and stderrLines to [''] (matches the typical single-line
+ * capture shape). Pass `resultOverrides` for any other result field.
+ */
+export const recordingOf = (
+  command: string,
+  args: string[],
+  stdout = '',
+  resultOverrides: Partial<Recording['result']> = {},
+): Recording => ({
+  call: callOf(command, args),
+  result: {
+    stdoutLines: [stdout, ''],
+    stderrLines: [''],
+    allLines: null,
+    exitCode: 0,
+    signal: null,
+    durationMs: 1,
+    aborted: false,
+    ...resultOverrides,
+  },
+  redactions: [],
+})

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -25,7 +25,11 @@ export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteS
     ...overrides,
   }
   if (base.loadedFile !== null && base.matcher === null) {
-    base.matcher = new MatcherState(base.loadedFile.recordings, base.canonicalize)
+    base.matcher = new MatcherState(
+      base.loadedFile.recordings,
+      base.canonicalize,
+      base.redactConfig,
+    )
   }
   return base
 }

--- a/tests/integration/canonicalize-redact.test.ts
+++ b/tests/integration/canonicalize-redact.test.ts
@@ -190,4 +190,47 @@ describe('canonicalize-time redact for args', () => {
     expect(canon.args?.[0]).toContain('<tmp>')
     expect(canon.args?.[0]).toContain('<redacted:args:github-pat-classic>')
   })
+
+  test('replay-miss error message does not contain raw credential from fresh-call args', () => {
+    // Regression guard for the buildReplayMissError credential-leak fix.
+    // The error message is built from session.canonicalize(call, opts) where
+    // opts carries redactConfig. This test verifies the canonical form (which
+    // is what gets stringified into the error message) is credential-free.
+    const recording: Recording = {
+      call: {
+        command: 'curl',
+        args: ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+        cwd: null,
+        env: {},
+        stdin: null,
+      },
+      result: {
+        stdoutLines: [],
+        stderrLines: [],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+        aborted: false,
+      },
+      redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
+    }
+    const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
+
+    // Different command so it won't match (credential is still present in args).
+    const freshCall: Call = {
+      command: 'wget',
+      args: ['-H', 'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    expect(matcher.findMatch(freshCall)).toBe(null)
+
+    // Verify the canonical form that buildReplayMissError would stringify is credential-free.
+    const canonical = defaultCanonicalize(freshCall, { redactConfig: DEFAULT_CONFIG.redact })
+    const stringified = JSON.stringify(canonical)
+    expect(stringified).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(stringified).toContain('<redacted:args:github-pat-classic>')
+  })
 })

--- a/tests/integration/canonicalize-redact.test.ts
+++ b/tests/integration/canonicalize-redact.test.ts
@@ -1,174 +1,85 @@
 import { describe, expect, test } from 'vitest'
 import { DEFAULT_CONFIG } from '../../src/config.js'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
-import type { Call, Recording } from '../../src/types.js'
+import { callOf, recordingOf } from '../helpers/fixtures.js'
 
 describe('canonicalize-time redact for args', () => {
   test('cassette args with counter-tagged placeholder match fresh call with raw credential', () => {
-    const cassetteCall: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer <redacted:args:github-pat-classic:1>'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
-    const freshCall: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const cassetteCall = callOf('curl', [
+      'Authorization: Bearer <redacted:args:github-pat-classic:1>',
+    ])
+    const freshCall = callOf('curl', [
+      'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+    ])
     const cassetteCanon = defaultCanonicalize(cassetteCall, { redactConfig: DEFAULT_CONFIG.redact })
     const freshCanon = defaultCanonicalize(freshCall, { redactConfig: DEFAULT_CONFIG.redact })
     expect(cassetteCanon).toEqual(freshCanon)
   })
 
   test('two different real credentials canonicalize to same form (both redacted to placeholder)', () => {
-    const a: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
-    const b: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const a = callOf('curl', ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'])
+    const b = callOf('curl', ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'])
     const ac = defaultCanonicalize(a, { redactConfig: DEFAULT_CONFIG.redact })
     const bc = defaultCanonicalize(b, { redactConfig: DEFAULT_CONFIG.redact })
     expect(ac).toEqual(bc)
   })
 
   test('args with NO credential do not get touched by redact (idempotent on benign args)', () => {
-    const call: Call = {
-      command: 'echo',
-      args: ['hello', 'world'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const call = callOf('echo', ['hello', 'world'])
     const canon = defaultCanonicalize(call, { redactConfig: DEFAULT_CONFIG.redact })
     expect(canon.args).toEqual(['hello', 'world'])
   })
 
   test('canonicalize without redactConfig: counter-strip still applies (idempotent on stripped form)', () => {
-    const cassetteCall: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer <redacted:args:github-pat-classic:5>'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const cassetteCall = callOf('curl', [
+      'Authorization: Bearer <redacted:args:github-pat-classic:5>',
+    ])
     const canon = defaultCanonicalize(cassetteCall)
     expect(canon.args).toEqual(['Authorization: Bearer <redacted:args:github-pat-classic>'])
   })
 
   test('MatcherState matches a stored cassette with placeholder against a fresh call with real credential', () => {
-    const recording: Recording = {
-      call: {
-        command: 'curl',
-        args: ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
-        cwd: null,
-        env: {},
-        stdin: null,
-      },
-      result: {
-        stdoutLines: ['ok'],
-        stderrLines: [],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 100,
-        aborted: false,
-      },
-      redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
-    }
+    const recording = recordingOf(
+      'curl',
+      ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+      'ok',
+      { stderrLines: [], durationMs: 100 },
+    )
+    recording.redactions = [{ rule: 'github-pat-classic', source: 'args', count: 1 }]
 
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
 
-    const freshCall: Call = {
-      command: 'curl',
-      args: ['-H', 'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
-    const matched = matcher.findMatch(freshCall)
-    expect(matched).toBe(recording)
+    const freshCall = callOf('curl', [
+      '-H',
+      'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+    ])
+    expect(matcher.findMatch(freshCall)).toBe(recording)
   })
 
   test('MatcherState does NOT match a fresh call with no credential against a cassette with one', () => {
-    const recording: Recording = {
-      call: {
-        command: 'curl',
-        args: ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
-        cwd: null,
-        env: {},
-        stdin: null,
-      },
-      result: {
-        stdoutLines: [],
-        stderrLines: [],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 100,
-        aborted: false,
-      },
-      redactions: [],
-    }
+    const recording = recordingOf(
+      'curl',
+      ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+      '',
+      { stdoutLines: [], stderrLines: [], durationMs: 100 },
+    )
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
-    const freshCall: Call = {
-      command: 'curl',
-      args: ['-H', 'Authorization: NoCredHere'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const freshCall = callOf('curl', ['-H', 'Authorization: NoCredHere'])
     expect(matcher.findMatch(freshCall)).toBe(null)
   })
 
   test('two fresh calls with different credentials of the same rule: first matches, second is consumed', () => {
-    const recording: Recording = {
-      call: {
-        command: 'curl',
-        args: ['Authorization: Bearer <redacted:args:github-pat-classic:1>'],
-        cwd: null,
-        env: {},
-        stdin: null,
-      },
-      result: {
-        stdoutLines: [],
-        stderrLines: [],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
-    }
+    const recording = recordingOf(
+      'curl',
+      ['Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+      '',
+      { stdoutLines: [], stderrLines: [] },
+    )
+    recording.redactions = [{ rule: 'github-pat-classic', source: 'args', count: 1 }]
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
 
-    const call1: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
-    const call2: Call = {
-      command: 'curl',
-      args: ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const call1 = callOf('curl', ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'])
+    const call2 = callOf('curl', ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'])
     expect(matcher.findMatch(call1)).toBe(recording)
     // Second call: same canonical form, but recording already consumed
     expect(matcher.findMatch(call2)).toBe(null)
@@ -176,55 +87,36 @@ describe('canonicalize-time redact for args', () => {
 
   test('canonicalize integrates with existing tmp-path normalization', () => {
     // Combination: tmp path AND credential in same arg
-    const call: Call = {
-      command: 'curl',
-      args: [
-        '/tmp/test-abc/file.txt --header Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-      ],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const call = callOf('curl', [
+      '/tmp/test-abc/file.txt --header Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+    ])
     const canon = defaultCanonicalize(call, { redactConfig: DEFAULT_CONFIG.redact })
     // Both transforms applied: <tmp> for the path, placeholder for the credential
     expect(canon.args?.[0]).toContain('<tmp>')
     expect(canon.args?.[0]).toContain('<redacted:args:github-pat-classic>')
   })
 
-  test('replay-miss error message does not contain raw credential from fresh-call args', () => {
-    // Regression guard for the buildReplayMissError credential-leak fix.
-    // The error message is built from session.canonicalize(call, opts) where
-    // opts carries redactConfig. This test verifies the canonical form (which
-    // is what gets stringified into the error message) is credential-free.
-    const recording: Recording = {
-      call: {
-        command: 'curl',
-        args: ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
-        cwd: null,
-        env: {},
-        stdin: null,
-      },
-      result: {
-        stdoutLines: [],
-        stderrLines: [],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
-    }
+  test('fresh-call args canonicalize without raw credential when redactConfig is forwarded', () => {
+    // The buildReplayMissError fix in wrapper.ts forwards redactConfig to
+    // canonicalize so the stringified canonical form (used in the error
+    // message text) is credential-free. This test verifies the underlying
+    // property: when redactConfig is forwarded, fresh-call args canonicalize
+    // to placeholder form, not raw credential. The buildReplayMissError
+    // fix is then a thin wrapper around this guarantee.
+    const recording = recordingOf(
+      'curl',
+      ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+      '',
+      { stdoutLines: [], stderrLines: [] },
+    )
+    recording.redactions = [{ rule: 'github-pat-classic', source: 'args', count: 1 }]
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
 
     // Different command so it won't match (credential is still present in args).
-    const freshCall: Call = {
-      command: 'wget',
-      args: ['-H', 'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    }
+    const freshCall = callOf('wget', [
+      '-H',
+      'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+    ])
     expect(matcher.findMatch(freshCall)).toBe(null)
 
     // Verify the canonical form that buildReplayMissError would stringify is credential-free.

--- a/tests/integration/canonicalize-redact.test.ts
+++ b/tests/integration/canonicalize-redact.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
+import type { Call, Recording } from '../../src/types.js'
+
+describe('canonicalize-time redact for args', () => {
+  test('cassette args with counter-tagged placeholder match fresh call with raw credential', () => {
+    const cassetteCall: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const freshCall: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const cassetteCanon = defaultCanonicalize(cassetteCall, { redactConfig: DEFAULT_CONFIG.redact })
+    const freshCanon = defaultCanonicalize(freshCall, { redactConfig: DEFAULT_CONFIG.redact })
+    expect(cassetteCanon).toEqual(freshCanon)
+  })
+
+  test('two different real credentials canonicalize to same form (both redacted to placeholder)', () => {
+    const a: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const b: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const ac = defaultCanonicalize(a, { redactConfig: DEFAULT_CONFIG.redact })
+    const bc = defaultCanonicalize(b, { redactConfig: DEFAULT_CONFIG.redact })
+    expect(ac).toEqual(bc)
+  })
+
+  test('args with NO credential do not get touched by redact (idempotent on benign args)', () => {
+    const call: Call = {
+      command: 'echo',
+      args: ['hello', 'world'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const canon = defaultCanonicalize(call, { redactConfig: DEFAULT_CONFIG.redact })
+    expect(canon.args).toEqual(['hello', 'world'])
+  })
+
+  test('canonicalize without redactConfig: counter-strip still applies (idempotent on stripped form)', () => {
+    const cassetteCall: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer <redacted:args:github-pat-classic:5>'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const canon = defaultCanonicalize(cassetteCall)
+    expect(canon.args).toEqual(['Authorization: Bearer <redacted:args:github-pat-classic>'])
+  })
+
+  test('MatcherState matches a stored cassette with placeholder against a fresh call with real credential', () => {
+    const recording: Recording = {
+      call: {
+        command: 'curl',
+        args: ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+        cwd: null,
+        env: {},
+        stdin: null,
+      },
+      result: {
+        stdoutLines: ['ok'],
+        stderrLines: [],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 100,
+        aborted: false,
+      },
+      redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
+    }
+
+    const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
+
+    const freshCall: Call = {
+      command: 'curl',
+      args: ['-H', 'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const matched = matcher.findMatch(freshCall)
+    expect(matched).toBe(recording)
+  })
+
+  test('MatcherState does NOT match a fresh call with no credential against a cassette with one', () => {
+    const recording: Recording = {
+      call: {
+        command: 'curl',
+        args: ['-H', 'Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+        cwd: null,
+        env: {},
+        stdin: null,
+      },
+      result: {
+        stdoutLines: [],
+        stderrLines: [],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 100,
+        aborted: false,
+      },
+      redactions: [],
+    }
+    const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
+    const freshCall: Call = {
+      command: 'curl',
+      args: ['-H', 'Authorization: NoCredHere'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    expect(matcher.findMatch(freshCall)).toBe(null)
+  })
+
+  test('two fresh calls with different credentials of the same rule: first matches, second is consumed', () => {
+    const recording: Recording = {
+      call: {
+        command: 'curl',
+        args: ['Authorization: Bearer <redacted:args:github-pat-classic:1>'],
+        cwd: null,
+        env: {},
+        stdin: null,
+      },
+      result: {
+        stdoutLines: [],
+        stderrLines: [],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+        aborted: false,
+      },
+      redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
+    }
+    const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
+
+    const call1: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const call2: Call = {
+      command: 'curl',
+      args: ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    expect(matcher.findMatch(call1)).toBe(recording)
+    // Second call: same canonical form, but recording already consumed
+    expect(matcher.findMatch(call2)).toBe(null)
+  })
+
+  test('canonicalize integrates with existing tmp-path normalization', () => {
+    // Combination: tmp path AND credential in same arg
+    const call: Call = {
+      command: 'curl',
+      args: [
+        '/tmp/test-abc/file.txt --header Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+      ],
+      cwd: null,
+      env: {},
+      stdin: null,
+    }
+    const canon = defaultCanonicalize(call, { redactConfig: DEFAULT_CONFIG.redact })
+    // Both transforms applied: <tmp> for the path, placeholder for the credential
+    expect(canon.args?.[0]).toContain('<tmp>')
+    expect(canon.args?.[0]).toContain('<redacted:args:github-pat-classic>')
+  })
+})

--- a/tests/integration/canonicalize-redact.test.ts
+++ b/tests/integration/canonicalize-redact.test.ts
@@ -11,30 +11,30 @@ describe('canonicalize-time redact for args', () => {
     const freshCall = callOf('curl', [
       'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
     ])
-    const cassetteCanon = defaultCanonicalize(cassetteCall, { redactConfig: DEFAULT_CONFIG.redact })
-    const freshCanon = defaultCanonicalize(freshCall, { redactConfig: DEFAULT_CONFIG.redact })
+    const cassetteCanon = defaultCanonicalize(cassetteCall, DEFAULT_CONFIG.redact)
+    const freshCanon = defaultCanonicalize(freshCall, DEFAULT_CONFIG.redact)
     expect(cassetteCanon).toEqual(freshCanon)
   })
 
   test('two different real credentials canonicalize to same form (both redacted to placeholder)', () => {
     const a = callOf('curl', ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'])
     const b = callOf('curl', ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'])
-    const ac = defaultCanonicalize(a, { redactConfig: DEFAULT_CONFIG.redact })
-    const bc = defaultCanonicalize(b, { redactConfig: DEFAULT_CONFIG.redact })
+    const ac = defaultCanonicalize(a, DEFAULT_CONFIG.redact)
+    const bc = defaultCanonicalize(b, DEFAULT_CONFIG.redact)
     expect(ac).toEqual(bc)
   })
 
   test('args with NO credential do not get touched by redact (idempotent on benign args)', () => {
     const call = callOf('echo', ['hello', 'world'])
-    const canon = defaultCanonicalize(call, { redactConfig: DEFAULT_CONFIG.redact })
+    const canon = defaultCanonicalize(call, DEFAULT_CONFIG.redact)
     expect(canon.args).toEqual(['hello', 'world'])
   })
 
-  test('canonicalize without redactConfig: counter-strip still applies (idempotent on stripped form)', () => {
+  test('counter-strip applies regardless of redactConfig (idempotent on stripped form)', () => {
     const cassetteCall = callOf('curl', [
       'Authorization: Bearer <redacted:args:github-pat-classic:5>',
     ])
-    const canon = defaultCanonicalize(cassetteCall)
+    const canon = defaultCanonicalize(cassetteCall, DEFAULT_CONFIG.redact)
     expect(canon.args).toEqual(['Authorization: Bearer <redacted:args:github-pat-classic>'])
   })
 
@@ -90,7 +90,7 @@ describe('canonicalize-time redact for args', () => {
     const call = callOf('curl', [
       '/tmp/test-abc/file.txt --header Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
     ])
-    const canon = defaultCanonicalize(call, { redactConfig: DEFAULT_CONFIG.redact })
+    const canon = defaultCanonicalize(call, DEFAULT_CONFIG.redact)
     // Both transforms applied: <tmp> for the path, placeholder for the credential
     expect(canon.args?.[0]).toContain('<tmp>')
     expect(canon.args?.[0]).toContain('<redacted:args:github-pat-classic>')
@@ -120,7 +120,7 @@ describe('canonicalize-time redact for args', () => {
     expect(matcher.findMatch(freshCall)).toBe(null)
 
     // Verify the canonical form that buildReplayMissError would stringify is credential-free.
-    const canonical = defaultCanonicalize(freshCall, { redactConfig: DEFAULT_CONFIG.redact })
+    const canonical = defaultCanonicalize(freshCall, DEFAULT_CONFIG.redact)
     const stringified = JSON.stringify(canonical)
     expect(stringified).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
     expect(stringified).toContain('<redacted:args:github-pat-classic>')

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -1,5 +1,6 @@
 import * as fc from 'fast-check'
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
 import { normalizeTmpPath, TMP_TOKEN } from '../../src/normalize.js'
 import type { Call, Recording, Result } from '../../src/types.js'
@@ -82,7 +83,9 @@ describe('defaultCanonicalize properties', () => {
   test('determinism: same input produces same output', () => {
     fc.assert(
       fc.property(genCall, (call) => {
-        expect(defaultCanonicalize(call)).toEqual(defaultCanonicalize(call))
+        expect(defaultCanonicalize(call, DEFAULT_CONFIG.redact)).toEqual(
+          defaultCanonicalize(call, DEFAULT_CONFIG.redact),
+        )
       }),
       { numRuns: 100 },
     )
@@ -91,7 +94,7 @@ describe('defaultCanonicalize properties', () => {
   test('omits cwd, env, stdin from canonical form', () => {
     fc.assert(
       fc.property(genCall, (call) => {
-        const c = defaultCanonicalize(call)
+        const c = defaultCanonicalize(call, DEFAULT_CONFIG.redact)
         expect(c.cwd).toBeUndefined()
         expect(c.env).toBeUndefined()
         expect(c.stdin).toBeUndefined()
@@ -129,7 +132,7 @@ describe('MatcherState properties', () => {
         fc.string({ maxLength: 30 }).filter((s) => !s.includes('\n')),
         (callA, otherCwd) => {
           const callB: Call = { ...callA, cwd: otherCwd, env: { OTHER: 'value' } }
-          const state = new MatcherState([recOf(callA)], defaultCanonicalize)
+          const state = new MatcherState([recOf(callA)], defaultCanonicalize, DEFAULT_CONFIG.redact)
           const matched = state.findMatch(callB)
           expect(matched).not.toBeNull()
         },
@@ -142,7 +145,7 @@ describe('MatcherState properties', () => {
     fc.assert(
       fc.property(genCall, fc.integer({ min: 1, max: 8 }), (call, n) => {
         const recordings = Array.from({ length: n }, () => recOf(call))
-        const state = new MatcherState(recordings, defaultCanonicalize)
+        const state = new MatcherState(recordings, defaultCanonicalize, DEFAULT_CONFIG.redact)
         for (let i = 0; i < n; i++) {
           expect(state.findMatch(call)).not.toBeNull()
         }

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -9,7 +9,10 @@ describe('DEFAULT_CONFIG', () => {
 
   test('default canonicalize returns command + args', () => {
     const call = { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null } as const
-    expect(DEFAULT_CONFIG.canonicalize(call)).toEqual({ command: 'git', args: ['status'] })
+    expect(DEFAULT_CONFIG.canonicalize(call, DEFAULT_CONFIG.redact)).toEqual({
+      command: 'git',
+      args: ['status'],
+    })
   })
 })
 

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test, vi } from 'vitest'
+import { DEFAULT_CONFIG } from '../../src/config.js'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
-import type { Canonicalize } from '../../src/types.js'
+import type { Call, Canonicalize } from '../../src/types.js'
 import { callOf, recordingOf } from '../helpers/fixtures.js'
 
 describe('defaultCanonicalize', () => {
   test('includes command and args', () => {
-    const canonical = defaultCanonicalize(callOf('git', ['status']))
+    const canonical = defaultCanonicalize(callOf('git', ['status']), DEFAULT_CONFIG.redact)
     expect(canonical.command).toBe('git')
     expect(canonical.args).toEqual(['status'])
   })
@@ -13,6 +14,7 @@ describe('defaultCanonicalize', () => {
   test('omits cwd, env, stdin from canonical form', () => {
     const canonical = defaultCanonicalize(
       callOf('git', ['status'], { cwd: '/some/dir', env: { FOO: 'bar' } }),
+      DEFAULT_CONFIG.redact,
     )
     expect(canonical.cwd).toBeUndefined()
     expect(canonical.env).toBeUndefined()
@@ -22,43 +24,46 @@ describe('defaultCanonicalize', () => {
   test('normalizes mkdtemp paths in args', () => {
     const canonical = defaultCanonicalize(
       callOf('git', ['remote', 'set-url', 'origin', '/tmp/test-abc/remote.git']),
+      DEFAULT_CONFIG.redact,
     )
     expect(canonical.args).toEqual(['remote', 'set-url', 'origin', '<tmp>/remote.git'])
   })
 
   test('is deterministic — same input produces same output', () => {
     const c = callOf('git', ['log'])
-    expect(defaultCanonicalize(c)).toEqual(defaultCanonicalize(c))
+    expect(defaultCanonicalize(c, DEFAULT_CONFIG.redact)).toEqual(
+      defaultCanonicalize(c, DEFAULT_CONFIG.redact),
+    )
   })
 })
 
 describe('MatcherState — basic matching', () => {
   test('returns null when no recordings', () => {
-    const m = new MatcherState([], defaultCanonicalize)
+    const m = new MatcherState([], defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', []))).toBeNull()
   })
 
   test('matches on command + args', () => {
     const recs = [recordingOf('git', ['status'], 'output')]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('output')
   })
 
   test('does not match on different command', () => {
     const recs = [recordingOf('git', ['status'])]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('hg', ['status']))).toBeNull()
   })
 
   test('does not match on different args', () => {
     const recs = [recordingOf('git', ['status'])]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', ['log']))).toBeNull()
   })
 
   test('args order matters under default', () => {
     const recs = [recordingOf('git', ['a', 'b'])]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', ['b', 'a']))).toBeNull()
   })
 
@@ -66,7 +71,7 @@ describe('MatcherState — basic matching', () => {
     const recs = [
       recordingOf('git', ['remote', 'set-url', 'origin', '/tmp/test-RECORD/remote.git']),
     ]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     const matched = m.findMatch(
       callOf('git', ['remote', 'set-url', 'origin', '/tmp/test-REPLAY/remote.git']),
     )
@@ -77,14 +82,14 @@ describe('MatcherState — basic matching', () => {
 describe('MatcherState — sequential consumption', () => {
   test('first call gets first match, second call gets second match', () => {
     const recs = [recordingOf('git', ['status'], 'first'), recordingOf('git', ['status'], 'second')]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('first')
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('second')
   })
 
   test('returns null when consumption exhausted', () => {
     const recs = [recordingOf('git', ['status'])]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     m.findMatch(callOf('git', ['status']))
     expect(m.findMatch(callOf('git', ['status']))).toBeNull()
   })
@@ -95,7 +100,7 @@ describe('MatcherState — sequential consumption', () => {
       recordingOf('git', ['log'], 'l1'),
       recordingOf('git', ['status'], 's2'),
     ]
-    const m = new MatcherState(recs, defaultCanonicalize)
+    const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('s1')
     expect(m.findMatch(callOf('git', ['log']))?.result.stdoutLines[0]).toBe('l1')
     expect(m.findMatch(callOf('git', ['status']))?.result.stdoutLines[0]).toBe('s2')
@@ -107,7 +112,7 @@ describe('MatcherState — ambiguity warning', () => {
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     try {
       const recs = [recordingOf('git', ['status'], 'a'), recordingOf('git', ['status'], 'b')]
-      const m = new MatcherState(recs, defaultCanonicalize)
+      const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
       m.findMatch(callOf('git', ['status']))
       const warnCalls = stderrSpy.mock.calls
         .map((c) => c[0] as string)
@@ -123,7 +128,7 @@ describe('MatcherState — custom canonicalize', () => {
   test('uses provided canonicalize fn (e.g., command-only matching)', () => {
     const commandOnly: Canonicalize = (call) => ({ command: call.command })
     const recs = [recordingOf('git', ['status'])]
-    const m = new MatcherState(recs, commandOnly)
+    const m = new MatcherState(recs, commandOnly, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', ['anything']))).not.toBeNull()
   })
 
@@ -134,7 +139,7 @@ describe('MatcherState — custom canonicalize', () => {
       return { command: c.command, args: c.args }
     }
     const recs = [recordingOf('git', ['a']), recordingOf('git', ['b'])]
-    new MatcherState(recs, tracking)
+    new MatcherState(recs, tracking, DEFAULT_CONFIG.redact)
     expect(calls).toHaveLength(2)
   })
 })

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -1,29 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
-import type { Call, Canonicalize, Recording } from '../../src/types.js'
-
-const callOf = (command: string, args: string[], extra: Partial<Call> = {}): Call => ({
-  command,
-  args,
-  cwd: null,
-  env: {},
-  stdin: null,
-  ...extra,
-})
-
-const recordingOf = (command: string, args: string[], stdout = ''): Recording => ({
-  call: callOf(command, args),
-  result: {
-    stdoutLines: [stdout, ''],
-    stderrLines: [''],
-    allLines: null,
-    exitCode: 0,
-    signal: null,
-    durationMs: 1,
-    aborted: false,
-  },
-  redactions: [],
-})
+import type { Canonicalize } from '../../src/types.js'
+import { callOf, recordingOf } from '../helpers/fixtures.js'
 
 describe('defaultCanonicalize', () => {
   test('includes command and args', () => {


### PR DESCRIPTION
## What Changed

- `Canonicalize` signature gains optional `opts?: { redactConfig?: RedactConfig }` second parameter.
- `defaultCanonicalize` for args applies three transforms in order: `normalizeTmpPath`, `stripCounter`, stripped-mode pipeline.
- `MatcherState` constructor takes optional `redactConfig` third arg; threads to canonicalize on pre-cache + match-time.
- `buildReplayMissError` forwards `session.redactConfig` to canonicalize (security fix: prevents raw credentials from leaking into error message text).
- 9 new integration tests covering the canonicalize-time redact path.

## Why

The recorder writes counter-tagged placeholders into cassette args. The matcher must correctly compare those cassette placeholders against fresh-call args containing raw credentials. Both arms canonicalize to the same counter-stripped form; deep-equal succeeds; replay works.

Existing `canonicalize(call)` 1-arg callers continue to work; the new `opts` is optional. Pre-existing 2-arg `new MatcherState(recordings, canonicalize)` constructions in tests pass without modification.

## Security fix

`buildReplayMissError` previously called `canonicalize(call)` without forwarding `redactConfig`, leaking raw credentials from fresh-call args into the error message text shown in stack traces and CI logs. Code review caught this; the signature extension surfaced the bug. Both diagnostic call sites now use the same hoisted `opts` constant with `redactConfig` forwarded. New regression test verifies canonical args are credential-free.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (361 passed, 1 pre-existing skip; +9 new tests)
- [x] `npm run build` produces clean dist/