### PR TITLE
feat: export redact API and types from package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { defaultCanonicalize } from './matcher.js'
 export { basenameCommand, normalizeTmpPath } from './normalize.js'
+export type { RedactInput, RedactOptions, RedactOutput } from './redact.js'
+export { BUNDLED_PATTERNS, redact } from './redact.js'
 export type {
   Call,
   Canonicalize,
@@ -7,6 +9,10 @@ export type {
   CassetteSession,
   Mode,
   Recording,
+  RedactConfig,
+  RedactionEntry,
+  RedactRule,
+  RedactSource,
   Result,
   UseCassetteOptions,
 } from './types.js'


### PR DESCRIPTION
## What Changed

Adds public exports for the redact API surface to `src/index.ts`. Single-file additive change; no behavior changes.

Runtime exports added:

- `redact`: public single-value pipeline entry point
- `BUNDLED_PATTERNS`: readonly array of 25 bundled credential rules

Type exports added:

- From `redact.ts`: `RedactInput`, `RedactOptions`, `RedactOutput`
- From `types.ts`: `RedactConfig`, `RedactRule`, `RedactionEntry`, `RedactSource`

Intentionally NOT exported:

- `seedCountersFromCassette`, `aggregateEntries`, `ENV_KEY_MATCH_RULE`: internal building blocks used by the CLI subcommands and the recorder. Users do not call these directly.
- `CassetteNotFoundError`: already accessible via the existing `shell-cassette/errors` subpath.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` produces clean dist/
- [x] `npm test` passes (449 passed, 1 platform skip)
- [x] Manual smoke import lists all 6 runtime exports alphabetically:

```
node -e "import('./dist/index.js').then(m => console.log(Object.keys(m).sort()))"
```

Output:

```
[ 'BUNDLED_PATTERNS', 'basenameCommand', 'defaultCanonicalize', 'normalizeTmpPath', 'redact', 'useCassette' ]
```