### PR TITLE
feat(cli): add re-redact subcommand

### DIFF
--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -11,7 +11,7 @@
 import { color, isTty, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
-import { CassetteConfigError, CassetteIOError } from './errors.js'
+import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { writeCassetteFile } from './io.js'
 import { loadCassette } from './loader.js'
 import { redact } from './redact.js'
@@ -182,12 +182,7 @@ async function reRedactOne(
   dryRun: boolean,
 ): Promise<{ modified: boolean; newRedactions: number }> {
   const cassette = await loadCassette(cassettePath)
-  if (cassette === null) {
-    throw new CassetteIOError(
-      `cassette file not found: ${cassettePath}`,
-      Object.assign(new Error(`cassette file not found: ${cassettePath}`), { code: 'ENOENT' }),
-    )
-  }
+  if (cassette === null) throw new CassetteNotFoundError(cassettePath)
 
   // Seed counters from existing placeholders so new findings continue the
   // per-(source, rule) sequence rather than restarting at 1.

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -181,16 +181,16 @@ async function reRedactOne(
   config: Readonly<RedactConfig>,
   dryRun: boolean,
 ): Promise<{ modified: boolean; newRedactions: number }> {
-  let cassette: CassetteFile
-  const loaded = await loadCassette(cassettePath)
-  if (loaded === null) {
+  const cassette = await loadCassette(cassettePath)
+  if (cassette === null) {
     throw new CassetteIOError(
       `cassette file not found: ${cassettePath}`,
       Object.assign(new Error(`cassette file not found: ${cassettePath}`), { code: 'ENOENT' }),
     )
   }
-  cassette = loaded
 
+  // Seed counters from existing placeholders so new findings continue the
+  // per-(source, rule) sequence rather than restarting at 1.
   const counters = seedCountersFromCassette(cassette)
   let newCount = 0
   const updatedRecordings: Recording[] = []
@@ -221,59 +221,46 @@ function reRedactRecording(
   const newEntries: RedactionEntry[] = []
   let newCount = 0
 
-  // env
   const env: Record<string, string> = {}
   for (const [key, value] of Object.entries(rec.call.env)) {
     const r = redact({ source: 'env', value }, config, { counted: true, counters })
     env[key] = r.output
-    if (r.entries.length > 0) {
-      newEntries.push(...r.entries)
-      newCount += r.entries.reduce((s, e) => s + e.count, 0)
-    }
+    newEntries.push(...r.entries)
+    newCount += r.entries.reduce((s, e) => s + e.count, 0)
   }
 
-  // args
   const args = rec.call.args.map((arg) => {
     const r = redact({ source: 'args', value: arg }, config, { counted: true, counters })
-    if (r.entries.length > 0) {
-      newEntries.push(...r.entries)
-      newCount += r.entries.reduce((s, e) => s + e.count, 0)
-    }
+    newEntries.push(...r.entries)
+    newCount += r.entries.reduce((s, e) => s + e.count, 0)
     return r.output
   })
 
-  // stdout lines
   const stdoutLines = rec.result.stdoutLines.map((line) => {
     const r = redact({ source: 'stdout', value: line }, config, { counted: true, counters })
-    if (r.entries.length > 0) {
-      newEntries.push(...r.entries)
-      newCount += r.entries.reduce((s, e) => s + e.count, 0)
-    }
+    newEntries.push(...r.entries)
+    newCount += r.entries.reduce((s, e) => s + e.count, 0)
     return r.output
   })
 
-  // stderr lines
   const stderrLines = rec.result.stderrLines.map((line) => {
     const r = redact({ source: 'stderr', value: line }, config, { counted: true, counters })
-    if (r.entries.length > 0) {
-      newEntries.push(...r.entries)
-      newCount += r.entries.reduce((s, e) => s + e.count, 0)
-    }
+    newEntries.push(...r.entries)
+    newCount += r.entries.reduce((s, e) => s + e.count, 0)
     return r.output
   })
 
-  // allLines
   const allLines =
     rec.result.allLines?.map((line) => {
       const r = redact({ source: 'allLines', value: line }, config, { counted: true, counters })
-      if (r.entries.length > 0) {
-        newEntries.push(...r.entries)
-        newCount += r.entries.reduce((s, e) => s + e.count, 0)
-      }
+      newEntries.push(...r.entries)
+      newCount += r.entries.reduce((s, e) => s + e.count, 0)
       return r.output
     }) ?? null
 
-  // Aggregate new entries with existing recording.redactions
+  // Concat-then-aggregate (rather than aggregate-then-merge) because existing
+  // rec.redactions and newEntries may share (source, rule) keys; aggregateEntries
+  // sums their counts in a single pass.
   const aggregated = aggregateEntries([...rec.redactions, ...newEntries])
 
   return {

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -1,11 +1,287 @@
-import { ShellCassetteError } from './errors.js'
+/**
+ * `shell-cassette re-redact` subcommand. Re-applies the current redaction
+ * rules to existing cassettes. Idempotent: running twice yields identical
+ * output. Use this when the bundled pattern set expands or when a user adds
+ * a custom rule and wants to upgrade existing cassettes.
+ *
+ * Existing placeholders are preserved; new findings get counters at
+ * max(existing) + 1 per (source, rule). v1 cassettes are upgraded to v2
+ * in place.
+ */
+import { color, isTty, stderr, stdout } from './cli-output.js'
+import { walkCassettes } from './cli-walk.js'
+import { loadConfigFromDir, loadConfigFromFile } from './config.js'
+import { CassetteConfigError, CassetteIOError } from './errors.js'
+import { writeCassetteFile } from './io.js'
+import { loadCassette } from './loader.js'
+import { redact } from './redact.js'
+import { aggregateEntries, seedCountersFromCassette } from './redact-pipeline.js'
+import { serialize } from './serialize.js'
+import type { CassetteFile, Recording, RedactConfig, RedactionEntry } from './types.js'
+import { RECORDED_BY } from './version.js'
+
+const RE_REDACT_HELP = `\
+Usage:
+  shell-cassette re-redact [paths...] [options]
+
+Re-applies the current redaction rules to existing cassettes. Idempotent:
+running twice yields identical output. Use this when the bundle expands or
+when you add a custom rule and want to upgrade existing cassettes.
+
+Existing placeholders are kept; new findings get counters at max(existing) + 1
+per (source, rule). v1 cassettes are upgraded to v2 in place.
+
+Exit codes:
+  0   no new redactions applied (all cassettes already covered)
+  1   at least one cassette modified
+  2   error
+
+Options:
+  --dry-run           preview changes without writing
+  --quiet             suppress stdout summary
+  --config <path>     override config discovery
+  --no-bundled        skip bundled patterns
+  --no-color
+  --color=always
+  --help
+`
+
+type ColorOverride = 'auto' | 'always' | 'never'
+
+type ReRedactFlags = {
+  paths: string[]
+  dryRun: boolean
+  quiet: boolean
+  configPath?: string
+  noBundled: boolean
+  colorOverride: ColorOverride
+  help: boolean
+}
+
+function parseReRedactArgs(args: readonly string[]): ReRedactFlags {
+  const flags: ReRedactFlags = {
+    paths: [],
+    dryRun: false,
+    quiet: false,
+    noBundled: false,
+    colorOverride: 'auto',
+    help: false,
+  }
+  for (let i = 0; i < args.length; i++) {
+    // args[i] is always defined here since i < args.length
+    // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+    const arg = args[i]!
+    if (arg === '--help' || arg === '-h') {
+      flags.help = true
+    } else if (arg === '--dry-run') {
+      flags.dryRun = true
+    } else if (arg === '--quiet') {
+      flags.quiet = true
+    } else if (arg === '--no-bundled') {
+      flags.noBundled = true
+    } else if (arg === '--no-color') {
+      flags.colorOverride = 'never'
+    } else if (arg === '--color=always') {
+      flags.colorOverride = 'always'
+    } else if (arg === '--config') {
+      const next = args[++i]
+      if (next === undefined) throw new CassetteConfigError('--config requires a path argument')
+      flags.configPath = next
+    } else if (arg.startsWith('--config=')) {
+      flags.configPath = arg.slice('--config='.length)
+    } else if (arg.startsWith('--')) {
+      throw new CassetteConfigError(`unknown flag: ${arg}`)
+    } else {
+      flags.paths.push(arg)
+    }
+  }
+  return flags
+}
 
 /**
- * `shell-cassette re-redact` subcommand stub. M11 will fill the implementation
- * with re-application of current redaction rules over existing cassettes; for
- * now this stub keeps the binary's argv dispatch wired so M9 ships a working
- * entry point.
+ * Re-redact one or more cassette files or directories. Returns 0 if no new
+ * redactions were applied, 1 if at least one cassette was modified (or would
+ * be modified in dry-run), 2 on error.
  */
-export async function runReRedact(_args: readonly string[]): Promise<number> {
-  throw new ShellCassetteError('runReRedact not implemented (stub for M9 wiring; M11 implements)')
+export async function runReRedact(args: readonly string[]): Promise<number> {
+  let flags: ReRedactFlags
+  try {
+    flags = parseReRedactArgs(args)
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}\n${RE_REDACT_HELP}`)
+    return 2
+  }
+
+  if (flags.help) {
+    stdout(RE_REDACT_HELP)
+    return 0
+  }
+
+  if (flags.paths.length === 0) {
+    stderr(`error: re-redact requires at least one path\n${RE_REDACT_HELP}`)
+    return 2
+  }
+
+  color.setEnabled(
+    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
+  )
+
+  const config = flags.configPath
+    ? await loadConfigFromFile(flags.configPath)
+    : await loadConfigFromDir(process.cwd())
+  const effectiveRedact: Readonly<RedactConfig> = flags.noBundled
+    ? Object.freeze({ ...config.redact, bundledPatterns: false })
+    : config.redact
+
+  let cassettePaths: string[]
+  try {
+    cassettePaths = await walkCassettes(flags.paths)
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}`)
+    return 2
+  }
+
+  let totalNew = 0
+  let modifiedCount = 0
+  for (const p of cassettePaths) {
+    try {
+      const result = await reRedactOne(p, effectiveRedact, flags.dryRun)
+      totalNew += result.newRedactions
+      if (result.modified) modifiedCount++
+      if (!flags.quiet) {
+        if (result.newRedactions === 0) {
+          stdout(`${p}: ${color.green('clean')} (no new findings)`)
+        } else if (flags.dryRun) {
+          stdout(
+            `${p}: ${color.yellow(`would redact ${result.newRedactions}`)} new findings (dry-run)`,
+          )
+        } else {
+          stdout(`${p}: ${color.yellow(`${result.newRedactions} new redactions applied`)}`)
+        }
+      }
+    } catch (e) {
+      stderr(`${p}: error: ${(e as Error).message}`)
+      return 2
+    }
+  }
+
+  if (!flags.quiet) {
+    if (flags.dryRun) {
+      stdout(`dry-run: would redact ${totalNew} new findings across ${modifiedCount} cassette(s).`)
+    } else {
+      stdout(`re-redacted ${totalNew} new findings across ${modifiedCount} cassette(s).`)
+    }
+  }
+
+  return totalNew > 0 ? 1 : 0
+}
+
+async function reRedactOne(
+  cassettePath: string,
+  config: Readonly<RedactConfig>,
+  dryRun: boolean,
+): Promise<{ modified: boolean; newRedactions: number }> {
+  let cassette: CassetteFile
+  const loaded = await loadCassette(cassettePath)
+  if (loaded === null) {
+    throw new CassetteIOError(
+      `cassette file not found: ${cassettePath}`,
+      Object.assign(new Error(`cassette file not found: ${cassettePath}`), { code: 'ENOENT' }),
+    )
+  }
+  cassette = loaded
+
+  const counters = seedCountersFromCassette(cassette)
+  let newCount = 0
+  const updatedRecordings: Recording[] = []
+
+  for (const rec of cassette.recordings) {
+    const { recording, newCountInRecording } = reRedactRecording(rec, config, counters)
+    updatedRecordings.push(recording)
+    newCount += newCountInRecording
+  }
+
+  if (newCount === 0) return { modified: false, newRedactions: 0 }
+  if (dryRun) return { modified: true, newRedactions: newCount }
+
+  const updated: CassetteFile = {
+    version: 2,
+    recordedBy: RECORDED_BY,
+    recordings: updatedRecordings,
+  }
+  await writeCassetteFile(cassettePath, serialize(updated))
+  return { modified: true, newRedactions: newCount }
+}
+
+function reRedactRecording(
+  rec: Recording,
+  config: Readonly<RedactConfig>,
+  counters: Map<string, number>,
+): { recording: Recording; newCountInRecording: number } {
+  const newEntries: RedactionEntry[] = []
+  let newCount = 0
+
+  // env
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(rec.call.env)) {
+    const r = redact({ source: 'env', value }, config, { counted: true, counters })
+    env[key] = r.output
+    if (r.entries.length > 0) {
+      newEntries.push(...r.entries)
+      newCount += r.entries.reduce((s, e) => s + e.count, 0)
+    }
+  }
+
+  // args
+  const args = rec.call.args.map((arg) => {
+    const r = redact({ source: 'args', value: arg }, config, { counted: true, counters })
+    if (r.entries.length > 0) {
+      newEntries.push(...r.entries)
+      newCount += r.entries.reduce((s, e) => s + e.count, 0)
+    }
+    return r.output
+  })
+
+  // stdout lines
+  const stdoutLines = rec.result.stdoutLines.map((line) => {
+    const r = redact({ source: 'stdout', value: line }, config, { counted: true, counters })
+    if (r.entries.length > 0) {
+      newEntries.push(...r.entries)
+      newCount += r.entries.reduce((s, e) => s + e.count, 0)
+    }
+    return r.output
+  })
+
+  // stderr lines
+  const stderrLines = rec.result.stderrLines.map((line) => {
+    const r = redact({ source: 'stderr', value: line }, config, { counted: true, counters })
+    if (r.entries.length > 0) {
+      newEntries.push(...r.entries)
+      newCount += r.entries.reduce((s, e) => s + e.count, 0)
+    }
+    return r.output
+  })
+
+  // allLines
+  const allLines =
+    rec.result.allLines?.map((line) => {
+      const r = redact({ source: 'allLines', value: line }, config, { counted: true, counters })
+      if (r.entries.length > 0) {
+        newEntries.push(...r.entries)
+        newCount += r.entries.reduce((s, e) => s + e.count, 0)
+      }
+      return r.output
+    }) ?? null
+
+  // Aggregate new entries with existing recording.redactions
+  const aggregated = aggregateEntries([...rec.redactions, ...newEntries])
+
+  return {
+    recording: {
+      call: { ...rec.call, env, args },
+      result: { ...rec.result, stdoutLines, stderrLines, allLines },
+      redactions: aggregated,
+    },
+    newCountInRecording: newCount,
+  }
 }

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -19,7 +19,7 @@ import { createHash } from 'node:crypto'
 import { color, isTty, previewMatch, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
-import { CassetteConfigError, CassetteIOError } from './errors.js'
+import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
@@ -194,12 +194,7 @@ async function scanOne(
   let cassette: CassetteFile
   try {
     const loaded = await loadCassette(cassettePath)
-    if (loaded === null) {
-      throw new CassetteIOError(
-        `cassette file not found: ${cassettePath}`,
-        Object.assign(new Error(`cassette file not found: ${cassettePath}`), { code: 'ENOENT' }),
-      )
-    }
+    if (loaded === null) throw new CassetteNotFoundError(cassettePath)
     cassette = loaded
   } catch (e) {
     return {

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -187,22 +187,27 @@ export async function runScan(args: readonly string[]): Promise<number> {
 }
 
 async function scanOne(
-  filePath: string,
+  cassettePath: string,
   config: Readonly<RedactConfig>,
   includeMatch: boolean,
 ): Promise<CassetteResult> {
   let cassette: CassetteFile
   try {
-    const loaded = await loadCassette(filePath)
+    const loaded = await loadCassette(cassettePath)
     if (loaded === null) {
       throw new CassetteIOError(
-        `cassette file not found: ${filePath}`,
-        Object.assign(new Error(`cassette file not found: ${filePath}`), { code: 'ENOENT' }),
+        `cassette file not found: ${cassettePath}`,
+        Object.assign(new Error(`cassette file not found: ${cassettePath}`), { code: 'ENOENT' }),
       )
     }
     cassette = loaded
   } catch (e) {
-    return { path: filePath, status: 'error', error: (e as Error).message, redactionsApplied: 0 }
+    return {
+      path: cassettePath,
+      status: 'error',
+      error: (e as Error).message,
+      redactionsApplied: 0,
+    }
   }
 
   const rules = buildGFlaggedRules(config)
@@ -217,7 +222,7 @@ async function scanOne(
   )
 
   return {
-    path: filePath,
+    path: cassettePath,
     status: findings.length > 0 ? 'dirty' : 'clean',
     findings: findings.length > 0 ? findings : undefined,
     redactionsApplied,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,6 +46,14 @@ export class CassetteIOError extends ShellCassetteError {
   }
 }
 
+export class CassetteNotFoundError extends ShellCassetteError {
+  static override code = 'CASSETTE_NOT_FOUND'
+
+  constructor(public readonly path: string) {
+    super(`cassette file not found: ${path}`)
+  }
+}
+
 export class CassetteConfigError extends ShellCassetteError {
   static override code = 'CASSETTE_CONFIG'
 }

--- a/tests/cli/re-redact.test.ts
+++ b/tests/cli/re-redact.test.ts
@@ -3,8 +3,11 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { runReRedact } from '../../src/cli-re-redact.js'
+import { restoreEnv } from '../helpers/env.js'
 
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+const originalNoColor = process.env.NO_COLOR
 
 let tmp: string
 let stdoutSpy: ReturnType<typeof vi.spyOn>
@@ -19,7 +22,7 @@ afterEach(async () => {
   await rm(tmp, { recursive: true, force: true })
   stdoutSpy?.mockRestore()
   stderrSpy?.mockRestore()
-  delete process.env.NO_COLOR
+  restoreEnv('NO_COLOR', originalNoColor)
 })
 
 function captureOutput() {

--- a/tests/cli/re-redact.test.ts
+++ b/tests/cli/re-redact.test.ts
@@ -1,0 +1,288 @@
+import { copyFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { runReRedact } from '../../src/cli-re-redact.js'
+
+const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+let tmp: string
+let stdoutSpy: ReturnType<typeof vi.spyOn>
+let stderrSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-rr-'))
+  // Pin NO_COLOR so terminal output is predictable in tests (no ANSI codes)
+  process.env.NO_COLOR = '1'
+})
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+  stdoutSpy?.mockRestore()
+  stderrSpy?.mockRestore()
+  delete process.env.NO_COLOR
+})
+
+function captureOutput() {
+  let stdoutBuf = ''
+  let stderrBuf = ''
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    stdoutBuf += chunk?.toString() ?? ''
+    return true
+  })
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    stderrBuf += chunk?.toString() ?? ''
+    return true
+  })
+  return {
+    get stdout() {
+      return stdoutBuf
+    },
+    get stderr() {
+      return stderrBuf
+    },
+  }
+}
+
+describe('runReRedact: idempotence', () => {
+  test('running twice yields no changes the second time', async () => {
+    const target = path.join(tmp, 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v2-dirty.json'), target)
+
+    captureOutput()
+    const first = await runReRedact([target, '--no-color'])
+    expect(first).toBe(1)
+
+    const second = await runReRedact([target, '--no-color'])
+    expect(second).toBe(0)
+  })
+})
+
+describe('runReRedact: keep-existing', () => {
+  test('pre-existing placeholders are unchanged after re-redact', async () => {
+    const target = path.join(tmp, 'foo.json')
+    const cassette = {
+      version: 2,
+      _warning: 'REVIEW',
+      _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: ['<redacted:args:github-pat-classic:1>'],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 100,
+            aborted: false,
+          },
+          _redactions: [{ rule: 'github-pat-classic', source: 'args', count: 1 }],
+        },
+      ],
+    }
+    await writeFile(target, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    captureOutput()
+    const code = await runReRedact([target, '--no-color'])
+    expect(code).toBe(0)
+
+    const after = JSON.parse(await readFile(target, 'utf8'))
+    expect(after.recordings[0].call.args[0]).toBe('<redacted:args:github-pat-classic:1>')
+  })
+})
+
+describe('runReRedact: counter max+1', () => {
+  test('new finding starts at max+1 per (source, rule)', async () => {
+    const target = path.join(tmp, 'foo.json')
+    // Cassette already has :1 in env for github-pat-classic. Add a new dirty arg.
+    const cassette = {
+      version: 2,
+      _warning: 'REVIEW',
+      _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+            cwd: null,
+            env: { OLD: '<redacted:env:github-pat-classic:1>' },
+            stdin: null,
+          },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 100,
+            aborted: false,
+          },
+          _redactions: [{ rule: 'github-pat-classic', source: 'env', count: 1 }],
+        },
+      ],
+    }
+    await writeFile(target, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    captureOutput()
+    const code = await runReRedact([target, '--no-color'])
+    expect(code).toBe(1)
+
+    const after = JSON.parse(await readFile(target, 'utf8'))
+    // args counter starts at 1 (separate (args, github-pat-classic) key)
+    expect(after.recordings[0].call.args[0]).toBe('Bearer <redacted:args:github-pat-classic:1>')
+    // env counter unchanged
+    expect(after.recordings[0].call.env.OLD).toBe('<redacted:env:github-pat-classic:1>')
+  })
+})
+
+describe('runReRedact: v1 upgrade', () => {
+  test('v1 cassette is upgraded to v2 in place', async () => {
+    const target = path.join(tmp, 'foo.json')
+    const v1 = {
+      version: 1,
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            exitCode: 0,
+            signal: null,
+            durationMs: 100,
+          },
+        },
+      ],
+    }
+    await writeFile(target, `${JSON.stringify(v1, null, 2)}\n`)
+
+    captureOutput()
+    const code = await runReRedact([target, '--no-color'])
+    expect(code).toBe(1)
+
+    const after = JSON.parse(await readFile(target, 'utf8'))
+    expect(after.version).toBe(2)
+    expect(after._recorded_by).toBeDefined()
+    expect(after._recorded_by.name).toBe('shell-cassette')
+    expect(after.recordings[0].call.args[0]).toBe('Bearer <redacted:args:github-pat-classic:1>')
+    expect(after.recordings[0]._redactions).toEqual([
+      { rule: 'github-pat-classic', source: 'args', count: 1 },
+    ])
+  })
+})
+
+describe('runReRedact: --dry-run', () => {
+  test('--dry-run does not write the cassette', async () => {
+    const target = path.join(tmp, 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v2-dirty.json'), target)
+    const before = await readFile(target, 'utf8')
+
+    captureOutput()
+    const code = await runReRedact([target, '--dry-run', '--no-color'])
+    expect(code).toBe(1)
+
+    const after = await readFile(target, 'utf8')
+    expect(after).toBe(before)
+  })
+})
+
+describe('runReRedact: error paths', () => {
+  test('non-existent path: exit 2', async () => {
+    const out = captureOutput()
+    const code = await runReRedact(['/nonexistent/path.json', '--no-color'])
+    expect(code).toBe(2)
+    expect(out.stderr).toContain('error')
+  })
+
+  test('unknown flag: exit 2', async () => {
+    const out = captureOutput()
+    const code = await runReRedact(['--unknown-flag'])
+    expect(code).toBe(2)
+    expect(out.stderr).toContain('unknown flag')
+  })
+
+  test('no path arg: exit 2 with help', async () => {
+    const out = captureOutput()
+    const code = await runReRedact([])
+    expect(code).toBe(2)
+    expect(out.stderr).toContain('requires at least one path')
+  })
+})
+
+describe('runReRedact: --quiet', () => {
+  test('--quiet suppresses all stdout output', async () => {
+    const target = path.join(tmp, 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v2-clean.json'), target)
+
+    const out = captureOutput()
+    const code = await runReRedact([target, '--quiet'])
+    expect(code).toBe(0)
+    expect(out.stdout).toBe('')
+  })
+})
+
+describe('runReRedact: --config <path>', () => {
+  test('--config <path> loads explicit config and custom rules apply', async () => {
+    const target = path.join(tmp, 'cassette.json')
+    const configPath = path.join(tmp, 'shell-cassette.config.mjs')
+    // Custom config: disable bundled patterns, add a custom rule that redacts 'hunter2'
+    await writeFile(
+      configPath,
+      `export default {
+  redact: {
+    bundledPatterns: false,
+    customPatterns: [{ name: 'custom-secret', pattern: /hunter2/g }],
+  }
+}`,
+      'utf8',
+    )
+    // Cassette with a value that only the custom rule would catch
+    await writeFile(
+      target,
+      JSON.stringify({
+        version: 2,
+        _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+        recordings: [
+          {
+            call: {
+              command: 'echo',
+              args: ['hunter2'],
+              cwd: null,
+              env: {},
+              stdin: null,
+            },
+            result: {
+              stdoutLines: [],
+              stderrLines: [],
+              allLines: null,
+              exitCode: 0,
+              signal: null,
+              durationMs: 0,
+              aborted: false,
+            },
+            _redactions: [],
+          },
+        ],
+      }),
+      'utf8',
+    )
+
+    captureOutput()
+    const code = await runReRedact([target, '--config', configPath, '--no-color'])
+    expect(code).toBe(1)
+
+    const after = JSON.parse(await readFile(target, 'utf8'))
+    expect(after.recordings[0].call.args[0]).toBe('<redacted:args:custom-secret:1>')
+  })
+})

--- a/tests/error-path/error-classes.test.ts
+++ b/tests/error-path/error-classes.test.ts
@@ -7,6 +7,7 @@ import {
   CassetteCollisionError,
   CassetteCorruptError,
   CassetteIOError,
+  CassetteNotFoundError,
   ConcurrencyError,
   ReplayMissError,
   ShellCassetteError,
@@ -136,5 +137,15 @@ describe('all error classes are instanceof ShellCassetteError', () => {
   test('CassetteIOError on long path', () => {
     const longPath = `/repo/${'a'.repeat(300)}/test.ts`
     expect(() => cassettePath(longPath, [], 'test', '__cassettes__')).toThrow(CassetteIOError)
+  })
+
+  test('CassetteNotFoundError carries the missing path', () => {
+    const missing = '/nope/does-not-exist.json'
+    const err = new CassetteNotFoundError(missing)
+    expect(err).toBeInstanceOf(CassetteNotFoundError)
+    expect(err).toBeInstanceOf(ShellCassetteError)
+    expect(err.path).toBe(missing)
+    expect(err.message).toContain(missing)
+    expect(CassetteNotFoundError.code).toBe('CASSETTE_NOT_FOUND')
   })
 })


### PR DESCRIPTION
## What Changed

Implements the `re-redact` CLI subcommand (`src/cli-re-redact.ts`), replacing the previous stub with the full algorithm.

Algorithm per cassette:

1. Load via `loadCassette` (null throws `CassetteNotFoundError`).
2. Seed counters via `seedCountersFromCassette` (reused from `redact-pipeline.ts`).
3. For each recording, run `redact()` with `{ counted: true, counters }` over env, args, stdoutLines, stderrLines, allLines.
4. Aggregate new entries with existing `recording.redactions` via `aggregateEntries` (reused from `redact-pipeline.ts`).
5. If no new findings: skip write.
6. If `--dry-run`: report what would change, do not write.
7. Otherwise: build updated `CassetteFile` (version 2, `recordedBy: RECORDED_BY`), serialize, atomic write via `writeCassetteFile`.

Exit codes: 0 no new redactions, 1 at least one cassette modified (or would be in dry-run), 2 error.

Flags: `--dry-run`, `--quiet`, `--config <path>`, `--no-bundled`, `--no-color`, `--color=always`, `--help`.

Idempotence: existing placeholders do not match any bundled regex, so a clean cassette stays clean on re-run.

v1 upgrade: v1 cassettes deserialize successfully; re-redact rewrites as v2 with `_recorded_by` and per-recording `_redactions`.

## Bug fixes folded in

- Closes #64: replaced the synthetic `ENOENT` `Error` (constructed only to satisfy `CassetteIOError`'s cause argument) with a typed `CassetteNotFoundError(path)` subclass. Both `cli-scan.ts` and `cli-re-redact.ts` now throw the typed class on null `loadCassette`.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (449 passed, 1 platform-skip)
- [x] `npm run build` passes
- [x] Manual smoke: `node dist/cli.js re-redact v2-clean.json --no-color --dry-run` exits 0
- [x] Manual smoke: `node dist/cli.js re-redact v2-dirty.json --no-color` exits 1, second run exits 0 (idempotent)

New tests in `tests/cli/re-redact.test.ts`:

- idempotence: running twice yields no changes the second time
- keep-existing: pre-existing placeholders unchanged after re-redact
- counter max+1: new finding starts at max+1 per (source, rule)
- v1 cassette upgraded to v2 in place
- `--dry-run` does not write the cassette
- non-existent path: exit 2
- unknown flag: exit 2
- no path arg: exit 2 with help
- `--quiet` suppresses all stdout output
- `--config` loads explicit config and custom rules apply

New error-path test in `tests/error-path/error-classes.test.ts`:

- `CassetteNotFoundError` carries the missing path, inherits from `ShellCassetteError`, and exposes `code: 'CASSETTE_NOT_FOUND'`.