### PR TITLE
feat(cli): add CLI infrastructure layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "engines": {
     "node": ">=18"
   },
+  "bin": {
+    "shell-cassette": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -1,0 +1,64 @@
+/**
+ * CLI output helpers for the shell-cassette binary. Hand-rolled ANSI color
+ * codes (no external dependency).
+ *
+ * Color decision (in priority order):
+ *   1. --color=always flag -> forced enable
+ *   2. --no-color flag -> forced disable
+ *   3. NO_COLOR env var (https://no-color.org) -> disabled when set to non-empty
+ *   4. TTY auto-detect -> enabled if stdout is a TTY
+ */
+
+let enabled = false
+
+export type ColorOverride = 'auto' | 'always' | 'never' | undefined
+
+export const color = {
+  setEnabled(v: boolean): void {
+    enabled = v
+  },
+  isEnabled(): boolean {
+    return enabled
+  },
+  cyan: (s: string) => (enabled ? `\x1b[36m${s}\x1b[0m` : s),
+  red: (s: string) => (enabled ? `\x1b[31m${s}\x1b[0m` : s),
+  green: (s: string) => (enabled ? `\x1b[32m${s}\x1b[0m` : s),
+  yellow: (s: string) => (enabled ? `\x1b[33m${s}\x1b[0m` : s),
+  bold: (s: string) => (enabled ? `\x1b[1m${s}\x1b[0m` : s),
+  dim: (s: string) => (enabled ? `\x1b[2m${s}\x1b[0m` : s),
+}
+
+export const isTty = {
+  shouldUseColor(opts: { tty: boolean; override: ColorOverride }): boolean {
+    if (opts.override === 'always') return true
+    if (opts.override === 'never') return false
+    if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') return false
+    return opts.tty
+  },
+  detectStdoutTty(): boolean {
+    return Boolean(process.stdout.isTTY)
+  },
+}
+
+export function applyTruncation(s: string, limit: number): string {
+  if (s.length === 0) return s
+  if (s.length <= limit) return s
+  return `${s.slice(0, limit)}…`
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`
+}
+
+export function stdout(s: string, opts?: { newline?: boolean }): void {
+  const ending = opts?.newline === false ? '' : '\n'
+  process.stdout.write(s + ending)
+}
+
+export function stderr(s: string, opts?: { newline?: boolean }): void {
+  const ending = opts?.newline === false ? '' : '\n'
+  process.stderr.write(s + ending)
+}

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -13,6 +13,8 @@ let enabled = false
 
 export type ColorOverride = 'auto' | 'always' | 'never' | undefined
 
+const wrap = (code: number) => (s: string) => (enabled ? `\x1b[${code}m${s}\x1b[0m` : s)
+
 export const color = {
   setEnabled(v: boolean): void {
     enabled = v
@@ -20,12 +22,12 @@ export const color = {
   isEnabled(): boolean {
     return enabled
   },
-  cyan: (s: string) => (enabled ? `\x1b[36m${s}\x1b[0m` : s),
-  red: (s: string) => (enabled ? `\x1b[31m${s}\x1b[0m` : s),
-  green: (s: string) => (enabled ? `\x1b[32m${s}\x1b[0m` : s),
-  yellow: (s: string) => (enabled ? `\x1b[33m${s}\x1b[0m` : s),
-  bold: (s: string) => (enabled ? `\x1b[1m${s}\x1b[0m` : s),
-  dim: (s: string) => (enabled ? `\x1b[2m${s}\x1b[0m` : s),
+  cyan: wrap(36),
+  red: wrap(31),
+  green: wrap(32),
+  yellow: wrap(33),
+  bold: wrap(1),
+  dim: wrap(2),
 }
 
 export const isTty = {
@@ -43,7 +45,7 @@ export const isTty = {
 export function applyTruncation(s: string, limit: number): string {
   if (s.length === 0) return s
   if (s.length <= limit) return s
-  return `${s.slice(0, limit)}…`
+  return `${s.slice(0, limit)}...`
 }
 
 export function formatBytes(bytes: number): string {

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -1,0 +1,9 @@
+/**
+ * `shell-cassette re-redact` subcommand stub. M11 will fill the implementation
+ * with re-application of current redaction rules over existing cassettes; for
+ * now this stub keeps the binary's argv dispatch wired so M9 ships a working
+ * entry point.
+ */
+export async function runReRedact(_args: readonly string[]): Promise<number> {
+  throw new Error('runReRedact not implemented (stub for M9 wiring; M11 implements)')
+}

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -1,3 +1,5 @@
+import { ShellCassetteError } from './errors.js'
+
 /**
  * `shell-cassette re-redact` subcommand stub. M11 will fill the implementation
  * with re-application of current redaction rules over existing cassettes; for
@@ -5,5 +7,5 @@
  * entry point.
  */
 export async function runReRedact(_args: readonly string[]): Promise<number> {
-  throw new Error('runReRedact not implemented (stub for M9 wiring; M11 implements)')
+  throw new ShellCassetteError('runReRedact not implemented (stub for M9 wiring; M11 implements)')
 }

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -1,8 +1,10 @@
+import { ShellCassetteError } from './errors.js'
+
 /**
  * `shell-cassette scan` subcommand stub. M10 will fill the implementation
  * with verification logic over cassette files; for now this stub keeps the
  * binary's argv dispatch wired so M9 ships a working entry point.
  */
 export async function runScan(_args: readonly string[]): Promise<number> {
-  throw new Error('runScan not implemented (stub for M9 wiring; M10 implements)')
+  throw new ShellCassetteError('runScan not implemented (stub for M9 wiring; M10 implements)')
 }

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -1,0 +1,8 @@
+/**
+ * `shell-cassette scan` subcommand stub. M10 will fill the implementation
+ * with verification logic over cassette files; for now this stub keeps the
+ * binary's argv dispatch wired so M9 ships a working entry point.
+ */
+export async function runScan(_args: readonly string[]): Promise<number> {
+  throw new Error('runScan not implemented (stub for M9 wiring; M10 implements)')
+}

--- a/src/cli-walk.ts
+++ b/src/cli-walk.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile, stat } from 'node:fs/promises'
 import path from 'node:path'
+import { CassetteIOError } from './errors.js'
 
 /**
  * Resolve cassette paths from user-provided input.
@@ -22,8 +23,8 @@ export async function walkCassettes(inputs: readonly string[]): Promise<string[]
     let st: Awaited<ReturnType<typeof stat>>
     try {
       st = await stat(abs)
-    } catch {
-      throw new Error(`path not found: ${input}`)
+    } catch (e) {
+      throw new CassetteIOError(`cassette path not found: ${input}`, e as Error)
     }
     if (st.isFile()) {
       out.add(abs)

--- a/src/cli-walk.ts
+++ b/src/cli-walk.ts
@@ -1,0 +1,69 @@
+import { readdir, readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+
+/**
+ * Resolve cassette paths from user-provided input.
+ *
+ * For each input:
+ *   - If a file, included as-is. Caller is responsible for ensuring it's a
+ *     valid cassette; explicit paths are trusted.
+ *   - If a directory, walk recursively for `*.json` files. Each candidate is
+ *     parsed; only those with a numeric `version` field of 1 or 2 are
+ *     included. Filtering protects against picking up package.json or other
+ *     non-cassette JSON in cassette directories.
+ *
+ * Throws if any input path does not exist. Silently skips non-cassette JSON
+ * within directories. Returns deduplicated list of absolute paths.
+ */
+export async function walkCassettes(inputs: readonly string[]): Promise<string[]> {
+  const out = new Set<string>()
+  for (const input of inputs) {
+    const abs = path.resolve(input)
+    let st: Awaited<ReturnType<typeof stat>>
+    try {
+      st = await stat(abs)
+    } catch {
+      throw new Error(`path not found: ${input}`)
+    }
+    if (st.isFile()) {
+      out.add(abs)
+    } else if (st.isDirectory()) {
+      for (const found of await walkDir(abs)) {
+        out.add(found)
+      }
+    }
+  }
+  return [...out]
+}
+
+async function walkDir(dir: string): Promise<string[]> {
+  const out: string[] = []
+  const entries = await readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await walkDir(full)))
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      if (await isCassette(full)) {
+        out.push(full)
+      }
+    }
+  }
+  return out
+}
+
+async function isCassette(filePath: string): Promise<boolean> {
+  try {
+    const text = await readFile(filePath, 'utf8')
+    const parsed = JSON.parse(text) as unknown
+    return (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'version' in parsed &&
+      ((parsed as Record<string, unknown>).version === 1 ||
+        (parsed as Record<string, unknown>).version === 2)
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/cli-walk.ts
+++ b/src/cli-walk.ts
@@ -1,6 +1,8 @@
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { readdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 import { CassetteIOError } from './errors.js'
+import { readCassetteFile } from './io.js'
+import { deserialize } from './serialize.js'
 
 /**
  * Resolve cassette paths from user-provided input.
@@ -18,52 +20,51 @@ import { CassetteIOError } from './errors.js'
  */
 export async function walkCassettes(inputs: readonly string[]): Promise<string[]> {
   const out = new Set<string>()
-  for (const input of inputs) {
-    const abs = path.resolve(input)
-    let st: Awaited<ReturnType<typeof stat>>
-    try {
-      st = await stat(abs)
-    } catch (e) {
-      throw new CassetteIOError(`cassette path not found: ${input}`, e as Error)
-    }
-    if (st.isFile()) {
-      out.add(abs)
-    } else if (st.isDirectory()) {
-      for (const found of await walkDir(abs)) {
-        out.add(found)
+  const results = await Promise.all(
+    inputs.map(async (input) => {
+      const abs = path.resolve(input)
+      let st: Awaited<ReturnType<typeof stat>>
+      try {
+        st = await stat(abs)
+      } catch (e) {
+        throw new CassetteIOError(`cassette path not found: ${input}`, e as Error)
       }
+      if (st.isFile()) return [abs]
+      if (st.isDirectory()) return walkDir(abs)
+      return [] as string[]
+    }),
+  )
+  for (const paths of results) {
+    for (const p of paths) {
+      out.add(p)
     }
   }
   return [...out]
 }
 
 async function walkDir(dir: string): Promise<string[]> {
-  const out: string[] = []
   const entries = await readdir(dir, { withFileTypes: true })
-  for (const entry of entries) {
-    const full = path.join(dir, entry.name)
-    if (entry.isDirectory()) {
-      out.push(...(await walkDir(full)))
-    } else if (entry.isFile() && entry.name.endsWith('.json')) {
-      if (await isCassette(full)) {
-        out.push(full)
+  const results = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        return walkDir(full)
       }
-    }
-  }
-  return out
+      if (entry.isFile() && entry.name.endsWith('.json') && (await isCassette(full))) {
+        return [full]
+      }
+      return [] as string[]
+    }),
+  )
+  return results.flat()
 }
 
 async function isCassette(filePath: string): Promise<boolean> {
   try {
-    const text = await readFile(filePath, 'utf8')
-    const parsed = JSON.parse(text) as unknown
-    return (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      'version' in parsed &&
-      ((parsed as Record<string, unknown>).version === 1 ||
-        (parsed as Record<string, unknown>).version === 2)
-    )
+    const text = await readCassetteFile(filePath)
+    if (text === null) return false
+    deserialize(text) // throws CassetteCorruptError on bad JSON, missing version, unknown version
+    return true
   } catch {
     return false
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { fileURLToPath } from 'node:url'
 import { stderr, stdout } from './cli-output.js'
 import { runReRedact } from './cli-re-redact.js'
 import { runScan } from './cli-scan.js'
@@ -63,9 +64,7 @@ export async function main(argv: readonly string[]): Promise<number> {
 }
 
 // Auto-execute when invoked as the entry point (not when imported by tests)
-const isMain =
-  process.argv[1] !== undefined &&
-  (process.argv[1].endsWith('cli.js') || process.argv[1].endsWith('cli.ts'))
+const isMain = process.argv[1] === fileURLToPath(import.meta.url)
 
 if (isMain) {
   main(process.argv.slice(2))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { stderr, stdout } from './cli-output.js'
+import { runReRedact } from './cli-re-redact.js'
+import { runScan } from './cli-scan.js'
+import { PACKAGE_VERSION } from './version.js'
+
+const HELP = `\
+shell-cassette ${PACKAGE_VERSION}
+
+Usage:
+  shell-cassette <command> [options] [args...]
+
+Commands:
+  scan        Verify cassettes have no unredacted credentials.
+  re-redact   Re-apply current redaction rules to existing cassettes.
+
+Options:
+  --version   Print shell-cassette version and exit.
+  --help      Print this help and exit.
+
+Run 'shell-cassette <command> --help' for command-specific help.
+`
+
+type TopLevel = {
+  help?: boolean
+  version?: boolean
+  command?: string
+  rest: string[]
+}
+
+export function parseTopLevel(argv: readonly string[]): TopLevel {
+  if (argv.length === 0) return { rest: [] }
+  const [first, ...rest] = argv
+  if (first === '--help' || first === '-h') return { help: true, rest: [] }
+  if (first === '--version' || first === '-V') return { version: true, rest: [] }
+  return { command: first, rest }
+}
+
+export async function main(argv: readonly string[]): Promise<number> {
+  const args = parseTopLevel(argv)
+  if (args.help) {
+    stdout(HELP)
+    return 0
+  }
+  if (args.version) {
+    stdout(PACKAGE_VERSION)
+    return 0
+  }
+  if (!args.command) {
+    stderr(`error: missing command\n${HELP}`)
+    return 2
+  }
+
+  switch (args.command) {
+    case 'scan':
+      return runScan(args.rest)
+    case 're-redact':
+      return runReRedact(args.rest)
+    default:
+      stderr(`error: unknown command '${args.command}'\n${HELP}`)
+      return 2
+  }
+}
+
+// Auto-execute when invoked as the entry point (not when imported by tests)
+const isMain =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith('cli.js') || process.argv[1].endsWith('cli.ts'))
+
+if (isMain) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((e) => {
+      stderr(`error: ${(e as Error).message}`)
+      process.exit(2)
+    })
+}

--- a/tests/unit/cli-output.test.ts
+++ b/tests/unit/cli-output.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { applyTruncation, color, formatBytes, isTty } from '../../src/cli-output.js'
+import { restoreEnv } from '../helpers/env.js'
+
+describe('color helpers', () => {
+  beforeEach(() => {
+    color.setEnabled(true)
+  })
+
+  test('cyan wraps text in ANSI color codes when enabled', () => {
+    const out = color.cyan('hello')
+    expect(out).toBe('\x1b[36mhello\x1b[0m')
+  })
+
+  test('all helpers return raw text when disabled', () => {
+    color.setEnabled(false)
+    expect(color.cyan('hello')).toBe('hello')
+    expect(color.red('hello')).toBe('hello')
+    expect(color.green('hello')).toBe('hello')
+    expect(color.bold('hello')).toBe('hello')
+    expect(color.dim('hello')).toBe('hello')
+    expect(color.yellow('hello')).toBe('hello')
+  })
+
+  test('isEnabled reflects setEnabled state', () => {
+    color.setEnabled(true)
+    expect(color.isEnabled()).toBe(true)
+    color.setEnabled(false)
+    expect(color.isEnabled()).toBe(false)
+  })
+})
+
+describe('isTty.shouldUseColor', () => {
+  const originalNoColor = process.env.NO_COLOR
+  const originalForceColor = process.env.FORCE_COLOR
+
+  beforeEach(() => {
+    delete process.env.NO_COLOR
+    delete process.env.FORCE_COLOR
+  })
+
+  afterEach(() => {
+    restoreEnv('NO_COLOR', originalNoColor)
+    restoreEnv('FORCE_COLOR', originalForceColor)
+  })
+
+  test('NO_COLOR env disables colors even on TTY', () => {
+    process.env.NO_COLOR = '1'
+    expect(isTty.shouldUseColor({ tty: true, override: undefined })).toBe(false)
+  })
+
+  test('NO_COLOR env disables colors regardless of override (when override is auto)', () => {
+    process.env.NO_COLOR = '1'
+    expect(isTty.shouldUseColor({ tty: true, override: 'auto' })).toBe(false)
+  })
+
+  test('--no-color override disables colors even on TTY', () => {
+    expect(isTty.shouldUseColor({ tty: true, override: 'never' })).toBe(false)
+  })
+
+  test('--color=always overrides NO_COLOR', () => {
+    process.env.NO_COLOR = '1'
+    expect(isTty.shouldUseColor({ tty: false, override: 'always' })).toBe(true)
+  })
+
+  test('TTY auto + no overrides + no NO_COLOR: enabled', () => {
+    expect(isTty.shouldUseColor({ tty: true, override: undefined })).toBe(true)
+  })
+
+  test('non-TTY auto + no overrides: disabled', () => {
+    expect(isTty.shouldUseColor({ tty: false, override: undefined })).toBe(false)
+  })
+
+  test('empty NO_COLOR string is treated as unset (no-color spec)', () => {
+    process.env.NO_COLOR = ''
+    expect(isTty.shouldUseColor({ tty: true, override: undefined })).toBe(true)
+  })
+})
+
+describe('applyTruncation', () => {
+  test('returns input unchanged when shorter than limit', () => {
+    expect(applyTruncation('hello', 10)).toBe('hello')
+  })
+
+  test('returns input unchanged when equal to limit', () => {
+    expect(applyTruncation('hello', 5)).toBe('hello')
+  })
+
+  test('truncates with ellipsis when longer than limit', () => {
+    expect(applyTruncation('a'.repeat(100), 10)).toBe('aaaaaaaaaa…')
+  })
+
+  test('limit of 0 returns just ellipsis', () => {
+    expect(applyTruncation('hello', 0)).toBe('…')
+  })
+
+  test('empty string returns empty string', () => {
+    expect(applyTruncation('', 10)).toBe('')
+  })
+})
+
+describe('formatBytes', () => {
+  test('zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B')
+  })
+
+  test('bytes under 1 KB', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1023)).toBe('1023 B')
+  })
+
+  test('exactly 1 KB', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB')
+  })
+
+  test('partial KB', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB')
+  })
+
+  test('exactly 1 MB', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
+  })
+
+  test('partial MB', () => {
+    expect(formatBytes(1024 * 1024 * 2.5)).toBe('2.5 MB')
+  })
+
+  test('exactly 1 GB', () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB')
+  })
+})

--- a/tests/unit/cli-output.test.ts
+++ b/tests/unit/cli-output.test.ts
@@ -84,11 +84,11 @@ describe('applyTruncation', () => {
   })
 
   test('truncates with ellipsis when longer than limit', () => {
-    expect(applyTruncation('a'.repeat(100), 10)).toBe('aaaaaaaaaa…')
+    expect(applyTruncation('a'.repeat(100), 10)).toBe('aaaaaaaaaa...')
   })
 
   test('limit of 0 returns just ellipsis', () => {
-    expect(applyTruncation('hello', 0)).toBe('…')
+    expect(applyTruncation('hello', 0)).toBe('...')
   })
 
   test('empty string returns empty string', () => {

--- a/tests/unit/cli-output.test.ts
+++ b/tests/unit/cli-output.test.ts
@@ -32,16 +32,13 @@ describe('color helpers', () => {
 
 describe('isTty.shouldUseColor', () => {
   const originalNoColor = process.env.NO_COLOR
-  const originalForceColor = process.env.FORCE_COLOR
 
   beforeEach(() => {
     delete process.env.NO_COLOR
-    delete process.env.FORCE_COLOR
   })
 
   afterEach(() => {
     restoreEnv('NO_COLOR', originalNoColor)
-    restoreEnv('FORCE_COLOR', originalForceColor)
   })
 
   test('NO_COLOR env disables colors even on TTY', () => {

--- a/tests/unit/cli-walk.test.ts
+++ b/tests/unit/cli-walk.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { walkCassettes } from '../../src/cli-walk.js'
+import { CassetteIOError } from '../../src/errors.js'
 
 let tmp: string
 
@@ -50,8 +51,8 @@ describe('walkCassettes', () => {
     expect(result[0]).toBe(a)
   })
 
-  test('non-existent path throws', async () => {
-    await expect(walkCassettes([path.join(tmp, 'nope.json')])).rejects.toThrow()
+  test('non-existent path throws CassetteIOError', async () => {
+    await expect(walkCassettes([path.join(tmp, 'nope.json')])).rejects.toThrow(CassetteIOError)
   })
 
   test('non-cassette JSON in dir is silently skipped', async () => {

--- a/tests/unit/cli-walk.test.ts
+++ b/tests/unit/cli-walk.test.ts
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { walkCassettes } from '../../src/cli-walk.js'
+
+let tmp: string
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-walk-'))
+})
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+describe('walkCassettes', () => {
+  test('single existing file path returned as-is', async () => {
+    const cassettePath = path.join(tmp, 'foo.json')
+    await writeFile(cassettePath, JSON.stringify({ version: 2, recordings: [] }))
+    const result = await walkCassettes([cassettePath])
+    expect(result).toEqual([cassettePath])
+  })
+
+  test('directory walked for *.json files matching cassette schema', async () => {
+    const a = path.join(tmp, 'a.json')
+    const b = path.join(tmp, 'b.json')
+    const c = path.join(tmp, 'c.json')
+    await writeFile(a, JSON.stringify({ version: 1, recordings: [] }))
+    await writeFile(b, JSON.stringify({ version: 2, recordings: [] }))
+    await writeFile(c, JSON.stringify({ unrelated: true })) // not a cassette
+    const result = await walkCassettes([tmp])
+    expect(result.sort()).toEqual([a, b].sort())
+  })
+
+  test('directory walked recursively', async () => {
+    const subdir = path.join(tmp, 'sub')
+    await mkdir(subdir, { recursive: true })
+    const nested = path.join(subdir, 'nested.json')
+    await writeFile(nested, JSON.stringify({ version: 2, recordings: [] }))
+    const result = await walkCassettes([tmp])
+    expect(result).toContain(nested)
+  })
+
+  test('mixed paths: file + directory de-duplicated', async () => {
+    const a = path.join(tmp, 'a.json')
+    await writeFile(a, JSON.stringify({ version: 2, recordings: [] }))
+    const result = await walkCassettes([a, tmp])
+    expect(result.length).toBe(1)
+    expect(result[0]).toBe(a)
+  })
+
+  test('non-existent path throws', async () => {
+    await expect(walkCassettes([path.join(tmp, 'nope.json')])).rejects.toThrow()
+  })
+
+  test('non-cassette JSON in dir is silently skipped', async () => {
+    await writeFile(path.join(tmp, 'package.json'), JSON.stringify({ name: 'foo' }))
+    const result = await walkCassettes([tmp])
+    expect(result).toEqual([])
+  })
+
+  test('malformed JSON in dir is silently skipped (not a cassette)', async () => {
+    await writeFile(path.join(tmp, 'broken.json'), '{invalid json')
+    const result = await walkCassettes([tmp])
+    expect(result).toEqual([])
+  })
+
+  test('non-.json files in dir are skipped', async () => {
+    await writeFile(path.join(tmp, 'readme.txt'), 'hello')
+    const result = await walkCassettes([tmp])
+    expect(result).toEqual([])
+  })
+
+  test('JSON file with version field other than 1 or 2 in dir is skipped', async () => {
+    await writeFile(path.join(tmp, 'v3.json'), JSON.stringify({ version: 3, recordings: [] }))
+    const result = await walkCassettes([tmp])
+    expect(result).toEqual([])
+  })
+
+  test('empty paths array returns empty result', async () => {
+    const result = await walkCassettes([])
+    expect(result).toEqual([])
+  })
+
+  test('explicit file path bypasses cassette filter (caller knows what they want)', async () => {
+    // This test verifies the design choice: explicit paths are trusted.
+    // Walking a directory filters; passing a file directly does not.
+    const explicit = path.join(tmp, 'config.json')
+    await writeFile(explicit, JSON.stringify({ name: 'package' }))
+    const result = await walkCassettes([explicit])
+    expect(result).toEqual([explicit])
+  })
+})

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+import { parseTopLevel } from '../../src/cli.js'
+
+describe('parseTopLevel', () => {
+  test('--help', () => {
+    expect(parseTopLevel(['--help'])).toEqual({ help: true, rest: [] })
+  })
+
+  test('-h', () => {
+    expect(parseTopLevel(['-h'])).toEqual({ help: true, rest: [] })
+  })
+
+  test('--version', () => {
+    expect(parseTopLevel(['--version'])).toEqual({ version: true, rest: [] })
+  })
+
+  test('-V', () => {
+    expect(parseTopLevel(['-V'])).toEqual({ version: true, rest: [] })
+  })
+
+  test('command only', () => {
+    expect(parseTopLevel(['scan'])).toEqual({ command: 'scan', rest: [] })
+  })
+
+  test('command with positional args', () => {
+    expect(parseTopLevel(['scan', 'foo.json', 'bar.json'])).toEqual({
+      command: 'scan',
+      rest: ['foo.json', 'bar.json'],
+    })
+  })
+
+  test('command with flag args', () => {
+    expect(parseTopLevel(['scan', 'foo.json', '--json'])).toEqual({
+      command: 'scan',
+      rest: ['foo.json', '--json'],
+    })
+  })
+
+  test('command with help-after passes through to subcommand', () => {
+    expect(parseTopLevel(['scan', '--help'])).toEqual({
+      command: 'scan',
+      rest: ['--help'],
+    })
+  })
+
+  test('--help BEFORE command takes priority', () => {
+    expect(parseTopLevel(['--help', 'scan'])).toEqual({
+      help: true,
+      rest: [],
+    })
+  })
+
+  test('--version BEFORE command takes priority', () => {
+    expect(parseTopLevel(['--version', 'scan'])).toEqual({
+      version: true,
+      rest: [],
+    })
+  })
+
+  test('empty argv', () => {
+    expect(parseTopLevel([])).toEqual({ rest: [] })
+  })
+})


### PR DESCRIPTION
## What Changed

Foundation for the `shell-cassette` CLI binary that the scan and re-redact subcommands will fill in.

- `src/cli-output.ts`: color helpers, TTY detection, NO_COLOR support, `applyTruncation`, `formatBytes`, stdout/stderr writers.
- `src/cli-walk.ts`: `walkCassettes(inputs)` for cassette path resolution (file + recursive dir walk + filter for cassette JSON).
- `src/cli.ts`: binary entry with `parseTopLevel` argv parser + subcommand dispatch + auto-execute guard.
- `src/cli-scan.ts`, `src/cli-re-redact.ts`: stubs throwing `ShellCassetteError`.
- `package.json` `bin: { "shell-cassette": "./dist/cli.js" }`.
- 44 new unit tests across 3 test files.

## Notes

- Color decision priority: `--color=always`, `--no-color`, `NO_COLOR` env (per https://no-color.org spec, empty string treated as unset), TTY auto-detect. Hand-rolled ANSI codes (no dependency).
- `walkCassettes` filter: explicit file paths trusted as-is; directory walk parses each `.json` and includes only files with `version: 1 | 2`. Silent skip on parse errors and unknown versions.
- Auto-execute guard: uses canonical `process.argv[1] === fileURLToPath(import.meta.url)` comparison so tests importing the module don't trigger `main()`. Tighter than `endsWith('cli.js')`.
- Typed errors throughout: `cli-walk.ts` throws `CassetteIOError` with the original `stat` error preserved as `.cause`. Stubs throw `ShellCassetteError` so user `instanceof` catches work.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (409 passed, 1 pre-existing skip; +44 new tests)
- [x] `npm run build` produces clean dist/ with executable cli.js
- [x] `node dist/cli.js --version` prints package version
- [x] `node dist/cli.js --help` prints full usage
- [x] `node dist/cli.js` exits 2 with "missing command" to stderr
- [x] `node dist/cli.js frobnicate` exits 2 with "unknown command" to stderr