### PR TITLE
feat(cli): add scan subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       - name: typecheck
         run: npm run typecheck
 
+      - name: build
+        run: npm run build
+
       - name: test
         run: npm test
 
       - name: test:dogfood
         run: npm run test:dogfood
-
-      - name: build
-        run: npm run build
 
   # Smoke test on the published tarball. Catches dist/ shape, exports map,
   # and peer-dep resolution issues that in-repo tests miss because they

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -42,6 +42,16 @@ export const isTty = {
   },
 }
 
+/**
+ * Produce a credential-safe preview: short values are shown verbatim;
+ * values >= 12 chars show the first 4 characters, ellipsis, and last 4 characters.
+ * Used to hint at a match without exposing the full credential value.
+ */
+export function previewMatch(s: string): string {
+  if (s.length < 12) return s
+  return `${s.slice(0, 4)}...${s.slice(-4)}`
+}
+
 export function applyTruncation(s: string, limit: number): string {
   if (s.length === 0) return s
   if (s.length <= limit) return s

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -1,9 +1,29 @@
+/**
+ * `shell-cassette scan` subcommand. Walks cassette files (or directories)
+ * and reports any unredacted findings — credentials that record mode would
+ * have redacted but are present in cassette content (env values, args,
+ * stdout/stderr/allLines).
+ *
+ * Two coverage paths:
+ *   1. env-key-match: env value with a key in the curated or user envKeys
+ *      list. Whole value is reported regardless of pattern.
+ *   2. pattern match: bundled or custom regex rules. Position-precise via
+ *      String.prototype.matchAll.
+ *
+ * Function-typed custom rules are skipped (can't report exact positions).
+ *
+ * Output format is locked at scanVersion: 1. See spec Section 4 for the
+ * complete --json shape.
+ */
 import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { color, isTty, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
-import { loadConfigFromDir } from './config.js'
+import { loadConfigFromDir, loadConfigFromFile } from './config.js'
+import { CassetteConfigError } from './errors.js'
+import { matchesEnvKeyList } from './recorder.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
+import { ENV_KEY_MATCH_RULE } from './redact-pipeline.js'
 import { deserialize } from './serialize.js'
 import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
 
@@ -94,12 +114,12 @@ function parseScanArgs(args: readonly string[]): ScanFlags {
       flags.colorOverride = 'always'
     } else if (arg === '--config') {
       const next = args[++i]
-      if (next === undefined) throw new Error('--config requires a path argument')
+      if (next === undefined) throw new CassetteConfigError('--config requires a path argument')
       flags.configPath = next
     } else if (arg.startsWith('--config=')) {
       flags.configPath = arg.slice('--config='.length)
     } else if (arg.startsWith('--')) {
-      throw new Error(`unknown flag: ${arg}`)
+      throw new CassetteConfigError(`unknown flag: ${arg}`)
     } else {
       flags.paths.push(arg)
     }
@@ -107,6 +127,10 @@ function parseScanArgs(args: readonly string[]): ScanFlags {
   return flags
 }
 
+/**
+ * Scan one or more cassette files or directories for unredacted credentials.
+ * Returns 0 if all clean, 1 if any dirty, 2 on error.
+ */
 export async function runScan(args: readonly string[]): Promise<number> {
   let flags: ScanFlags
   try {
@@ -130,7 +154,9 @@ export async function runScan(args: readonly string[]): Promise<number> {
     isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
   )
 
-  const config = await loadConfigFromDir(flags.configPath ?? process.cwd())
+  const config = flags.configPath
+    ? await loadConfigFromFile(flags.configPath)
+    : await loadConfigFromDir(process.cwd())
   const effectiveRedact: Readonly<RedactConfig> = flags.noBundled
     ? Object.freeze({ ...config.redact, bundledPatterns: false })
     : config.redact
@@ -175,10 +201,8 @@ async function scanOne(
   }
 
   const findings: Finding[] = []
-  for (let i = 0; i < cassette.recordings.length; i++) {
-    // recordings[i] is always defined here since i < recordings.length
-    // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
-    findings.push(...findingsForRecording(cassette.recordings[i]!, i, config, includeMatch))
+  for (const [i, rec] of cassette.recordings.entries()) {
+    findings.push(...findingsForRecording(rec, i, config, includeMatch))
   }
 
   const redactionsApplied = cassette.recordings.reduce(
@@ -194,8 +218,11 @@ async function scanOne(
   }
 }
 
-// Build g-flagged regex copies for each scan invocation. Bundled patterns are
-// stored without the g flag (stateless for .test()/.exec()); scan needs matchAll.
+/**
+ * Build g-flagged regex copies of bundled + custom rules for matchAll usage.
+ * Built once per recording (not per-value) to amortize the allocation cost.
+ * Function-typed custom rules are skipped — they can't report match positions.
+ */
 function buildGFlaggedRules(
   config: Readonly<RedactConfig>,
 ): readonly { name: string; pattern: RegExp }[] {
@@ -230,6 +257,16 @@ function isSuppressed(value: string, config: Readonly<RedactConfig>): boolean {
   return false
 }
 
+/** Returns true if value is already a redaction placeholder (counter-tagged or counter-stripped). */
+function isPlaceholder(value: string): boolean {
+  return /^<redacted:[^:>]+:[^:>]+(:\d+)?>$/.test(value)
+}
+
+/**
+ * Iterate all 5 sources in a recording (env, args, stdout, stderr, allLines)
+ * and produce a list of unredacted Finding objects. Each finding includes
+ * source-specific position info embedded in its id.
+ */
 function findingsForRecording(
   rec: Recording,
   index: number,
@@ -239,8 +276,25 @@ function findingsForRecording(
   const rules = buildGFlaggedRules(config)
   const findings: Finding[] = []
 
-  // env: scan each value, use key as position label
+  // env: env-key-match check first, then pattern scan on non-matching keys
   for (const [key, value] of Object.entries(rec.call.env)) {
+    // env-key-match: if the key matches the curated/user envKeys list, the
+    // recorder would have redacted the whole value regardless of pattern.
+    // Scan must report this so cassettes that would have been redacted by
+    // record mode aren't falsely reported as clean.
+    if (matchesEnvKeyList(key, config.envKeys) && !isPlaceholder(value)) {
+      findings.push({
+        id: `rec${index}-env-${key}:0-${ENV_KEY_MATCH_RULE}`,
+        recordingIndex: index,
+        source: 'env',
+        rule: ENV_KEY_MATCH_RULE,
+        match: includeMatch ? value : undefined,
+        matchHash: `sha256:${createHash('sha256').update(value).digest('hex')}`,
+        matchLength: value.length,
+        matchPreview: previewMatch(value),
+      })
+      continue // don't also pattern-scan; whole value is already sensitive
+    }
     findings.push(...scanValue(value, 'env', key, index, rules, config, includeMatch))
   }
 

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -1,10 +1,373 @@
-import { ShellCassetteError } from './errors.js'
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { color, isTty, stderr, stdout } from './cli-output.js'
+import { walkCassettes } from './cli-walk.js'
+import { loadConfigFromDir } from './config.js'
+import { BUNDLED_PATTERNS } from './redact-patterns.js'
+import { deserialize } from './serialize.js'
+import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
 
-/**
- * `shell-cassette scan` subcommand stub. M10 will fill the implementation
- * with verification logic over cassette files; for now this stub keeps the
- * binary's argv dispatch wired so M9 ships a working entry point.
- */
-export async function runScan(_args: readonly string[]): Promise<number> {
-  throw new ShellCassetteError('runScan not implemented (stub for M9 wiring; M10 implements)')
+const SCAN_VERSION = 1
+
+const SCAN_HELP = `\
+Usage:
+  shell-cassette scan [paths...] [options]
+
+Walks cassette files (or directories of them) and reports any unredacted
+findings. Read-only; does not modify cassettes.
+
+Exit codes:
+  0   all cassettes clean
+  1   at least one cassette has findings
+  2   error (missing path, malformed cassette, conflicting flags)
+
+Options:
+  --json              structured output
+  --quiet             suppress stdout (exit code only)
+  --include-match     [with --json] include raw match values (UNSAFE for piping)
+  --config <path>     override config discovery
+  --no-bundled        skip bundled patterns; user rules + suppress only
+  --no-color
+  --color=always
+  --help
+`
+
+type Finding = {
+  id: string
+  recordingIndex: number
+  source: RedactSource
+  rule: string
+  match?: string // only set with --include-match
+  matchHash: string
+  matchLength: number
+  matchPreview: string
+}
+
+type CassetteResult = {
+  path: string
+  status: 'clean' | 'dirty' | 'error'
+  findings?: Finding[]
+  error?: string
+  redactionsApplied: number
+}
+
+type ColorOverride = 'auto' | 'always' | 'never'
+
+type ScanFlags = {
+  paths: string[]
+  json: boolean
+  quiet: boolean
+  includeMatch: boolean
+  configPath?: string
+  noBundled: boolean
+  colorOverride: ColorOverride
+  help: boolean
+}
+
+function parseScanArgs(args: readonly string[]): ScanFlags {
+  const flags: ScanFlags = {
+    paths: [],
+    json: false,
+    quiet: false,
+    includeMatch: false,
+    noBundled: false,
+    colorOverride: 'auto',
+    help: false,
+  }
+  for (let i = 0; i < args.length; i++) {
+    // args[i] is always defined here since i < args.length
+    // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+    const arg = args[i]!
+    if (arg === '--help' || arg === '-h') {
+      flags.help = true
+    } else if (arg === '--json') {
+      flags.json = true
+    } else if (arg === '--quiet') {
+      flags.quiet = true
+    } else if (arg === '--include-match') {
+      flags.includeMatch = true
+    } else if (arg === '--no-bundled') {
+      flags.noBundled = true
+    } else if (arg === '--no-color') {
+      flags.colorOverride = 'never'
+    } else if (arg === '--color=always') {
+      flags.colorOverride = 'always'
+    } else if (arg === '--config') {
+      const next = args[++i]
+      if (next === undefined) throw new Error('--config requires a path argument')
+      flags.configPath = next
+    } else if (arg.startsWith('--config=')) {
+      flags.configPath = arg.slice('--config='.length)
+    } else if (arg.startsWith('--')) {
+      throw new Error(`unknown flag: ${arg}`)
+    } else {
+      flags.paths.push(arg)
+    }
+  }
+  return flags
+}
+
+export async function runScan(args: readonly string[]): Promise<number> {
+  let flags: ScanFlags
+  try {
+    flags = parseScanArgs(args)
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}\n${SCAN_HELP}`)
+    return 2
+  }
+
+  if (flags.help) {
+    stdout(SCAN_HELP)
+    return 0
+  }
+
+  if (flags.paths.length === 0) {
+    stderr(`error: scan requires at least one path\n${SCAN_HELP}`)
+    return 2
+  }
+
+  color.setEnabled(
+    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
+  )
+
+  const config = await loadConfigFromDir(flags.configPath ?? process.cwd())
+  const effectiveRedact: Readonly<RedactConfig> = flags.noBundled
+    ? Object.freeze({ ...config.redact, bundledPatterns: false })
+    : config.redact
+
+  let cassettePaths: string[]
+  try {
+    cassettePaths = await walkCassettes(flags.paths)
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}`)
+    return 2
+  }
+
+  const results: CassetteResult[] = []
+  for (const p of cassettePaths) {
+    results.push(await scanOne(p, effectiveRedact, flags.includeMatch))
+  }
+
+  if (flags.json) {
+    stdout(JSON.stringify(buildJsonOutput(results), null, 2))
+  } else if (!flags.quiet) {
+    printHumanOutput(results)
+  }
+
+  const errors = results.filter((r) => r.status === 'error').length
+  const dirty = results.filter((r) => r.status === 'dirty').length
+  if (errors > 0) return 2
+  if (dirty > 0) return 1
+  return 0
+}
+
+async function scanOne(
+  filePath: string,
+  config: Readonly<RedactConfig>,
+  includeMatch: boolean,
+): Promise<CassetteResult> {
+  let cassette: CassetteFile
+  try {
+    const text = await readFile(filePath, 'utf8')
+    cassette = deserialize(text)
+  } catch (e) {
+    return { path: filePath, status: 'error', error: (e as Error).message, redactionsApplied: 0 }
+  }
+
+  const findings: Finding[] = []
+  for (let i = 0; i < cassette.recordings.length; i++) {
+    // recordings[i] is always defined here since i < recordings.length
+    // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+    findings.push(...findingsForRecording(cassette.recordings[i]!, i, config, includeMatch))
+  }
+
+  const redactionsApplied = cassette.recordings.reduce(
+    (sum, r) => sum + r.redactions.reduce((s, e) => s + e.count, 0),
+    0,
+  )
+
+  return {
+    path: filePath,
+    status: findings.length > 0 ? 'dirty' : 'clean',
+    findings: findings.length > 0 ? findings : undefined,
+    redactionsApplied,
+  }
+}
+
+// Build g-flagged regex copies for each scan invocation. Bundled patterns are
+// stored without the g flag (stateless for .test()/.exec()); scan needs matchAll.
+function buildGFlaggedRules(
+  config: Readonly<RedactConfig>,
+): readonly { name: string; pattern: RegExp }[] {
+  const rules: { name: string; pattern: RegExp }[] = []
+
+  if (config.bundledPatterns) {
+    for (const rule of BUNDLED_PATTERNS) {
+      if (rule.pattern instanceof RegExp) {
+        const flags = rule.pattern.flags.includes('g')
+          ? rule.pattern.flags
+          : `${rule.pattern.flags}g`
+        rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
+      }
+    }
+  }
+
+  for (const rule of config.customPatterns) {
+    if (rule.pattern instanceof RegExp) {
+      const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`
+      rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
+    }
+    // Function-typed custom patterns: not scannable by position; skip for scan.
+  }
+
+  return rules
+}
+
+function isSuppressed(value: string, config: Readonly<RedactConfig>): boolean {
+  for (const sup of config.suppressPatterns) {
+    if (sup.test(value)) return true
+  }
+  return false
+}
+
+function findingsForRecording(
+  rec: Recording,
+  index: number,
+  config: Readonly<RedactConfig>,
+  includeMatch: boolean,
+): Finding[] {
+  const rules = buildGFlaggedRules(config)
+  const findings: Finding[] = []
+
+  // env: scan each value, use key as position label
+  for (const [key, value] of Object.entries(rec.call.env)) {
+    findings.push(...scanValue(value, 'env', key, index, rules, config, includeMatch))
+  }
+
+  // args: scan each arg, use arg index as position label
+  for (const [argIdx, arg] of rec.call.args.entries()) {
+    findings.push(...scanValue(arg, 'args', argIdx.toString(), index, rules, config, includeMatch))
+  }
+
+  // stdout lines: use 1-based line number as position label
+  for (const [lineIdx, line] of rec.result.stdoutLines.entries()) {
+    findings.push(
+      ...scanValue(line, 'stdout', (lineIdx + 1).toString(), index, rules, config, includeMatch),
+    )
+  }
+
+  // stderr lines
+  for (const [lineIdx, line] of rec.result.stderrLines.entries()) {
+    findings.push(
+      ...scanValue(line, 'stderr', (lineIdx + 1).toString(), index, rules, config, includeMatch),
+    )
+  }
+
+  // allLines (only when present)
+  if (rec.result.allLines !== null) {
+    for (const [lineIdx, line] of rec.result.allLines.entries()) {
+      findings.push(
+        ...scanValue(
+          line,
+          'allLines',
+          (lineIdx + 1).toString(),
+          index,
+          rules,
+          config,
+          includeMatch,
+        ),
+      )
+    }
+  }
+
+  return findings
+}
+
+function scanValue(
+  value: string,
+  source: RedactSource,
+  positionLabel: string,
+  recordingIndex: number,
+  rules: readonly { name: string; pattern: RegExp }[],
+  config: Readonly<RedactConfig>,
+  includeMatch: boolean,
+): Finding[] {
+  if (isSuppressed(value, config)) return []
+
+  const findings: Finding[] = []
+
+  for (const rule of rules) {
+    // Reset lastIndex before each matchAll (g-flag regexes are stateful)
+    rule.pattern.lastIndex = 0
+    for (const m of value.matchAll(rule.pattern)) {
+      const matchStr = m[0]
+      const col = m.index ?? 0
+      const position = `${positionLabel}:${col}`
+      const id = `rec${recordingIndex}-${source}-${position}-${rule.name}`
+      findings.push({
+        id,
+        recordingIndex,
+        source,
+        rule: rule.name,
+        match: includeMatch ? matchStr : undefined,
+        matchHash: `sha256:${createHash('sha256').update(matchStr).digest('hex')}`,
+        matchLength: matchStr.length,
+        matchPreview: previewMatch(matchStr),
+      })
+    }
+  }
+
+  return findings
+}
+
+function previewMatch(s: string): string {
+  if (s.length < 12) return s
+  return `${s.slice(0, 4)}...${s.slice(-4)}`
+}
+
+function buildJsonOutput(results: readonly CassetteResult[]): unknown {
+  const summary = {
+    scanned: results.length,
+    clean: results.filter((r) => r.status === 'clean').length,
+    dirty: results.filter((r) => r.status === 'dirty').length,
+    errors: results.filter((r) => r.status === 'error').length,
+    totalFindings: results.reduce((s, r) => s + (r.findings?.length ?? 0), 0),
+  }
+  // Build cassette entries in the locked JSON API shape
+  const cassettes = results.map((r) => {
+    if (r.status === 'error') {
+      return { path: r.path, status: r.status, error: r.error, redactionsApplied: 0 }
+    }
+    if (r.status === 'dirty') {
+      return {
+        path: r.path,
+        status: r.status,
+        redactionsApplied: r.redactionsApplied,
+        findings: r.findings,
+      }
+    }
+    return { path: r.path, status: r.status, redactionsApplied: r.redactionsApplied }
+  })
+  return { scanVersion: SCAN_VERSION, summary, cassettes }
+}
+
+function printHumanOutput(results: readonly CassetteResult[]): void {
+  for (const r of results) {
+    if (r.status === 'clean') {
+      stdout(
+        `${r.path}: ${color.green('clean')} (${r.redactionsApplied} redaction(s) already applied)`,
+      )
+    } else if (r.status === 'error') {
+      stdout(`${r.path}: ${color.red('error')} - ${r.error}`)
+    } else {
+      stdout(`${r.path}: ${color.yellow(`${r.findings?.length} unredacted finding(s)`)}`)
+      for (const f of r.findings ?? []) {
+        stdout(`  [${f.id}]: ${color.cyan(f.matchPreview)} (${f.matchLength} chars)`)
+      }
+    }
+  }
+  const dirty = results.filter((r) => r.status === 'dirty').length
+  const errors = results.filter((r) => r.status === 'error').length
+  stdout('')
+  stdout(`${results.length} cassette(s) scanned, ${dirty} dirty, ${errors} error(s).`)
 }

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -1,6 +1,6 @@
 /**
  * `shell-cassette scan` subcommand. Walks cassette files (or directories)
- * and reports any unredacted findings — credentials that record mode would
+ * and reports any unredacted findings: credentials that record mode would
  * have redacted but are present in cassette content (env values, args,
  * stdout/stderr/allLines).
  *
@@ -16,15 +16,14 @@
  * complete --json shape.
  */
 import { createHash } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
-import { color, isTty, stderr, stdout } from './cli-output.js'
+import { color, isTty, previewMatch, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
-import { CassetteConfigError } from './errors.js'
+import { CassetteConfigError, CassetteIOError } from './errors.js'
+import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
-import { ENV_KEY_MATCH_RULE } from './redact-pipeline.js'
-import { deserialize } from './serialize.js'
+import { ENV_KEY_MATCH_RULE, REDACTION_PLACEHOLDER_PATTERN } from './redact-pipeline.js'
 import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
 
 const SCAN_VERSION = 1
@@ -194,15 +193,22 @@ async function scanOne(
 ): Promise<CassetteResult> {
   let cassette: CassetteFile
   try {
-    const text = await readFile(filePath, 'utf8')
-    cassette = deserialize(text)
+    const loaded = await loadCassette(filePath)
+    if (loaded === null) {
+      throw new CassetteIOError(
+        `cassette file not found: ${filePath}`,
+        Object.assign(new Error(`cassette file not found: ${filePath}`), { code: 'ENOENT' }),
+      )
+    }
+    cassette = loaded
   } catch (e) {
     return { path: filePath, status: 'error', error: (e as Error).message, redactionsApplied: 0 }
   }
 
+  const rules = buildGFlaggedRules(config)
   const findings: Finding[] = []
   for (const [i, rec] of cassette.recordings.entries()) {
-    findings.push(...findingsForRecording(rec, i, config, includeMatch))
+    findings.push(...findingsForRecording(rec, i, rules, config, includeMatch))
   }
 
   const redactionsApplied = cassette.recordings.reduce(
@@ -220,8 +226,8 @@ async function scanOne(
 
 /**
  * Build g-flagged regex copies of bundled + custom rules for matchAll usage.
- * Built once per recording (not per-value) to amortize the allocation cost.
- * Function-typed custom rules are skipped — they can't report match positions.
+ * Built once per cassette and passed in to amortize regex allocation.
+ * Function-typed custom rules are skipped; they can't report match positions.
  */
 function buildGFlaggedRules(
   config: Readonly<RedactConfig>,
@@ -252,6 +258,7 @@ function buildGFlaggedRules(
 
 function isSuppressed(value: string, config: Readonly<RedactConfig>): boolean {
   for (const sup of config.suppressPatterns) {
+    sup.lastIndex = 0
     if (sup.test(value)) return true
   }
   return false
@@ -259,7 +266,7 @@ function isSuppressed(value: string, config: Readonly<RedactConfig>): boolean {
 
 /** Returns true if value is already a redaction placeholder (counter-tagged or counter-stripped). */
 function isPlaceholder(value: string): boolean {
-  return /^<redacted:[^:>]+:[^:>]+(:\d+)?>$/.test(value)
+  return REDACTION_PLACEHOLDER_PATTERN.test(value)
 }
 
 /**
@@ -270,10 +277,10 @@ function isPlaceholder(value: string): boolean {
 function findingsForRecording(
   rec: Recording,
   index: number,
+  rules: readonly { name: string; pattern: RegExp }[],
   config: Readonly<RedactConfig>,
   includeMatch: boolean,
 ): Finding[] {
-  const rules = buildGFlaggedRules(config)
   const findings: Finding[] = []
 
   // env: env-key-match check first, then pattern scan on non-matching keys
@@ -374,23 +381,33 @@ function scanValue(
   return findings
 }
 
-function previewMatch(s: string): string {
-  if (s.length < 12) return s
-  return `${s.slice(0, 4)}...${s.slice(-4)}`
-}
-
 function buildJsonOutput(results: readonly CassetteResult[]): unknown {
+  let clean = 0
+  let dirty = 0
+  let errors = 0
+  let totalFindings = 0
+  for (const r of results) {
+    if (r.status === 'clean') clean++
+    else if (r.status === 'dirty') dirty++
+    else errors++
+    if (r.status === 'dirty') totalFindings += r.findings?.length ?? 0
+  }
   const summary = {
     scanned: results.length,
-    clean: results.filter((r) => r.status === 'clean').length,
-    dirty: results.filter((r) => r.status === 'dirty').length,
-    errors: results.filter((r) => r.status === 'error').length,
-    totalFindings: results.reduce((s, r) => s + (r.findings?.length ?? 0), 0),
+    clean,
+    dirty,
+    errors,
+    totalFindings,
   }
   // Build cassette entries in the locked JSON API shape
   const cassettes = results.map((r) => {
     if (r.status === 'error') {
-      return { path: r.path, status: r.status, error: r.error, redactionsApplied: 0 }
+      return {
+        path: r.path,
+        status: r.status,
+        error: r.error,
+        redactionsApplied: r.redactionsApplied,
+      }
     }
     if (r.status === 'dirty') {
       return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -185,6 +185,22 @@ async function findConfigFile(startDir: string): Promise<string | null> {
   }
 }
 
+/**
+ * Load a config from a specific file path (no upward walk). Used by CLI
+ * `--config <path>` flag where the user explicitly names the file.
+ */
+export async function loadConfigFromFile(filePath: string): Promise<Readonly<Config>> {
+  let imported: { default?: unknown } | unknown
+  try {
+    imported = await import(pathToFileURL(filePath).href)
+  } catch (e) {
+    throw new CassetteConfigError(`failed to load config at ${filePath}: ${(e as Error).message}`)
+  }
+  const exported = (imported as { default?: unknown }).default ?? imported
+  validateConfig(exported)
+  return mergeWithDefaults(exported as PartialConfig)
+}
+
 export async function loadConfigFromDir(startDir: string): Promise<Readonly<Config>> {
   const filePath = await findConfigFile(startDir)
   if (filePath === null) return DEFAULT_CONFIG

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -83,7 +83,7 @@ function redactLine(source: RedactSource, line: string, session: CassetteSession
   return r.output
 }
 
-function matchesEnvKeyList(key: string, userKeys: readonly string[]): boolean {
+export function matchesEnvKeyList(key: string, userKeys: readonly string[]): boolean {
   const upper = key.toUpperCase()
   for (const k of CURATED_ENV_KEYS) {
     if (upper.includes(k.toUpperCase())) return true

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -94,6 +94,7 @@ export function runPipeline(
   const warnings: string[] = []
 
   for (const sup of config.suppressPatterns) {
+    sup.lastIndex = 0
     if (sup.test(value)) {
       return { output: value, entries, warnings }
     }
@@ -175,6 +176,14 @@ function applyRegexRule(
 // stripCounter and walkStringsForPlaceholders construct g-flagged RegExp
 // instances from this string so lastIndex state never leaks between callers.
 const COUNTER_PLACEHOLDER_PATTERN = '<redacted:([^:>]+):([^:>]+):(\\d+)>'
+
+/**
+ * Matches a fully-formed redaction placeholder in both counter-tagged form
+ * (<redacted:source:rule:N>) and counter-stripped form (<redacted:source:rule>).
+ * Exported so scan can skip values that are already redacted without duplicating
+ * the shape. If formatPlaceholder's output shape ever changes, update this too.
+ */
+export const REDACTION_PLACEHOLDER_PATTERN = /^<redacted:[^:>]+:[^:>]+(:\d+)?>$/
 
 // Hoisted to module level: String.prototype.replace resets lastIndex to 0
 // after completion (per ECMAScript spec), so reusing this regex across calls

--- a/tests/cli/scan.test.ts
+++ b/tests/cli/scan.test.ts
@@ -330,3 +330,105 @@ describe('runScan: --json + --quiet interaction', () => {
     expect(parsed.scanVersion).toBe(1)
   })
 })
+
+describe('runScan: isSuppressed g-flag lastIndex bug (closes #62)', () => {
+  test('g-flagged suppress pattern suppresses all three consecutive matching recordings', async () => {
+    // Without resetting lastIndex before each .test() call, a g-flagged suppress
+    // regex retains state between recordings. The second or third recording that
+    // matches the same pattern would incorrectly fall through as unsuppressed.
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-suppress-'))
+    const configPath = path.join(tmp, 'shell-cassette.config.mjs')
+    const cassettePath = path.join(tmp, 'suppress.json')
+    try {
+      // Config: disable bundled patterns; use a g-flagged custom suppress pattern.
+      // The suppress pattern is written as a string to avoid JSON serialization issues.
+      await writeFile(
+        configPath,
+        `export default { redact: { bundledPatterns: false, suppressPatterns: [/secret/gi] } }`,
+        'utf8',
+      )
+      // Cassette: three recordings, each with a custom pattern value that would
+      // trigger a bundled or custom rule. We use a custom rule via config instead.
+      // Actually: use a cassette with three arg values containing a custom pattern.
+      // Suppress them all so the scan returns clean.
+      await writeFile(
+        cassettePath,
+        JSON.stringify({
+          version: 2,
+          _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+          recordings: [
+            {
+              call: {
+                command: 'curl',
+                args: ['my-secret-token-1'],
+                cwd: null,
+                env: {},
+                stdin: null,
+              },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+            {
+              call: {
+                command: 'curl',
+                args: ['my-secret-token-2'],
+                cwd: null,
+                env: {},
+                stdin: null,
+              },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+            {
+              call: {
+                command: 'curl',
+                args: ['my-secret-token-3'],
+                cwd: null,
+                env: {},
+                stdin: null,
+              },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+          ],
+        }),
+        'utf8',
+      )
+      captureOutput()
+      // With bundled patterns disabled and values suppressed, all three recordings
+      // must come back clean. Without the lastIndex fix, recordings 2 and 3 would
+      // escape the suppress check and the scan would return dirty.
+      const code = await runScan([cassettePath, '--json', '--config', configPath])
+      expect(code).toBe(0)
+      const parsed = JSON.parse(stdoutBuf)
+      expect(parsed.summary.dirty).toBe(0)
+      expect(parsed.cassettes[0].status).toBe('clean')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/cli/scan.test.ts
+++ b/tests/cli/scan.test.ts
@@ -1,0 +1,214 @@
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { runScan } from '../../src/cli-scan.js'
+import { restoreEnv } from '../helpers/env.js'
+
+const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+const originalNoColor = process.env.NO_COLOR
+const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>
+let stderrSpy: ReturnType<typeof vi.spyOn>
+let stdoutBuf: string
+let stderrBuf: string
+
+function captureOutput() {
+  stdoutBuf = ''
+  stderrBuf = ''
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    stdoutBuf += chunk?.toString() ?? ''
+    return true
+  })
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    stderrBuf += chunk?.toString() ?? ''
+    return true
+  })
+}
+
+beforeEach(() => {
+  // Pin NO_COLOR so terminal output is predictable in tests (no ANSI codes)
+  process.env.NO_COLOR = '1'
+})
+
+afterEach(() => {
+  stdoutSpy?.mockRestore()
+  stderrSpy?.mockRestore()
+  restoreEnv('NO_COLOR', originalNoColor)
+  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+})
+
+describe('runScan: clean cassettes', () => {
+  test('clean cassette: exit 0, output marks clean', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-clean.json')])
+    expect(code).toBe(0)
+    expect(stdoutBuf).toContain('clean')
+    expect(stdoutBuf).toContain('v2-clean.json')
+  })
+
+  test('--quiet on clean cassette: no stdout, exit 0', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-clean.json'), '--quiet'])
+    expect(code).toBe(0)
+    expect(stdoutBuf).toBe('')
+  })
+})
+
+describe('runScan: dirty cassettes', () => {
+  test('dirty cassette: exit 1, findings reported', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-dirty.json')])
+    expect(code).toBe(1)
+    expect(stdoutBuf).toContain('unredacted')
+    expect(stdoutBuf).toContain('github-pat-classic')
+  })
+
+  test('--quiet on dirty cassette: no stdout, exit 1', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--quiet'])
+    expect(code).toBe(1)
+    expect(stdoutBuf).toBe('')
+  })
+})
+
+describe('runScan: --json output', () => {
+  test('clean cassette --json: scanVersion + summary', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-clean.json'), '--json'])
+    expect(code).toBe(0)
+    const parsed = JSON.parse(stdoutBuf)
+    expect(parsed.scanVersion).toBe(1)
+    expect(parsed.summary.scanned).toBe(1)
+    expect(parsed.summary.clean).toBe(1)
+    expect(parsed.summary.dirty).toBe(0)
+    expect(parsed.cassettes).toHaveLength(1)
+    expect(parsed.cassettes[0].status).toBe('clean')
+  })
+
+  test('dirty cassette --json: findings array with required fields', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--json'])
+    expect(code).toBe(1)
+    const parsed = JSON.parse(stdoutBuf)
+    expect(parsed.scanVersion).toBe(1)
+    expect(parsed.summary.dirty).toBe(1)
+    expect(parsed.cassettes[0].findings.length).toBeGreaterThan(0)
+    const finding = parsed.cassettes[0].findings[0]
+    expect(finding.id).toMatch(/^rec\d+-\w+-/)
+    expect(finding.recordingIndex).toBeTypeOf('number')
+    expect(finding.source).toBeTypeOf('string')
+    expect(finding.rule).toBeTypeOf('string')
+    expect(finding.matchHash).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(finding.matchLength).toBeTypeOf('number')
+    expect(finding.matchPreview).toBeTypeOf('string')
+    // Default --json must NOT include the raw match
+    expect(finding.match).toBeUndefined()
+  })
+
+  test('--json --include-match: raw match field present', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--json', '--include-match'])
+    expect(code).toBe(1)
+    const parsed = JSON.parse(stdoutBuf)
+    const finding = parsed.cassettes[0].findings[0]
+    expect(finding.match).toBeTypeOf('string')
+    expect(finding.match).toBe('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+  })
+
+  test('matchPreview format: >=12 chars uses first4...last4', async () => {
+    captureOutput()
+    await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--json'])
+    const parsed = JSON.parse(stdoutBuf)
+    const finding = parsed.cassettes[0].findings[0]
+    expect(finding.matchLength).toBe(40) // GitHub PAT length
+    // first 4 chars + ... + last 4 chars
+    expect(finding.matchPreview).toBe('ghp_...7890')
+  })
+})
+
+describe('runScan: error cases', () => {
+  test('non-existent path: exit 2, error to stderr', async () => {
+    captureOutput()
+    const code = await runScan(['/nonexistent/path.json'])
+    expect(code).toBe(2)
+    expect(stderrBuf).toContain('error')
+  })
+
+  test('unknown flag: exit 2', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-clean.json'), '--unknown-flag'])
+    expect(code).toBe(2)
+    expect(stderrBuf).toContain('unknown flag')
+  })
+
+  test('no path arg: exit 2 with help', async () => {
+    captureOutput()
+    const code = await runScan([])
+    expect(code).toBe(2)
+    expect(stderrBuf).toContain('requires at least one path')
+  })
+
+  test('--help: exit 0 with help text', async () => {
+    captureOutput()
+    const code = await runScan(['--help'])
+    expect(code).toBe(0)
+    expect(stdoutBuf).toContain('Usage:')
+    expect(stdoutBuf).toContain('--json')
+  })
+})
+
+describe('runScan: multi-path', () => {
+  test('multi-path: aggregates results, exit 1 if any dirty', async () => {
+    captureOutput()
+    const code = await runScan([
+      path.join(FIXTURES, 'v2-clean.json'),
+      path.join(FIXTURES, 'v2-dirty.json'),
+    ])
+    expect(code).toBe(1)
+    expect(stdoutBuf).toContain('clean')
+    expect(stdoutBuf).toContain('unredacted')
+  })
+
+  test('directory walk: scans nested cassettes', async () => {
+    captureOutput()
+    const code = await runScan([FIXTURES])
+    // Both v2-clean.json and v2-dirty.json exist in the fixtures dir
+    expect([0, 1]).toContain(code)
+    expect(stdoutBuf).toContain('cassette')
+  })
+})
+
+describe('runScan: --no-bundled', () => {
+  test('--no-bundled disables bundled patterns', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--no-bundled'])
+    // With bundled patterns disabled, the gh-pat rule won't match. No findings expected.
+    expect(code).toBe(0)
+    expect(stdoutBuf).toContain('clean')
+  })
+})
+
+describe('runScan: matchHash correctness', () => {
+  test('matchHash is sha256 of the raw match value', async () => {
+    captureOutput()
+    await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--json', '--include-match'])
+    const parsed = JSON.parse(stdoutBuf)
+    const finding = parsed.cassettes[0].findings[0]
+    // Verify hash independently
+    const { createHash } = await import('node:crypto')
+    const expected = `sha256:${createHash('sha256')
+      .update(finding.match as string)
+      .digest('hex')}`
+    expect(finding.matchHash).toBe(expected)
+  })
+})
+
+describe('runScan: summary line', () => {
+  test('summary shows scanned count and dirty count', async () => {
+    captureOutput()
+    await runScan([path.join(FIXTURES, 'v2-clean.json'), path.join(FIXTURES, 'v2-dirty.json')])
+    expect(stdoutBuf).toContain('2 cassette(s) scanned')
+    expect(stdoutBuf).toContain('1 dirty')
+  })
+})

--- a/tests/cli/scan.test.ts
+++ b/tests/cli/scan.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { runScan } from '../../src/cli-scan.js'
@@ -210,5 +212,121 @@ describe('runScan: summary line', () => {
     await runScan([path.join(FIXTURES, 'v2-clean.json'), path.join(FIXTURES, 'v2-dirty.json')])
     expect(stdoutBuf).toContain('2 cassette(s) scanned')
     expect(stdoutBuf).toContain('1 dirty')
+  })
+})
+
+describe('runScan: env-key-match coverage', () => {
+  test('env value with curated key but no pattern match: reported as unredacted', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-envkey-'))
+    try {
+      const cassettePath = path.join(tmp, 'envkey.json')
+      await writeFile(
+        cassettePath,
+        JSON.stringify({
+          version: 2,
+          _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+          recordings: [
+            {
+              call: {
+                command: 'curl',
+                args: [],
+                cwd: null,
+                env: { GITHUB_TOKEN: 'opaque-internal-format-no-known-shape' },
+                stdin: null,
+              },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+          ],
+        }),
+        'utf8',
+      )
+      captureOutput()
+      const code = await runScan([cassettePath, '--json'])
+      expect(code).toBe(1)
+      const parsed = JSON.parse(stdoutBuf)
+      expect(parsed.cassettes[0].findings[0].rule).toBe('env-key-match')
+      expect(parsed.cassettes[0].findings[0].source).toBe('env')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('env value already redacted as placeholder: not reported', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-envkey-'))
+    try {
+      const cassettePath = path.join(tmp, 'envkey.json')
+      await writeFile(
+        cassettePath,
+        JSON.stringify({
+          version: 2,
+          _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+          recordings: [
+            {
+              call: {
+                command: 'curl',
+                args: [],
+                cwd: null,
+                env: { GITHUB_TOKEN: '<redacted:env:env-key-match:1>' },
+                stdin: null,
+              },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [{ rule: 'env-key-match', source: 'env', count: 1 }],
+            },
+          ],
+        }),
+        'utf8',
+      )
+      captureOutput()
+      const code = await runScan([cassettePath, '--json'])
+      expect(code).toBe(0)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('runScan: --config <path>', () => {
+  test('--config <path> loads explicit config file', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-config-'))
+    try {
+      const configPath = path.join(tmp, 'shell-cassette.config.mjs')
+      // Custom config with bundled patterns disabled
+      await writeFile(configPath, `export default { redact: { bundledPatterns: false } }`, 'utf8')
+      captureOutput()
+      const code = await runScan([path.join(FIXTURES, 'v2-dirty.json'), '--config', configPath])
+      // With bundled patterns disabled, the dirty cassette is clean
+      expect(code).toBe(0)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('runScan: --json + --quiet interaction', () => {
+  test('--json --quiet: --json takes precedence; JSON still emitted', async () => {
+    captureOutput()
+    const code = await runScan([path.join(FIXTURES, 'v2-clean.json'), '--json', '--quiet'])
+    expect(code).toBe(0)
+    // --json overrides --quiet (matches plan reference impl)
+    expect(stdoutBuf.length).toBeGreaterThan(0)
+    const parsed = JSON.parse(stdoutBuf)
+    expect(parsed.scanVersion).toBe(1)
   })
 })

--- a/tests/e2e/cli-binary.test.ts
+++ b/tests/e2e/cli-binary.test.ts
@@ -1,20 +1,16 @@
-import { stat } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { execa } from 'execa'
-import { beforeAll, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 const CLI_BIN = path.resolve('dist/cli.js')
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
 
-beforeAll(async () => {
-  try {
-    await stat(CLI_BIN)
-  } catch {
-    throw new Error(`dist/cli.js missing: run \`npm run build\` before e2e tests`)
-  }
-})
+// Skip the suite if dist isn't built so local `npm test` works without a prior
+// `npm run build`. CI builds before test, so all six tests run there.
+const HAS_BUILT_CLI = existsSync(CLI_BIN)
 
-describe('shell-cassette binary (e2e)', () => {
+describe.skipIf(!HAS_BUILT_CLI)('shell-cassette binary (e2e)', () => {
   test('--version prints package version', async () => {
     const result = await execa('node', [CLI_BIN, '--version'])
     expect(result.exitCode).toBe(0)

--- a/tests/e2e/cli-binary.test.ts
+++ b/tests/e2e/cli-binary.test.ts
@@ -1,0 +1,60 @@
+import path from 'node:path'
+import { execa } from 'execa'
+import { describe, expect, test } from 'vitest'
+
+const CLI_BIN = path.resolve('dist/cli.js')
+const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+describe('shell-cassette binary (e2e)', () => {
+  test('--version prints package version', async () => {
+    const result = await execa('node', [CLI_BIN, '--version'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  test('--help prints usage', async () => {
+    const result = await execa('node', [CLI_BIN, '--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Usage:')
+    expect(result.stdout).toContain('scan')
+    expect(result.stdout).toContain('re-redact')
+  })
+
+  test('scan on clean cassette: exit 0', async () => {
+    const result = await execa('node', [
+      CLI_BIN,
+      'scan',
+      path.join(FIXTURES, 'v2-clean.json'),
+      '--no-color',
+    ])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('clean')
+  })
+
+  test('scan on dirty cassette: exit 1', async () => {
+    const result = await execa(
+      'node',
+      [CLI_BIN, 'scan', path.join(FIXTURES, 'v2-dirty.json'), '--no-color'],
+      { reject: false },
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('unredacted')
+  })
+
+  test('scan --json valid JSON output', async () => {
+    const result = await execa(
+      'node',
+      [CLI_BIN, 'scan', path.join(FIXTURES, 'v2-dirty.json'), '--json'],
+      { reject: false },
+    )
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.stdout)
+    expect(parsed.scanVersion).toBe(1)
+  })
+
+  test('unknown command: exit 2', async () => {
+    const result = await execa('node', [CLI_BIN, 'frobnicate'], { reject: false })
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('unknown command')
+  })
+})

--- a/tests/e2e/cli-binary.test.ts
+++ b/tests/e2e/cli-binary.test.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   try {
     await stat(CLI_BIN)
   } catch {
-    throw new Error(`dist/cli.js missing — run \`npm run build\` before e2e tests`)
+    throw new Error(`dist/cli.js missing: run \`npm run build\` before e2e tests`)
   }
 })
 

--- a/tests/e2e/cli-binary.test.ts
+++ b/tests/e2e/cli-binary.test.ts
@@ -1,9 +1,18 @@
+import { stat } from 'node:fs/promises'
 import path from 'node:path'
 import { execa } from 'execa'
-import { describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 
 const CLI_BIN = path.resolve('dist/cli.js')
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+beforeAll(async () => {
+  try {
+    await stat(CLI_BIN)
+  } catch {
+    throw new Error(`dist/cli.js missing — run \`npm run build\` before e2e tests`)
+  }
+})
 
 describe('shell-cassette binary (e2e)', () => {
   test('--version prints package version', async () => {

--- a/tests/fixtures/cassettes/v2-clean.json
+++ b/tests/fixtures/cassettes/v2-clean.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "_warning": "REVIEW BEFORE COMMITTING. shell-cassette redacts bundled credential patterns + curated env-key values + your custom rules.",
+  "_recorded_by": { "name": "shell-cassette", "version": "0.4.0" },
+  "recordings": [
+    {
+      "call": {
+        "command": "node",
+        "args": ["-v"],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": ["v18.0.0"],
+        "stderrLines": [],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 100,
+        "aborted": false
+      },
+      "_redactions": []
+    }
+  ]
+}

--- a/tests/fixtures/cassettes/v2-dirty.json
+++ b/tests/fixtures/cassettes/v2-dirty.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "_warning": "REVIEW BEFORE COMMITTING.",
+  "_recorded_by": { "name": "shell-cassette", "version": "0.4.0" },
+  "recordings": [
+    {
+      "call": {
+        "command": "curl",
+        "args": ["-H", "Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": [],
+        "stderrLines": [],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 100,
+        "aborted": false
+      },
+      "_redactions": []
+    }
+  ]
+}

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -33,6 +33,32 @@ describe('redact-pipeline: suppress short-circuit', () => {
     expect(result.output).toBe('normal-value')
     expect(result.entries).toEqual([])
   })
+
+  test('g-flagged suppress pattern: all three consecutive matching calls suppress correctly (lastIndex bug)', () => {
+    // A g-flagged regex retains lastIndex between .test() calls. Without resetting
+    // lastIndex to 0 before each call, the second (or third) call against a different
+    // string may incorrectly return false even though the string matches.
+    const config: RedactConfig = {
+      ...baseConfig,
+      suppressPatterns: [/secret/gi],
+    }
+    const v1 = runPipeline({ source: 'env', value: 'my-secret-token-1' }, config, {
+      counted: false,
+    })
+    const v2 = runPipeline({ source: 'env', value: 'my-secret-token-2' }, config, {
+      counted: false,
+    })
+    const v3 = runPipeline({ source: 'env', value: 'my-secret-token-3' }, config, {
+      counted: false,
+    })
+    // All three values match the suppress pattern; all three must be suppressed.
+    expect(v1.output).toBe('my-secret-token-1')
+    expect(v2.output).toBe('my-secret-token-2')
+    expect(v3.output).toBe('my-secret-token-3')
+    expect(v1.entries).toEqual([])
+    expect(v2.entries).toEqual([])
+    expect(v3.entries).toEqual([])
+  })
 })
 
 describe('redact-pipeline: bundled patterns', () => {


### PR DESCRIPTION
## What Changed

Implements `shell-cassette scan` for pre-commit verification. Walks cassette files (or directories), reports unredacted findings, exits 0/1/2 for clean/dirty/error.

- `src/cli-scan.ts` (replaces stub): full implementation with locked `scanVersion: 1` JSON API.
- `tests/fixtures/cassettes/v2-clean.json`, `v2-dirty.json`: fixture cassettes.
- `tests/cli/scan.test.ts`: 22 unit tests covering all paths.
- `tests/e2e/cli-binary.test.ts`: 6 e2e binary smoke tests, suite skips when dist not built.
- `loadConfigFromFile` helper in `src/config.ts` for `--config <path>` support.
- `matchesEnvKeyList` exported from `src/recorder.ts` for scan to use.

## Critical fix from review: env-key-match coverage

The recorder redacts env values when the KEY matches the curated list (or `config.envKeys`), regardless of value pattern. Scan was only running regex patterns: a cassette with `GITHUB_TOKEN: 'opaque-format'` scanned clean despite record mode redacting it. Fixed: scan checks the env-key-match path first, before the regex sweep.

## Bug fixes folded in

- Closes #62: g-flag `lastIndex` bug in suppress-pattern check (both `src/redact-pipeline.ts` and the new `src/cli-scan.ts`); regression tests added in `tests/unit/redact-pipeline.test.ts` and `tests/cli/scan.test.ts`.

## Notes

- Single-pass match position discovery via `String.prototype.matchAll`. No double-call to redact pipeline.
- Match preview: `<first 4>...<last 4>` (ASCII); full match if length < 12. Exported from `cli-output.ts` so re-redact can reuse.
- Match safety: `--json` defaults to hash + preview only; `--include-match` opt-in for raw values.
- Function-typed custom rules: silently skipped (can't report exact positions); documented in JSDoc.
- `--config <path>` loads explicit file via new `loadConfigFromFile` (was incorrectly using `loadConfigFromDir` which expects a directory).
- Shared `REDACTION_PLACEHOLDER_PATTERN` exported from `redact-pipeline.ts` so scan's `isPlaceholder` check stays in sync if the placeholder shape ever changes.
- CI: build now runs before test so the e2e binary suite executes in CI (previously skipped silently).

Flags supported: `--json`, `--quiet`, `--include-match`, `--config <path>`, `--no-bundled`, `--no-color`, `--color=always`, `--help`.

## Related Issues

Closes #62.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (438 passed, 1 pre-existing platform skip)
- [x] `npm run build` produces clean dist/
- [x] `node dist/cli.js scan tests/fixtures/cassettes/v2-clean.json` exits 0 with "clean"
- [x] `node dist/cli.js scan tests/fixtures/cassettes/v2-dirty.json` exits 1 with "unredacted"
- [x] `node dist/cli.js scan tests/fixtures/cassettes/v2-dirty.json --json` returns valid scanVersion: 1 JSON