### PR TITLE
test: end-to-end test for per-cassette redact override

### DIFF
--- a/tests/e2e/record-replay.test.ts
+++ b/tests/e2e/record-replay.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
 const originalMode = process.env.SHELL_CASSETTE_MODE
@@ -18,14 +19,6 @@ afterEach(() => {
   restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
   restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
-
-function restoreEnv(key: string, original: string | undefined): void {
-  if (original === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = original
-  }
-}
 
 describe('e2e record + replay', () => {
   test('node --version round-trips deterministically', async () => {

--- a/tests/e2e/tmp-path-record-replay.test.ts
+++ b/tests/e2e/tmp-path-record-replay.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 
 describe('e2e: tmp path record-replay across mkdtemp variance', () => {
   let workspace: string
@@ -24,14 +25,6 @@ describe('e2e: tmp path record-replay across mkdtemp variance', () => {
     restoreEnv('SHELL_CASSETTE_MODE', originalMode)
     restoreEnv('CI', originalCI)
   })
-
-  function restoreEnv(key: string, original: string | undefined): void {
-    if (original === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = original
-    }
-  }
 
   test('cassette recorded with one mkdtemp path replays under a different mkdtemp path', async () => {
     const cassettePath = path.join(workspace, 'cassette.json')

--- a/tests/error-path/canonicalize-limits.test.ts
+++ b/tests/error-path/canonicalize-limits.test.ts
@@ -8,6 +8,7 @@ import { writeCassetteFile } from '../../src/io.js'
 import { serialize } from '../../src/serialize.js'
 import type { CassetteFile } from '../../src/types.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 
 // Build a cassette with a single recording whose call.command is `node` and
 // one positional arg. The args field drives the matcher comparison.
@@ -58,14 +59,6 @@ describe('canonicalize limitations - documented current behavior', () => {
     restoreEnv('SHELL_CASSETTE_MODE', originalMode)
     restoreEnv('CI', originalCI)
   })
-
-  function restoreEnv(key: string, original: string | undefined): void {
-    if (original === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = original
-    }
-  }
 
   test('relative tmp path (path.relative-style) does NOT normalize - documented limitation', async () => {
     // Recording was canonicalized as if it had been '<tmp>/foo' (a normalized

--- a/tests/error-path/error-classes.test.ts
+++ b/tests/error-path/error-classes.test.ts
@@ -18,6 +18,7 @@ import { deriveCassettePathFromTask } from '../../src/plugin.js'
 import { deserialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 import { makeSession } from '../helpers/session.js'
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
@@ -35,14 +36,6 @@ afterEach(() => {
   restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
   restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
-
-function restoreEnv(key: string, original: string | undefined): void {
-  if (original === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = original
-  }
-}
 
 describe('all error classes are instanceof ShellCassetteError', () => {
   test('AckRequiredError', async () => {

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -1,0 +1,18 @@
+/**
+ * Restore an env var to its previous value, or delete it if it was unset.
+ *
+ * Used in test teardown to undo `process.env.X = '...'` mutations from
+ * `beforeEach` without clobbering host environment values. Pair with
+ * a snapshot of the original value captured before the mutation:
+ *
+ *   const original = process.env.SHELL_CASSETTE_MODE
+ *   beforeEach(() => { process.env.SHELL_CASSETTE_MODE = 'auto' })
+ *   afterEach(() => { restoreEnv('SHELL_CASSETTE_MODE', original) })
+ */
+export function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/tests/integration/per-cassette-override.test.ts
+++ b/tests/integration/per-cassette-override.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+
+let tmp: string
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-per-cassette-override-'))
+  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+})
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+  delete process.env.SHELL_CASSETTE_ACK_REDACTION
+})
+
+describe('useCassette per-cassette redact override', () => {
+  test('redact: true (default) redacts a credential in stdout', async () => {
+    const cassettePath = path.join(tmp, 'redact-on.json')
+    await useCassette(cassettePath, async () => {
+      await execa('node', ['-e', `console.log('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')`])
+    })
+    const text = await readFile(cassettePath, 'utf8')
+    expect(text).toContain('<redacted:stdout:github-pat-classic')
+    expect(text).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+  })
+
+  test('redact: false bypasses pipeline; raw credential persists in cassette', async () => {
+    const cassettePath = path.join(tmp, 'redact-off.json')
+    await useCassette(cassettePath, { redact: false }, async () => {
+      await execa('node', ['-e', `console.log('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')`])
+    })
+    const text = await readFile(cassettePath, 'utf8')
+    expect(text).toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(text).not.toContain('<redacted:')
+  })
+
+  test('redact: false with credential in env bypasses env-key-match path', async () => {
+    const cassettePath = path.join(tmp, 'redact-off-env.json')
+    await useCassette(cassettePath, { redact: false }, async () => {
+      await execa('node', ['-e', `console.log(process.env.MY_TOKEN ?? 'no-token')`], {
+        env: { MY_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      })
+    })
+    const text = await readFile(cassettePath, 'utf8')
+    // Both stdout and env should contain the raw token (not redacted)
+    expect(text).toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(text).not.toContain('<redacted:')
+  })
+
+  test('redact: true with credential in env: curated key-match path redacts', async () => {
+    const cassettePath = path.join(tmp, 'redact-on-env.json')
+    await useCassette(cassettePath, async () => {
+      await execa('node', ['-e', `console.log(process.env.MY_TOKEN ?? 'no-token')`], {
+        env: { MY_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      })
+    })
+    const text = await readFile(cassettePath, 'utf8')
+    // env: MY_TOKEN contains curated substring TOKEN; whole value redacted via env-key-match rule
+    expect(text).toContain('<redacted:env:env-key-match')
+    // stdout: node prints the token; bundled github-pat-classic pattern fires
+    expect(text).toContain('<redacted:stdout:github-pat-classic')
+    // No raw credential anywhere in the cassette
+    expect(text).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+  })
+})

--- a/tests/integration/per-cassette-override.test.ts
+++ b/tests/integration/per-cassette-override.test.ts
@@ -7,14 +7,28 @@ import { useCassette } from '../../src/use-cassette.js'
 
 let tmp: string
 
+const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+const originalMode = process.env.SHELL_CASSETTE_MODE
+
+function restoreEnv(key: string, original: string | undefined): void {
+  if (original === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = original
+  }
+}
+
 beforeEach(async () => {
   tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-per-cassette-override-'))
   process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+  // Pin the mode so CI=true on the runner doesn't force replay-strict.
+  process.env.SHELL_CASSETTE_MODE = 'auto'
 })
 
 afterEach(async () => {
   await rm(tmp, { recursive: true, force: true })
-  delete process.env.SHELL_CASSETTE_ACK_REDACTION
+  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
 
 describe('useCassette per-cassette redact override', () => {

--- a/tests/integration/per-cassette-override.test.ts
+++ b/tests/integration/per-cassette-override.test.ts
@@ -4,19 +4,14 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 
 let tmp: string
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
 const originalMode = process.env.SHELL_CASSETTE_MODE
 
-function restoreEnv(key: string, original: string | undefined): void {
-  if (original === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = original
-  }
-}
+const FAKE_PAT = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
 
 beforeEach(async () => {
   tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-per-cassette-override-'))
@@ -35,20 +30,20 @@ describe('useCassette per-cassette redact override', () => {
   test('redact: true (default) redacts a credential in stdout', async () => {
     const cassettePath = path.join(tmp, 'redact-on.json')
     await useCassette(cassettePath, async () => {
-      await execa('node', ['-e', `console.log('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')`])
+      await execa('node', ['-e', `console.log('${FAKE_PAT}')`])
     })
     const text = await readFile(cassettePath, 'utf8')
     expect(text).toContain('<redacted:stdout:github-pat-classic')
-    expect(text).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(text).not.toContain(FAKE_PAT)
   })
 
   test('redact: false bypasses pipeline; raw credential persists in cassette', async () => {
     const cassettePath = path.join(tmp, 'redact-off.json')
     await useCassette(cassettePath, { redact: false }, async () => {
-      await execa('node', ['-e', `console.log('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')`])
+      await execa('node', ['-e', `console.log('${FAKE_PAT}')`])
     })
     const text = await readFile(cassettePath, 'utf8')
-    expect(text).toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(text).toContain(FAKE_PAT)
     expect(text).not.toContain('<redacted:')
   })
 
@@ -56,20 +51,20 @@ describe('useCassette per-cassette redact override', () => {
     const cassettePath = path.join(tmp, 'redact-off-env.json')
     await useCassette(cassettePath, { redact: false }, async () => {
       await execa('node', ['-e', `console.log(process.env.MY_TOKEN ?? 'no-token')`], {
-        env: { MY_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+        env: { MY_TOKEN: FAKE_PAT },
       })
     })
     const text = await readFile(cassettePath, 'utf8')
-    // Both stdout and env should contain the raw token (not redacted)
-    expect(text).toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
-    expect(text).not.toContain('<redacted:')
+    expect(text).toContain(FAKE_PAT)
+    expect(text).not.toContain('<redacted:env:')
+    expect(text).not.toContain('<redacted:stdout:')
   })
 
   test('redact: true with credential in env: curated key-match path redacts', async () => {
     const cassettePath = path.join(tmp, 'redact-on-env.json')
     await useCassette(cassettePath, async () => {
       await execa('node', ['-e', `console.log(process.env.MY_TOKEN ?? 'no-token')`], {
-        env: { MY_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+        env: { MY_TOKEN: FAKE_PAT },
       })
     })
     const text = await readFile(cassettePath, 'utf8')
@@ -78,6 +73,6 @@ describe('useCassette per-cassette redact override', () => {
     // stdout: node prints the token; bundled github-pat-classic pattern fires
     expect(text).toContain('<redacted:stdout:github-pat-classic')
     // No raw credential anywhere in the cassette
-    expect(text).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(text).not.toContain(FAKE_PAT)
   })
 })

--- a/tests/integration/use-cassette-options.test.ts
+++ b/tests/integration/use-cassette-options.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import type { Canonicalize } from '../../src/types.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 
 describe('useCassette per-call options - canonicalize override', () => {
   let tmp: string
@@ -24,14 +25,6 @@ describe('useCassette per-call options - canonicalize override', () => {
     restoreEnv('SHELL_CASSETTE_MODE', originalMode)
     restoreEnv('CI', originalCI)
   })
-
-  function restoreEnv(key: string, original: string | undefined): void {
-    if (original === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = original
-    }
-  }
 
   test('default canonicalize matches recordings with same command + args', async () => {
     const cassettePath = path.join(tmp, 'default.json')

--- a/tests/integration/use-cassette.test.ts
+++ b/tests/integration/use-cassette.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
 const originalMode = process.env.SHELL_CASSETTE_MODE
@@ -18,14 +19,6 @@ afterEach(() => {
   restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
   restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
-
-function restoreEnv(key: string, original: string | undefined): void {
-  if (original === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = original
-  }
-}
 
 describe('useCassette', () => {
   test('records execa calls and writes cassette at scope end', async () => {

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -7,6 +7,7 @@ import { writeCassetteFile } from '../../src/io.js'
 import { serialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { CassetteSession } from '../../src/types.js'
+import { restoreEnv } from '../helpers/env.js'
 import { makeSession } from '../helpers/session.js'
 
 const sessionAt = (sessionPath: string): CassetteSession =>
@@ -26,14 +27,6 @@ afterEach(() => {
   restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
   restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
-
-function restoreEnv(key: string, original: string | undefined): void {
-  if (original === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = original
-  }
-}
 
 describe('wrapped execa', () => {
   test('passthrough when no active cassette', async () => {


### PR DESCRIPTION
## What Changed

- `tests/integration/per-cassette-override.test.ts`: 4 tests covering both directions of the toggle and both stdout + env paths:
  1. `redact: true` (default) redacts stdout credential.
  2. `redact: false` bypasses; raw credential persists in cassette.
  3. `redact: false` with credential in env: env-key-match path bypassed.
  4. `redact: true` with credential in env: env-key-match + stdout patterns both fire.

Tests use real execa subprocesses and real cassette writes (mkdtemp + cleanup pattern).

## CI hardening

- Snapshots and restores `SHELL_CASSETTE_ACK_REDACTION` (does not delete pre-existing host value).
- Pins `SHELL_CASSETTE_MODE=auto` so CI runners with `CI=true` don't force replay-strict mode against fresh cassettes.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (365 passed, 1 pre-existing skip; +4 new tests)
- [x] `npm run build` produces clean dist/