### PR TITLE
refactor: type restructure, scan-record symmetry property, test infrastructure helpers

### DIFF
--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -176,7 +176,13 @@ export async function runReRedact(args: readonly string[]): Promise<number> {
   return totalNew > 0 ? 1 : 0
 }
 
-async function reRedactOne(
+/**
+ * Per-cassette re-redact entry point. Exported solely so the property test
+ * in tests/property/re-redact-idempotence.property.test.ts can drive it
+ * without spawning a subprocess. Internal-test consumer; not part of the
+ * public API.
+ */
+export async function reRedactOne(
   cassettePath: string,
   config: Readonly<RedactConfig>,
   dryRun: boolean,

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -186,7 +186,11 @@ export async function runScan(args: readonly string[]): Promise<number> {
   return 0
 }
 
-async function scanOne(
+/**
+ * Exported for use in tests (scan-record-symmetry property test). Internal-test
+ * consumer only; not part of the public API surface.
+ */
+export async function scanOne(
   cassettePath: string,
   config: Readonly<RedactConfig>,
   includeMatch: boolean,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { ConcurrencyError } from './errors.js'
+import { ConcurrencyError, ShellCassetteError } from './errors.js'
 import { cassettePath } from './paths.js'
 
 type VitestSuiteLike = {
@@ -25,7 +25,12 @@ Options:
 
   const filepath = task.file?.filepath
   if (!filepath) {
-    throw new Error('shell-cassette: vitest task missing file.filepath')
+    // task.file comes from vitest's task type which we don't own; we can't
+    // restructure vitest's types to prove this branch is unreachable. Throw a
+    // typed ShellCassetteError so programmatic instanceof catches still work.
+    throw new ShellCassetteError(
+      'shell-cassette: vitest task missing file.filepath (internal bug; should be unreachable)',
+    )
   }
 
   const describePath: string[] = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,12 +131,10 @@ export type UseCassetteOptions = {
   redact?: boolean
 }
 
-export type CassetteSession = {
+type SessionBase = {
   name: string
   path: string
   scopeDefault: 'auto' | 'passthrough'
-  loadedFile: CassetteFile | null
-  matcher: MatcherStateLike | null // built lazily; defined in matcher.ts
   canonicalize: Canonicalize
   /**
    * Frozen redaction config for this session. Loaded from Config.redact.
@@ -163,6 +161,31 @@ export type CassetteSession = {
   newRecordings: Recording[]
   warnings: string[]
 }
+
+/**
+ * Session before lazy-load: the cassette file has not been read yet and
+ * the matcher has not been initialized. Both fields are null.
+ */
+export type PendingSession = SessionBase & {
+  matcher: null
+  loadedFile: null
+}
+
+/**
+ * Session after lazy-load: the matcher is initialized (non-null). The
+ * cassette file may still be null when recording into a brand-new cassette.
+ */
+export type LoadedSession = SessionBase & {
+  matcher: MatcherStateLike
+  loadedFile: CassetteFile | null
+}
+
+/**
+ * Discriminated union over lazy-load state. Discriminant is `matcher`:
+ *   null  => PendingSession (pre-lazy-load)
+ *   non-null => LoadedSession (post-lazy-load)
+ */
+export type CassetteSession = PendingSession | LoadedSession
 
 // Forward-declared interface; implemented in matcher.ts
 export interface MatcherStateLike {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -122,8 +122,9 @@ export async function runWrapped<Opts, ResultShape>(
 /**
  * Ensures the session has completed lazy-load, returning a LoadedSession.
  * If `session.matcher` is already non-null, returns the session as-is (fast
- * path). Otherwise performs the one-time lazy-load: reads the cassette file
- * from disk, seeds redact counters, and initializes the matcher.
+ * path; TS narrows the union via the discriminant). Otherwise performs the
+ * one-time lazy-load: reads the cassette file from disk, seeds redact
+ * counters, and initializes the matcher.
  *
  * Keying on `matcher === null` (rather than `loadedFile === null`) is
  * intentional: `loadedFile` stays null for brand-new cassettes even after
@@ -131,16 +132,14 @@ export async function runWrapped<Opts, ResultShape>(
  * The matcher is always set unconditionally on first load, so it is the
  * correct single-use sentinel.
  *
- * The `as unknown as LoadedSession` casts are safe because:
- * - Fast path: `session.matcher !== null` proves the runtime shape is already
- *   LoadedSession; TS can't track the discriminant across the union boundary.
- * - Slow path: we unconditionally assign `session.matcher = new MatcherState(...)`
- *   before casting, so the runtime shape satisfies LoadedSession at that point.
- *   TS can't track in-place field mutation on a discriminated-union member.
+ * The slow-path `as unknown as LoadedSession` casts are needed because TS
+ * can't track in-place field mutation on a discriminated-union member: we
+ * unconditionally assign `session.matcher = new MatcherState(...)` before
+ * casting, so the runtime shape satisfies LoadedSession at that point.
  */
 async function ensureSessionLoaded(session: CassetteSession): Promise<LoadedSession> {
   if (session.matcher !== null) {
-    return session as unknown as LoadedSession
+    return session
   }
   const cassetteFile = await loadCassette(session.path)
   if (cassetteFile !== null) {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -7,7 +7,7 @@ import { resolveMode } from './mode.js'
 import { record } from './recorder.js'
 import { seedCountersFromCassette } from './redact-pipeline.js'
 import { getActiveCassette } from './state.js'
-import type { Call, CassetteSession, MatcherStateLike, Recording, Result } from './types.js'
+import type { Call, CassetteSession, LoadedSession, Recording, Result } from './types.js'
 
 const NO_ACTIVE_SESSION_HELP = `shell-cassette is in replay mode but no active cassette session is bound.
 
@@ -56,29 +56,12 @@ export async function runWrapped<Opts, ResultShape>(
     return hooks.realCall(file, args, options)
   }
 
-  if (session.loadedFile === null) {
-    const file = await loadCassette(session.path)
-    if (file !== null) {
-      session.loadedFile = file
-      // Seed redact counters from existing cassette placeholders so
-      // auto-additive appends continue from the existing per-(source, rule)
-      // ceiling. Spec Q5 + counter rebuild on cassette load.
-      const seeded = seedCountersFromCassette(file)
-      for (const [k, v] of seeded) {
-        session.redactCounters.set(k, v)
-      }
-    }
-    session.matcher = new MatcherState(
-      session.loadedFile?.recordings ?? [],
-      session.canonicalize,
-      session.redactConfig,
-    )
-  }
+  const loaded = await ensureSessionLoaded(session)
 
   const mode = resolveMode(
     process.env.SHELL_CASSETTE_MODE,
     Boolean(process.env.CI),
-    session.scopeDefault,
+    loaded.scopeDefault,
   )
 
   if (mode === 'passthrough') {
@@ -86,24 +69,23 @@ export async function runWrapped<Opts, ResultShape>(
   }
 
   const call = hooks.buildCall(file, args, options)
-  const matcher = ensureMatcher(session.matcher)
 
   if (mode === 'replay') {
-    if (session.loadedFile === null) {
+    if (loaded.loadedFile === null) {
       throw new ReplayMissError(
-        `no cassette at ${session.path}; run with SHELL_CASSETTE_MODE=record to create.`,
+        `no cassette at ${loaded.path}; run with SHELL_CASSETTE_MODE=record to create.`,
       )
     }
-    const recording = matcher.findMatch(call)
+    const recording = loaded.matcher.findMatch(call)
     if (recording === null) {
-      throw buildReplayMissError(call, session)
+      throw buildReplayMissError(call, loaded)
     }
     return hooks.synthesize(recording, options)
   }
 
   let cameFromAutoMiss = false
   if (mode === 'auto') {
-    const recording = matcher.findMatch(call)
+    const recording = loaded.matcher.findMatch(call)
     if (recording !== null) {
       return hooks.synthesize(recording, options)
     }
@@ -129,12 +111,57 @@ export async function runWrapped<Opts, ResultShape>(
   const start = performance.now()
   try {
     const result = await hooks.realCall(file, args, options)
-    captureAndRecord(call, result, performance.now() - start, hooks, session)
+    captureAndRecord(call, result, performance.now() - start, hooks, loaded)
     return result
   } catch (err) {
-    captureAndRecord(call, err, performance.now() - start, hooks, session)
+    captureAndRecord(call, err, performance.now() - start, hooks, loaded)
     throw err
   }
+}
+
+/**
+ * Ensures the session has completed lazy-load, returning a LoadedSession.
+ * If `session.matcher` is already non-null, returns the session as-is (fast
+ * path). Otherwise performs the one-time lazy-load: reads the cassette file
+ * from disk, seeds redact counters, and initializes the matcher.
+ *
+ * Keying on `matcher === null` (rather than `loadedFile === null`) is
+ * intentional: `loadedFile` stays null for brand-new cassettes even after
+ * lazy-load, so keying on it would re-run the load block on every call.
+ * The matcher is always set unconditionally on first load, so it is the
+ * correct single-use sentinel.
+ *
+ * The `as unknown as LoadedSession` casts are safe because:
+ * - Fast path: `session.matcher !== null` proves the runtime shape is already
+ *   LoadedSession; TS can't track the discriminant across the union boundary.
+ * - Slow path: we unconditionally assign `session.matcher = new MatcherState(...)`
+ *   before casting, so the runtime shape satisfies LoadedSession at that point.
+ *   TS can't track in-place field mutation on a discriminated-union member.
+ */
+async function ensureSessionLoaded(session: CassetteSession): Promise<LoadedSession> {
+  if (session.matcher !== null) {
+    return session as unknown as LoadedSession
+  }
+  const cassetteFile = await loadCassette(session.path)
+  if (cassetteFile !== null) {
+    // Widen to unknown first because PendingSession.loadedFile is typed as
+    // null (literal). The field assignment is safe: the mutation promotes this
+    // PendingSession to a LoadedSession, which we return below.
+    ;(session as unknown as LoadedSession).loadedFile = cassetteFile
+    // Seed redact counters from existing cassette placeholders so
+    // auto-additive appends continue from the existing per-(source, rule)
+    // ceiling. Spec Q5 + counter rebuild on cassette load.
+    const seeded = seedCountersFromCassette(cassetteFile)
+    for (const [k, v] of seeded) {
+      session.redactCounters.set(k, v)
+    }
+  }
+  ;(session as unknown as LoadedSession).matcher = new MatcherState(
+    cassetteFile?.recordings ?? [],
+    session.canonicalize,
+    session.redactConfig,
+  )
+  return session as unknown as LoadedSession
 }
 
 function captureAndRecord<Opts, ResultShape>(
@@ -142,22 +169,15 @@ function captureAndRecord<Opts, ResultShape>(
   raw: unknown,
   durationMs: number,
   hooks: RunnerHooks<Opts, ResultShape>,
-  session: CassetteSession,
+  session: LoadedSession,
 ): void {
   const result = hooks.captureResult(raw, durationMs)
   record(call, result, session)
 }
 
-function ensureMatcher(matcher: MatcherStateLike | null): MatcherStateLike {
-  if (matcher === null) {
-    throw new Error('shell-cassette: matcher was not initialized before use (internal bug)')
-  }
-  return matcher
-}
-
 const REPLAY_MISS_DIAGNOSTIC_LIMIT = 10
 
-function buildReplayMissError(call: Call, session: CassetteSession): ReplayMissError {
+function buildReplayMissError(call: Call, session: LoadedSession): ReplayMissError {
   const canonical = session.canonicalize(call, session.redactConfig)
   const recordings = session.loadedFile?.recordings ?? []
   const shown = recordings.slice(0, REPLAY_MISS_DIAGNOSTIC_LIMIT)

--- a/tests/cli/re-redact.test.ts
+++ b/tests/cli/re-redact.test.ts
@@ -1,25 +1,24 @@
-import { copyFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { copyFile, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { runReRedact } from '../../src/cli-re-redact.js'
+import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
 import { restoreEnv } from '../helpers/env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
 
 const originalNoColor = process.env.NO_COLOR
 
-let tmp: string
+const tmpDir = useTmpDir('shell-cassette-rr-')
 let stdoutSpy: ReturnType<typeof vi.spyOn>
 let stderrSpy: ReturnType<typeof vi.spyOn>
 
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-rr-'))
+beforeEach(() => {
   // Pin NO_COLOR so terminal output is predictable in tests (no ANSI codes)
   process.env.NO_COLOR = '1'
 })
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
+afterEach(() => {
   stdoutSpy?.mockRestore()
   stderrSpy?.mockRestore()
   restoreEnv('NO_COLOR', originalNoColor)
@@ -48,7 +47,7 @@ function captureOutput() {
 
 describe('runReRedact: idempotence', () => {
   test('running twice yields no changes the second time', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await copyFile(path.join(FIXTURES, 'v2-dirty.json'), target)
 
     captureOutput()
@@ -62,7 +61,7 @@ describe('runReRedact: idempotence', () => {
 
 describe('runReRedact: keep-existing', () => {
   test('pre-existing placeholders are unchanged after re-redact', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     const cassette = {
       version: 2,
       _warning: 'REVIEW',
@@ -102,7 +101,7 @@ describe('runReRedact: keep-existing', () => {
 
 describe('runReRedact: counter max+1', () => {
   test('new finding starts at max+1 per (source, rule)', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     // Cassette already has :1 in env for github-pat-classic. Add a new dirty arg.
     const cassette = {
       version: 2,
@@ -112,7 +111,7 @@ describe('runReRedact: counter max+1', () => {
         {
           call: {
             command: 'curl',
-            args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+            args: [`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`],
             cwd: null,
             env: { OLD: '<redacted:env:github-pat-classic:1>' },
             stdin: null,
@@ -146,14 +145,14 @@ describe('runReRedact: counter max+1', () => {
 
 describe('runReRedact: v1 upgrade', () => {
   test('v1 cassette is upgraded to v2 in place', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     const v1 = {
       version: 1,
       recordings: [
         {
           call: {
             command: 'curl',
-            args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+            args: [`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`],
             cwd: null,
             env: {},
             stdin: null,
@@ -187,7 +186,7 @@ describe('runReRedact: v1 upgrade', () => {
 
 describe('runReRedact: --dry-run', () => {
   test('--dry-run does not write the cassette', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await copyFile(path.join(FIXTURES, 'v2-dirty.json'), target)
     const before = await readFile(target, 'utf8')
 
@@ -225,7 +224,7 @@ describe('runReRedact: error paths', () => {
 
 describe('runReRedact: --quiet', () => {
   test('--quiet suppresses all stdout output', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await copyFile(path.join(FIXTURES, 'v2-clean.json'), target)
 
     const out = captureOutput()
@@ -237,8 +236,8 @@ describe('runReRedact: --quiet', () => {
 
 describe('runReRedact: --config <path>', () => {
   test('--config <path> loads explicit config and custom rules apply', async () => {
-    const target = path.join(tmp, 'cassette.json')
-    const configPath = path.join(tmp, 'shell-cassette.config.mjs')
+    const target = path.join(tmpDir.ref(), 'cassette.json')
+    const configPath = path.join(tmpDir.ref(), 'shell-cassette.config.mjs')
     // Custom config: disable bundled patterns, add a custom rule that redacts 'hunter2'
     await writeFile(
       configPath,

--- a/tests/cli/scan.test.ts
+++ b/tests/cli/scan.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { runScan } from '../../src/cli-scan.js'
+import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
 import { restoreEnv } from '../helpers/env.js'
 
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
@@ -115,7 +116,7 @@ describe('runScan: --json output', () => {
     const parsed = JSON.parse(stdoutBuf)
     const finding = parsed.cassettes[0].findings[0]
     expect(finding.match).toBeTypeOf('string')
-    expect(finding.match).toBe('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(finding.match).toBe(SAMPLE_GITHUB_PAT_CLASSIC)
   })
 
   test('matchPreview format: >=12 chars uses first4...last4', async () => {

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -1,65 +1,57 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { loadConfigFromDir } from '../../src/config.js'
 import { CassetteConfigError } from '../../src/errors.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('loadConfigFromDir', () => {
-  let tmp: string
-
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-config-'))
-  })
-
-  afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true })
-  })
+  const tmpDir = useTmpDir('shell-cassette-config-')
 
   test('returns default config when no file found', async () => {
-    const config = await loadConfigFromDir(tmp)
+    const config = await loadConfigFromDir(tmpDir.ref())
     expect(config.cassetteDir).toBe('__cassettes__')
   })
 
   test('loads .js config file', async () => {
     await writeFile(
-      path.join(tmp, 'shell-cassette.config.js'),
+      path.join(tmpDir.ref(), 'shell-cassette.config.js'),
       `export default { cassetteDir: 'custom-cassettes' }`,
     )
-    const config = await loadConfigFromDir(tmp)
+    const config = await loadConfigFromDir(tmpDir.ref())
     expect(config.cassetteDir).toBe('custom-cassettes')
   })
 
   test('loads .mjs config file', async () => {
     await writeFile(
-      path.join(tmp, 'shell-cassette.config.mjs'),
+      path.join(tmpDir.ref(), 'shell-cassette.config.mjs'),
       `export default { redact: { envKeys: ['STRIPE_KEY'] } }`,
     )
-    const config = await loadConfigFromDir(tmp)
+    const config = await loadConfigFromDir(tmpDir.ref())
     expect(config.redact.envKeys).toEqual(['STRIPE_KEY'])
   })
 
   test('throws CassetteConfigError on syntax error in config', async () => {
     await writeFile(
-      path.join(tmp, 'shell-cassette.config.js'),
+      path.join(tmpDir.ref(), 'shell-cassette.config.js'),
       'export default { syntax error here',
     )
-    await expect(loadConfigFromDir(tmp)).rejects.toThrow(CassetteConfigError)
+    await expect(loadConfigFromDir(tmpDir.ref())).rejects.toThrow(CassetteConfigError)
   })
 
   test('throws CassetteConfigError on invalid config shape', async () => {
     await writeFile(
-      path.join(tmp, 'shell-cassette.config.js'),
+      path.join(tmpDir.ref(), 'shell-cassette.config.js'),
       'export default { cassetteDir: 42 }',
     )
-    await expect(loadConfigFromDir(tmp)).rejects.toThrow(CassetteConfigError)
+    await expect(loadConfigFromDir(tmpDir.ref())).rejects.toThrow(CassetteConfigError)
   })
 
   test('walks up parent directories looking for config', async () => {
-    const subdir = path.join(tmp, 'a', 'b')
+    const subdir = path.join(tmpDir.ref(), 'a', 'b')
     await mkdir(subdir, { recursive: true })
     await writeFile(
-      path.join(tmp, 'shell-cassette.config.js'),
+      path.join(tmpDir.ref(), 'shell-cassette.config.js'),
       `export default { cassetteDir: 'parent-cassettes' }`,
     )
     const config = await loadConfigFromDir(subdir)

--- a/tests/e2e/tinyexec-record-replay.test.ts
+++ b/tests/e2e/tinyexec-record-replay.test.ts
@@ -1,30 +1,27 @@
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { _resetForTesting } from '../../src/state.js'
 import { x } from '../../src/tinyexec.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
-let tmp: string
+const tmpDir = useTmpDir('shell-cassette-e2e-')
 
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-e2e-'))
+beforeEach(() => {
   _resetForTesting()
   process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
   delete process.env.SHELL_CASSETTE_MODE
   delete process.env.CI
 })
 
-afterEach(async () => {
+afterEach(() => {
   _resetForTesting()
-  await rm(tmp, { recursive: true, force: true })
   delete process.env.SHELL_CASSETTE_ACK_REDACTION
 })
 
 describe('tinyexec e2e', () => {
   test('record then replay round-trip on node --version', async () => {
-    const cassettePath = path.join(tmp, 'node-version.json')
+    const cassettePath = path.join(tmpDir.ref(), 'node-version.json')
 
     let recordedStdout = ''
     await useCassette(cassettePath, async () => {
@@ -43,7 +40,7 @@ describe('tinyexec e2e', () => {
   })
 
   test('record then replay handles non-zero exit (no throw by default)', async () => {
-    const cassettePath = path.join(tmp, 'node-fail.json')
+    const cassettePath = path.join(tmpDir.ref(), 'node-fail.json')
 
     await useCassette(cassettePath, async () => {
       const r = await x('node', ['-e', 'process.exit(1)'])
@@ -59,7 +56,7 @@ describe('tinyexec e2e', () => {
   })
 
   test('throwOnError throws on replay when exit code is non-zero', async () => {
-    const cassettePath = path.join(tmp, 'node-fail-throw.json')
+    const cassettePath = path.join(tmpDir.ref(), 'node-fail-throw.json')
 
     await useCassette(cassettePath, async () => {
       // Record run with throwOnError - real tinyexec throws
@@ -78,7 +75,7 @@ describe('tinyexec e2e', () => {
   })
 
   test('record stdout with newlines, replay preserves them', async () => {
-    const cassettePath = path.join(tmp, 'node-multiline.json')
+    const cassettePath = path.join(tmpDir.ref(), 'node-multiline.json')
 
     let recordedStdout = ''
     await useCassette(cassettePath, async () => {

--- a/tests/error-path/canonicalize-limits.test.ts
+++ b/tests/error-path/canonicalize-limits.test.ts
@@ -1,5 +1,3 @@
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { ReplayMissError } from '../../src/errors.js'
@@ -9,6 +7,8 @@ import { serialize } from '../../src/serialize.js'
 import type { CassetteFile } from '../../src/types.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
+import { makeRecording } from '../helpers/recording.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 // Build a cassette with a single recording whose call.command is `node` and
 // one positional arg. The args field drives the matcher comparison.
@@ -17,44 +17,27 @@ function makeCassette(args: string[]): CassetteFile {
     version: 1,
     recordedBy: null,
     recordings: [
-      {
-        call: {
-          command: 'node',
-          args,
-          cwd: null,
-          env: {},
-          stdin: null,
-        },
-        result: {
-          stdoutLines: ['recorded', ''],
-          stderrLines: [''],
-          allLines: null,
-          exitCode: 0,
-          signal: null,
-          durationMs: 1,
-          aborted: false,
-        },
-        redactions: [],
-      },
+      makeRecording({
+        call: { command: 'node', args, cwd: null, env: {}, stdin: null },
+        result: { stdoutLines: ['recorded', ''], stderrLines: [''], durationMs: 1 },
+      }),
     ],
   }
 }
 
 describe('canonicalize limitations - documented current behavior', () => {
-  let workspace: string
+  const workspaceDir = useTmpDir('shell-cassette-limits-')
   const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
   const originalMode = process.env.SHELL_CASSETTE_MODE
   const originalCI = process.env.CI
 
-  beforeEach(async () => {
-    workspace = await mkdtemp(path.join(tmpdir(), 'shell-cassette-limits-'))
+  beforeEach(() => {
     process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
     process.env.SHELL_CASSETTE_MODE = 'replay' // strict replay so misses throw
     delete process.env.CI
   })
 
-  afterEach(async () => {
-    await rm(workspace, { recursive: true, force: true })
+  afterEach(() => {
     restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
     restoreEnv('SHELL_CASSETTE_MODE', originalMode)
     restoreEnv('CI', originalCI)
@@ -64,7 +47,7 @@ describe('canonicalize limitations - documented current behavior', () => {
     // Recording was canonicalized as if it had been '<tmp>/foo' (a normalized
     // absolute path). Replay attempts a RELATIVE path that doesn't match any
     // tmp prefix regex, so canonicalize leaves it unchanged. Match fails.
-    const cassettePath = path.join(workspace, 'rel.json')
+    const cassettePath = path.join(workspaceDir.ref(), 'rel.json')
     await writeCassetteFile(cassettePath, serialize(makeCassette(['-e', '<tmp>/foo'])))
 
     const result = useCassette(cassettePath, async () => {
@@ -81,7 +64,7 @@ describe('canonicalize limitations - documented current behavior', () => {
     // C:\\Users\\<u>\\AppData\\Local\\Temp. /scratch is NOT covered, so the
     // recorded path is canonicalized as the literal string. A different
     // /scratch/... path on replay does not match.
-    const cassettePath = path.join(workspace, 'scratch.json')
+    const cassettePath = path.join(workspaceDir.ref(), 'scratch.json')
     await writeCassetteFile(cassettePath, serialize(makeCassette(['-e', '/scratch/RECORDED/foo'])))
 
     const result = useCassette(cassettePath, async () => {

--- a/tests/helpers/credential-fixtures.ts
+++ b/tests/helpers/credential-fixtures.ts
@@ -1,0 +1,91 @@
+/**
+ * Vetted sample credentials for each bundled redaction rule.
+ * Source of truth: tests/unit/redact-patterns.test.ts per-rule regression fixtures.
+ *
+ * Use these constants in integration, unit, cli, and property tests instead of
+ * scattering bare credential strings throughout the test suite. When a bundled
+ * rule's pattern changes, only this file (and redact-patterns.test.ts) need
+ * updating.
+ */
+
+/** Sample matching github-pat-classic. Vetted in M2. */
+export const SAMPLE_GITHUB_PAT_CLASSIC = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+
+/** Alternate sample matching github-pat-classic (used where two distinct PATs are needed). */
+export const SAMPLE_GITHUB_PAT_CLASSIC_2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+
+/** Sample matching github-pat-fine-grained. */
+export const SAMPLE_GITHUB_PAT_FINE_GRAINED = `github_pat_${'A'.repeat(82)}`
+
+/** Sample matching github-oauth. */
+export const SAMPLE_GITHUB_OAUTH = `gho_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`
+
+/** Sample matching github-user-to-server. */
+export const SAMPLE_GITHUB_USER_TO_SERVER = `ghu_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`
+
+/** Sample matching github-server-to-server. */
+export const SAMPLE_GITHUB_SERVER_TO_SERVER = `ghs_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`
+
+/** Sample matching github-refresh. */
+export const SAMPLE_GITHUB_REFRESH = `ghr_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`
+
+/** Sample matching aws-access-key-id. */
+export const SAMPLE_AWS_ACCESS_KEY_ID = 'AKIA0123456789ABCDEF'
+
+/** Sample matching stripe-secret-live. */
+export const SAMPLE_STRIPE_SECRET_LIVE = `sk_live_${'a'.repeat(24)}`
+
+/** Sample matching stripe-secret-test. */
+export const SAMPLE_STRIPE_SECRET_TEST = `sk_test_${'a'.repeat(24)}`
+
+/** Sample matching stripe-restricted-live. */
+export const SAMPLE_STRIPE_RESTRICTED_LIVE = `rk_live_${'a'.repeat(24)}`
+
+/** Sample matching stripe-restricted-test. */
+export const SAMPLE_STRIPE_RESTRICTED_TEST = `rk_test_${'a'.repeat(24)}`
+
+/** Sample matching anthropic-api-key. */
+export const SAMPLE_ANTHROPIC_API_KEY = `sk-ant-api03-${'a'.repeat(80)}`
+
+/** Sample matching openai-api-key (bare sk- prefix). */
+export const SAMPLE_OPENAI_API_KEY = `sk-${'a'.repeat(48)}`
+
+/** Sample matching openai-api-key with sk-proj- prefix. */
+export const SAMPLE_OPENAI_API_KEY_PROJ = `sk-proj-${'a'.repeat(48)}`
+
+/** Sample matching google-api-key. */
+export const SAMPLE_GOOGLE_API_KEY = `AIza${'a'.repeat(35)}`
+
+/** Sample matching slack-token (xoxb- prefix). */
+export const SAMPLE_SLACK_TOKEN = 'xoxb-1234567890'
+
+/** Sample matching slack-webhook-url. */
+export const SAMPLE_SLACK_WEBHOOK_URL =
+  'https://hooks.slack.com/services/T0AB12CDE/B0FG34HIJ/0123456789ABCDEF'
+
+/** Sample matching gitlab-pat. */
+export const SAMPLE_GITLAB_PAT = `glpat-${'a'.repeat(20)}`
+
+/** Sample matching npm-token. */
+export const SAMPLE_NPM_TOKEN = `npm_${'a'.repeat(36)}`
+
+/** Sample matching digitalocean-pat. */
+export const SAMPLE_DIGITALOCEAN_PAT = `dop_v1_${'0'.repeat(64)}`
+
+/** Sample matching sendgrid-api-key. */
+export const SAMPLE_SENDGRID_API_KEY = `SG.${'a'.repeat(22)}.${'a'.repeat(43)}`
+
+/** Sample matching mailgun-api-key. */
+export const SAMPLE_MAILGUN_API_KEY = `key-${'0'.repeat(32)}`
+
+/** Sample matching huggingface-token. */
+export const SAMPLE_HUGGINGFACE_TOKEN = `hf_${'a'.repeat(34)}`
+
+/** Sample matching pypi-token. */
+export const SAMPLE_PYPI_TOKEN = `pypi-AgE${'a'.repeat(50)}`
+
+/** Sample matching discord-bot-token. */
+export const SAMPLE_DISCORD_BOT_TOKEN = `M${'a'.repeat(23)}.${'a'.repeat(6)}.${'a'.repeat(27)}`
+
+/** Sample matching square-production-token. */
+export const SAMPLE_SQUARE_PRODUCTION_TOKEN = `EAAA${'a'.repeat(60)}`

--- a/tests/helpers/recording.ts
+++ b/tests/helpers/recording.ts
@@ -1,0 +1,42 @@
+import type { Recording, Result } from '../../src/types.js'
+
+/**
+ * Build a minimal Result with sensible defaults. Callers override only the
+ * fields they care about. Defaults: exitCode 0, no signal, not aborted,
+ * zero duration, empty line arrays, no allLines.
+ */
+export function makeResult(overrides: Partial<Result> = {}): Result {
+  return {
+    stdoutLines: [],
+    stderrLines: [],
+    allLines: null,
+    exitCode: 0,
+    signal: null,
+    durationMs: 0,
+    aborted: false,
+    ...overrides,
+  }
+}
+
+/**
+ * Build a minimal Recording with sensible defaults. Pass `result` as a
+ * Partial<Result> and it will be merged into makeResult() defaults.
+ * Callers override only the fields they care about.
+ */
+export function makeRecording(
+  overrides: Omit<Partial<Recording>, 'result'> & { result?: Partial<Result> } = {},
+): Recording {
+  const { result: resultOverrides, ...rest } = overrides
+  return {
+    call: {
+      command: 'cmd',
+      args: [],
+      cwd: null,
+      env: {},
+      stdin: null,
+    },
+    result: makeResult(resultOverrides),
+    redactions: [],
+    ...rest,
+  }
+}

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -1,20 +1,54 @@
 import { DEFAULT_CONFIG } from '../../src/config.js'
 import { MatcherState } from '../../src/matcher.js'
-import type { CassetteSession } from '../../src/types.js'
+import type { CassetteSession, LoadedSession, PendingSession } from '../../src/types.js'
 
-// Mirror wrapper.ts lazy-load invariant: the wrapper only initializes
-// session.matcher on the lazy-load path (when loadedFile is null on first
-// call). Tests that pre-populate loadedFile must also pre-populate matcher,
-// or ensureMatcher() throws "internal bug" on the first call. Tracked under
-// issue #26 (CassetteSession type permits unreachable states).
+/**
+ * Build a CassetteSession for tests.
+ *
+ * Passing `loadedFile: null` (default in overrides) without a `matcher`
+ * returns a PendingSession. Passing a non-null `loadedFile` (and no
+ * explicit `matcher`) auto-constructs a MatcherState so the session is a
+ * valid LoadedSession. You may also pass an explicit `matcher` to override.
+ *
+ * The union type is CassetteSession so callers can assign to either branch
+ * without an explicit cast.
+ */
 export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
   const canonicalize = overrides.canonicalize ?? DEFAULT_CONFIG.canonicalize
-  const base: CassetteSession = {
+
+  if (overrides.loadedFile !== undefined && overrides.loadedFile !== null) {
+    // Build a LoadedSession: loadedFile is present, initialize matcher if needed.
+    const loadedFile = overrides.loadedFile
+    const matcher =
+      overrides.matcher ??
+      new MatcherState(
+        loadedFile.recordings,
+        canonicalize,
+        overrides.redactConfig ?? DEFAULT_CONFIG.redact,
+      )
+    const loaded: LoadedSession = {
+      name: 'test',
+      path: '/tmp/test.json',
+      scopeDefault: 'auto',
+      canonicalize,
+      redactConfig: DEFAULT_CONFIG.redact,
+      redactEnabled: true,
+      redactCounters: new Map(),
+      redactionEntries: [],
+      newRecordings: [],
+      warnings: [],
+      ...overrides,
+      loadedFile,
+      matcher,
+    }
+    return loaded
+  }
+
+  // Build a PendingSession: matcher: null, loadedFile: null.
+  const pending: PendingSession = {
     name: 'test',
     path: '/tmp/test.json',
     scopeDefault: 'auto',
-    loadedFile: { version: 2, recordedBy: null, recordings: [] },
-    matcher: null,
     canonicalize,
     redactConfig: DEFAULT_CONFIG.redact,
     redactEnabled: true,
@@ -23,13 +57,8 @@ export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteS
     newRecordings: [],
     warnings: [],
     ...overrides,
+    loadedFile: null,
+    matcher: null,
   }
-  if (base.loadedFile !== null && base.matcher === null) {
-    base.matcher = new MatcherState(
-      base.loadedFile.recordings,
-      base.canonicalize,
-      base.redactConfig,
-    )
-  }
-  return base
+  return pending
 }

--- a/tests/helpers/session.ts
+++ b/tests/helpers/session.ts
@@ -5,13 +5,20 @@ import type { CassetteSession, LoadedSession, PendingSession } from '../../src/t
 /**
  * Build a CassetteSession for tests.
  *
- * Passing `loadedFile: null` (default in overrides) without a `matcher`
- * returns a PendingSession. Passing a non-null `loadedFile` (and no
- * explicit `matcher`) auto-constructs a MatcherState so the session is a
- * valid LoadedSession. You may also pass an explicit `matcher` to override.
+ * Branches on `loadedFile`:
+ * - `loadedFile: null` (or unset) returns a PendingSession with
+ *   `matcher: null` and `loadedFile: null`. Any `matcher` override passed
+ *   in this branch is ignored, since PendingSession.matcher is the `null`
+ *   literal type.
+ * - non-null `loadedFile` returns a LoadedSession; an explicit `matcher`
+ *   override is honored, otherwise one is auto-constructed from the
+ *   cassette's recordings.
  *
- * The union type is CassetteSession so callers can assign to either branch
- * without an explicit cast.
+ * The "loaded with `loadedFile: null`" runtime state (lazy-load completed
+ * for a cassette that does not exist on disk yet) is reachable in
+ * production but is not constructible via this helper today. If a test
+ * needs that exact shape, route through the wrapper's lazy-load path or
+ * extend this helper.
  */
 export const makeSession = (overrides: Partial<CassetteSession> = {}): CassetteSession => {
   const canonicalize = overrides.canonicalize ?? DEFAULT_CONFIG.canonicalize

--- a/tests/helpers/tmp-dir.ts
+++ b/tests/helpers/tmp-dir.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach } from 'vitest'
+
+/**
+ * Registers beforeEach/afterEach hooks that create a fresh temp directory
+ * before each test and remove it after. Returns a ref object whose `.ref()`
+ * getter returns the current temp dir path.
+ *
+ * Usage:
+ *   const tmp = useTmpDir()
+ *   test('...', async () => {
+ *     const dir = tmp.ref()
+ *     // use dir
+ *   })
+ */
+export function useTmpDir(prefix = 'shell-cassette-test-'): { ref: () => string } {
+  let current = ''
+
+  beforeEach(async () => {
+    current = await mkdtemp(path.join(tmpdir(), prefix))
+  })
+
+  afterEach(async () => {
+    await rm(current, { recursive: true, force: true })
+    current = ''
+  })
+
+  return {
+    ref(): string {
+      return current
+    },
+  }
+}

--- a/tests/integration/atomic-write.test.ts
+++ b/tests/integration/atomic-write.test.ts
@@ -1,36 +1,28 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { readCassetteFile, writeCassetteFile } from '../../src/io.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('writeCassetteFile (atomic)', () => {
-  let tmp: string
-
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
-  })
-
-  afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true })
-  })
+  const tmpDir = useTmpDir()
 
   test('writes content to path', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await writeCassetteFile(target, '{"hello":"world"}')
     const content = await readFile(target, 'utf8')
     expect(content).toBe('{"hello":"world"}')
   })
 
   test('creates parent directories on demand', async () => {
-    const target = path.join(tmp, 'a', 'b', 'c', 'foo.json')
+    const target = path.join(tmpDir.ref(), 'a', 'b', 'c', 'foo.json')
     await writeCassetteFile(target, '{}')
     const content = await readFile(target, 'utf8')
     expect(content).toBe('{}')
   })
 
   test('overwrites existing file atomically', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await writeCassetteFile(target, 'first')
     await writeCassetteFile(target, 'second')
     const content = await readFile(target, 'utf8')
@@ -38,7 +30,7 @@ describe('writeCassetteFile (atomic)', () => {
   })
 
   test('cleans up temp file on success', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await writeCassetteFile(target, '{}')
     const dirEntries = await readDirectory(path.dirname(target))
     expect(dirEntries.filter((e) => e.includes('.tmp.'))).toHaveLength(0)
@@ -46,25 +38,17 @@ describe('writeCassetteFile (atomic)', () => {
 })
 
 describe('readCassetteFile', () => {
-  let tmp: string
-
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
-  })
-
-  afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true })
-  })
+  const tmpDir = useTmpDir()
 
   test('returns string content for existing file', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await writeCassetteFile(target, 'hello')
     const result = await readCassetteFile(target)
     expect(result).toBe('hello')
   })
 
   test('returns null for missing file', async () => {
-    const target = path.join(tmp, 'missing.json')
+    const target = path.join(tmpDir.ref(), 'missing.json')
     const result = await readCassetteFile(target)
     expect(result).toBeNull()
   })

--- a/tests/integration/canonicalize-redact.test.ts
+++ b/tests/integration/canonicalize-redact.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import { DEFAULT_CONFIG } from '../../src/config.js'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
+import {
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_CLASSIC_2,
+} from '../helpers/credential-fixtures.js'
 import { callOf, recordingOf } from '../helpers/fixtures.js'
 
 describe('canonicalize-time redact for args', () => {
@@ -8,17 +12,15 @@ describe('canonicalize-time redact for args', () => {
     const cassetteCall = callOf('curl', [
       'Authorization: Bearer <redacted:args:github-pat-classic:1>',
     ])
-    const freshCall = callOf('curl', [
-      'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-    ])
+    const freshCall = callOf('curl', [`Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`])
     const cassetteCanon = defaultCanonicalize(cassetteCall, DEFAULT_CONFIG.redact)
     const freshCanon = defaultCanonicalize(freshCall, DEFAULT_CONFIG.redact)
     expect(cassetteCanon).toEqual(freshCanon)
   })
 
   test('two different real credentials canonicalize to same form (both redacted to placeholder)', () => {
-    const a = callOf('curl', ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'])
-    const b = callOf('curl', ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'])
+    const a = callOf('curl', [`Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`])
+    const b = callOf('curl', [`Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC_2}`])
     const ac = defaultCanonicalize(a, DEFAULT_CONFIG.redact)
     const bc = defaultCanonicalize(b, DEFAULT_CONFIG.redact)
     expect(ac).toEqual(bc)
@@ -49,10 +51,7 @@ describe('canonicalize-time redact for args', () => {
 
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
 
-    const freshCall = callOf('curl', [
-      '-H',
-      'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-    ])
+    const freshCall = callOf('curl', ['-H', `Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`])
     expect(matcher.findMatch(freshCall)).toBe(recording)
   })
 
@@ -78,8 +77,8 @@ describe('canonicalize-time redact for args', () => {
     recording.redactions = [{ rule: 'github-pat-classic', source: 'args', count: 1 }]
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
 
-    const call1 = callOf('curl', ['Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'])
-    const call2 = callOf('curl', ['Authorization: Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'])
+    const call1 = callOf('curl', [`Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`])
+    const call2 = callOf('curl', [`Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC_2}`])
     expect(matcher.findMatch(call1)).toBe(recording)
     // Second call: same canonical form, but recording already consumed
     expect(matcher.findMatch(call2)).toBe(null)
@@ -88,7 +87,7 @@ describe('canonicalize-time redact for args', () => {
   test('canonicalize integrates with existing tmp-path normalization', () => {
     // Combination: tmp path AND credential in same arg
     const call = callOf('curl', [
-      '/tmp/test-abc/file.txt --header Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+      `/tmp/test-abc/file.txt --header Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`,
     ])
     const canon = defaultCanonicalize(call, DEFAULT_CONFIG.redact)
     // Both transforms applied: <tmp> for the path, placeholder for the credential
@@ -113,16 +112,13 @@ describe('canonicalize-time redact for args', () => {
     const matcher = new MatcherState([recording], defaultCanonicalize, DEFAULT_CONFIG.redact)
 
     // Different command so it won't match (credential is still present in args).
-    const freshCall = callOf('wget', [
-      '-H',
-      'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-    ])
+    const freshCall = callOf('wget', ['-H', `Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`])
     expect(matcher.findMatch(freshCall)).toBe(null)
 
     // Verify the canonical form that buildReplayMissError would stringify is credential-free.
     const canonical = defaultCanonicalize(freshCall, DEFAULT_CONFIG.redact)
     const stringified = JSON.stringify(canonical)
-    expect(stringified).not.toContain('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(stringified).not.toContain(SAMPLE_GITHUB_PAT_CLASSIC)
     expect(stringified).toContain('<redacted:args:github-pat-classic>')
   })
 })

--- a/tests/integration/loader.test.ts
+++ b/tests/integration/loader.test.ts
@@ -1,28 +1,20 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { CassetteCorruptError } from '../../src/errors.js'
 import { loadCassette } from '../../src/loader.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('loadCassette', () => {
-  let tmp: string
-
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
-  })
-
-  afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true })
-  })
+  const tmpDir = useTmpDir()
 
   test('returns null when file does not exist', async () => {
-    const result = await loadCassette(path.join(tmp, 'missing.json'))
+    const result = await loadCassette(path.join(tmpDir.ref(), 'missing.json'))
     expect(result).toBeNull()
   })
 
   test('parses valid cassette file', async () => {
-    const target = path.join(tmp, 'foo.json')
+    const target = path.join(tmpDir.ref(), 'foo.json')
     await writeFile(target, JSON.stringify({ version: 1, recordings: [] }), 'utf8')
     const result = await loadCassette(target)
     expect(result).not.toBeNull()
@@ -31,13 +23,13 @@ describe('loadCassette', () => {
   })
 
   test('throws CassetteCorruptError on bad JSON', async () => {
-    const target = path.join(tmp, 'bad.json')
+    const target = path.join(tmpDir.ref(), 'bad.json')
     await writeFile(target, '{ not json', 'utf8')
     await expect(loadCassette(target)).rejects.toThrow(CassetteCorruptError)
   })
 
   test('throws CassetteCorruptError on unknown version', async () => {
-    const target = path.join(tmp, 'unknown.json')
+    const target = path.join(tmpDir.ref(), 'unknown.json')
     await writeFile(target, JSON.stringify({ version: 99 }), 'utf8')
     await expect(loadCassette(target)).rejects.toThrow(CassetteCorruptError)
   })

--- a/tests/integration/per-cassette-override.test.ts
+++ b/tests/integration/per-cassette-override.test.ts
@@ -1,34 +1,33 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
 import { restoreEnv } from '../helpers/env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
-let tmp: string
+const tmpDir = useTmpDir('shell-cassette-per-cassette-override-')
 
 const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
 const originalMode = process.env.SHELL_CASSETTE_MODE
 
-const FAKE_PAT = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+const FAKE_PAT = SAMPLE_GITHUB_PAT_CLASSIC
 
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-per-cassette-override-'))
+beforeEach(() => {
   process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
   // Pin the mode so CI=true on the runner doesn't force replay-strict.
   process.env.SHELL_CASSETTE_MODE = 'auto'
 })
 
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
+afterEach(() => {
   restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
   restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
 
 describe('useCassette per-cassette redact override', () => {
   test('redact: true (default) redacts a credential in stdout', async () => {
-    const cassettePath = path.join(tmp, 'redact-on.json')
+    const cassettePath = path.join(tmpDir.ref(), 'redact-on.json')
     await useCassette(cassettePath, async () => {
       await execa('node', ['-e', `console.log('${FAKE_PAT}')`])
     })
@@ -38,7 +37,7 @@ describe('useCassette per-cassette redact override', () => {
   })
 
   test('redact: false bypasses pipeline; raw credential persists in cassette', async () => {
-    const cassettePath = path.join(tmp, 'redact-off.json')
+    const cassettePath = path.join(tmpDir.ref(), 'redact-off.json')
     await useCassette(cassettePath, { redact: false }, async () => {
       await execa('node', ['-e', `console.log('${FAKE_PAT}')`])
     })
@@ -48,7 +47,7 @@ describe('useCassette per-cassette redact override', () => {
   })
 
   test('redact: false with credential in env bypasses env-key-match path', async () => {
-    const cassettePath = path.join(tmp, 'redact-off-env.json')
+    const cassettePath = path.join(tmpDir.ref(), 'redact-off-env.json')
     await useCassette(cassettePath, { redact: false }, async () => {
       await execa('node', ['-e', `console.log(process.env.MY_TOKEN ?? 'no-token')`], {
         env: { MY_TOKEN: FAKE_PAT },
@@ -61,7 +60,7 @@ describe('useCassette per-cassette redact override', () => {
   })
 
   test('redact: true with credential in env: curated key-match path redacts', async () => {
-    const cassettePath = path.join(tmp, 'redact-on-env.json')
+    const cassettePath = path.join(tmpDir.ref(), 'redact-on-env.json')
     await useCassette(cassettePath, async () => {
       await execa('node', ['-e', `console.log(process.env.MY_TOKEN ?? 'no-token')`], {
         env: { MY_TOKEN: FAKE_PAT },

--- a/tests/integration/recorder-redact.test.ts
+++ b/tests/integration/recorder-redact.test.ts
@@ -2,17 +2,15 @@ import { describe, expect, test } from 'vitest'
 import { record } from '../../src/recorder.js'
 import { seedCountersFromCassette } from '../../src/redact-pipeline.js'
 import type { Call, Result } from '../../src/types.js'
+import {
+  SAMPLE_AWS_ACCESS_KEY_ID,
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_CLASSIC_2,
+} from '../helpers/credential-fixtures.js'
+import { makeResult } from '../helpers/recording.js'
 import { makeSession } from '../helpers/session.js'
 
-const benignResult: Result = {
-  stdoutLines: [],
-  stderrLines: [],
-  allLines: null,
-  exitCode: 0,
-  signal: null,
-  durationMs: 100,
-  aborted: false,
-}
+const benignResult: Result = makeResult({ durationMs: 100 })
 
 describe('recorder applies redaction across all 5 sources', () => {
   test('env value with curated env-key match is redacted via env-key rule', () => {
@@ -21,7 +19,7 @@ describe('recorder applies redaction across all 5 sources', () => {
       command: 'curl',
       args: [],
       cwd: null,
-      env: { GH_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      env: { GH_TOKEN: SAMPLE_GITHUB_PAT_CLASSIC },
       stdin: null,
     }
     record(call, benignResult, session)
@@ -35,7 +33,7 @@ describe('recorder applies redaction across all 5 sources', () => {
       command: 'curl',
       args: [],
       cwd: null,
-      env: { CONFIG_BLOB: 'prefix ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 suffix' },
+      env: { CONFIG_BLOB: `prefix ${SAMPLE_GITHUB_PAT_CLASSIC} suffix` },
       stdin: null,
     }
     record(call, benignResult, session)
@@ -47,7 +45,7 @@ describe('recorder applies redaction across all 5 sources', () => {
     const session = makeSession()
     const call: Call = {
       command: 'curl',
-      args: ['-H', 'Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      args: ['-H', `Authorization: Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`],
       cwd: null,
       env: {},
       stdin: null,
@@ -61,7 +59,7 @@ describe('recorder applies redaction across all 5 sources', () => {
     const session = makeSession()
     const result: Result = {
       ...benignResult,
-      stdoutLines: ['line 1', 'token: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890', 'line 3'],
+      stdoutLines: ['line 1', `token: ${SAMPLE_GITHUB_PAT_CLASSIC}`, 'line 3'],
     }
     record({ command: 'gh', args: [], cwd: null, env: {}, stdin: null }, result, session)
     const stored = session.newRecordings[0]
@@ -72,8 +70,8 @@ describe('recorder applies redaction across all 5 sources', () => {
     const session = makeSession()
     const result: Result = {
       ...benignResult,
-      stderrLines: ['warn: AKIA0123456789ABCDEF'],
-      allLines: ['stdout-then-stderr: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      stderrLines: [`warn: ${SAMPLE_AWS_ACCESS_KEY_ID}`],
+      allLines: [`stdout-then-stderr: ${SAMPLE_GITHUB_PAT_CLASSIC}`],
     }
     record({ command: 'gh', args: [], cwd: null, env: {}, stdin: null }, result, session)
     const stored = session.newRecordings[0]
@@ -87,10 +85,7 @@ describe('recorder applies redaction across all 5 sources', () => {
     const session = makeSession()
     const call: Call = {
       command: 'curl',
-      args: [
-        'Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-        'Bearer ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321',
-      ],
+      args: [`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`, `Bearer ${SAMPLE_GITHUB_PAT_CLASSIC_2}`],
       cwd: null,
       env: {},
       stdin: null,
@@ -104,14 +99,14 @@ describe('recorder applies redaction across all 5 sources', () => {
     const session = makeSession()
     const call1: Call = {
       command: 'curl',
-      args: ['ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      args: [SAMPLE_GITHUB_PAT_CLASSIC],
       cwd: null,
       env: {},
       stdin: null,
     }
     const call2: Call = {
       command: 'curl',
-      args: ['ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'],
+      args: [SAMPLE_GITHUB_PAT_CLASSIC_2],
       cwd: null,
       env: {},
       stdin: null,
@@ -160,7 +155,7 @@ describe('recorder applies redaction across all 5 sources', () => {
     // Record a new call with a fresh PAT; counter should continue at :4
     const call: Call = {
       command: 'curl',
-      args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      args: [`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`],
       cwd: null,
       env: {},
       stdin: null,
@@ -176,15 +171,15 @@ describe('recorder applies redaction across all 5 sources', () => {
     session.redactEnabled = false
     const call: Call = {
       command: 'curl',
-      args: ['Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'],
+      args: [`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`],
       cwd: null,
-      env: { GH_TOKEN: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      env: { GH_TOKEN: SAMPLE_GITHUB_PAT_CLASSIC },
       stdin: null,
     }
     record(call, benignResult, session)
     const stored = session.newRecordings[0]
-    expect(stored?.call.args[0]).toBe('Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
-    expect(stored?.call.env.GH_TOKEN).toBe('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(stored?.call.args[0]).toBe(`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`)
+    expect(stored?.call.env.GH_TOKEN).toBe(SAMPLE_GITHUB_PAT_CLASSIC)
     expect(stored?.redactions).toEqual([])
   })
 })

--- a/tests/integration/use-cassette-options.test.ts
+++ b/tests/integration/use-cassette-options.test.ts
@@ -1,33 +1,31 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import type { Canonicalize } from '../../src/types.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('useCassette per-call options - canonicalize override', () => {
-  let tmp: string
+  const tmpDir = useTmpDir()
   const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
   const originalMode = process.env.SHELL_CASSETTE_MODE
   const originalCI = process.env.CI
 
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
+  beforeEach(() => {
     process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
     delete process.env.SHELL_CASSETTE_MODE
     delete process.env.CI
   })
-  afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true })
+  afterEach(() => {
     restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
     restoreEnv('SHELL_CASSETTE_MODE', originalMode)
     restoreEnv('CI', originalCI)
   })
 
   test('default canonicalize matches recordings with same command + args', async () => {
-    const cassettePath = path.join(tmp, 'default.json')
+    const cassettePath = path.join(tmpDir.ref(), 'default.json')
     // First pass: record
     await useCassette(cassettePath, async () => {
       await execa('node', ['-e', 'console.log("a")'])
@@ -40,7 +38,7 @@ describe('useCassette per-call options - canonicalize override', () => {
   })
 
   test('custom canonicalize: command-only matches across different args', async () => {
-    const cassettePath = path.join(tmp, 'custom.json')
+    const cassettePath = path.join(tmpDir.ref(), 'custom.json')
     const commandOnly: Canonicalize = (call) => ({ command: call.command })
     // Record one call
     await useCassette(cassettePath, { canonicalize: commandOnly }, async () => {
@@ -55,8 +53,8 @@ describe('useCassette per-call options - canonicalize override', () => {
   })
 
   test('cassette file content is identical between 2-arg and 3-arg useCassette forms', async () => {
-    const a = path.join(tmp, 'two-arg.json')
-    const b = path.join(tmp, 'three-arg.json')
+    const a = path.join(tmpDir.ref(), 'two-arg.json')
+    const b = path.join(tmpDir.ref(), 'three-arg.json')
     await useCassette(a, async () => {
       await execa('node', ['-e', 'console.log("x")'])
     })

--- a/tests/integration/wrapper-tinyexec.test.ts
+++ b/tests/integration/wrapper-tinyexec.test.ts
@@ -1,10 +1,11 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { serialize } from '../../src/serialize.js'
 import { _resetForTesting, clearActiveCassette } from '../../src/state.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { makeRecording } from '../helpers/recording.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 vi.mock('tinyexec', () => ({
   x: vi.fn(),
@@ -13,10 +14,9 @@ vi.mock('tinyexec', () => ({
 const { x: realXMock } = await import('tinyexec')
 const { x } = await import('../../src/tinyexec.js')
 
-let tmp: string
+const tmpDir = useTmpDir()
 
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
+beforeEach(() => {
   _resetForTesting()
   vi.mocked(realXMock).mockReset()
   process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
@@ -24,10 +24,9 @@ beforeEach(async () => {
   delete process.env.CI
 })
 
-afterEach(async () => {
+afterEach(() => {
   _resetForTesting()
   clearActiveCassette()
-  await rm(tmp, { recursive: true, force: true })
   delete process.env.SHELL_CASSETTE_ACK_REDACTION
 })
 
@@ -42,7 +41,7 @@ describe('tinyexec integration', () => {
       killed: false,
     } as never)
 
-    const cassettePath = path.join(tmp, 'test.json')
+    const cassettePath = path.join(tmpDir.ref(), 'test.json')
     await useCassette(cassettePath, async () => {
       await x('echo', ['recorded-output'])
     })
@@ -56,25 +55,16 @@ describe('tinyexec integration', () => {
   })
 
   test('replay reads cassette file and synthesizes result', async () => {
-    const cassettePath = path.join(tmp, 'test.json')
+    const cassettePath = path.join(tmpDir.ref(), 'test.json')
 
     const cassetteJson = serialize({
       version: 1,
       recordedBy: null,
       recordings: [
-        {
+        makeRecording({
           call: { command: 'echo', args: ['canned'], cwd: null, env: {}, stdin: null },
-          result: {
-            stdoutLines: ['canned'],
-            stderrLines: [''],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
-            durationMs: 0,
-            aborted: false,
-          },
-          redactions: [],
-        },
+          result: { stdoutLines: ['canned'], stderrLines: [''] },
+        }),
       ],
     })
     await writeFile(cassettePath, cassetteJson, 'utf8')
@@ -97,7 +87,7 @@ describe('tinyexec integration', () => {
   })
 
   test('lazy load: cassette file not read when no x() call happens', async () => {
-    const cassettePath = path.join(tmp, 'never-loaded.json')
+    const cassettePath = path.join(tmpDir.ref(), 'never-loaded.json')
 
     await useCassette(cassettePath, async () => {
       // no x() calls in scope
@@ -108,25 +98,16 @@ describe('tinyexec integration', () => {
   })
 
   test('lazy write: cassette only written when newRecordings has entries', async () => {
-    const cassettePath = path.join(tmp, 'replay-only.json')
+    const cassettePath = path.join(tmpDir.ref(), 'replay-only.json')
 
     const cassetteJson = serialize({
       version: 1,
       recordedBy: null,
       recordings: [
-        {
+        makeRecording({
           call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
-          result: {
-            stdoutLines: ['hi'],
-            stderrLines: [''],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
-            durationMs: 0,
-            aborted: false,
-          },
-          redactions: [],
-        },
+          result: { stdoutLines: ['hi'], stderrLines: [''] },
+        }),
       ],
     })
     await writeFile(cassettePath, cassetteJson, 'utf8')

--- a/tests/property/re-redact-idempotence.property.test.ts
+++ b/tests/property/re-redact-idempotence.property.test.ts
@@ -1,0 +1,89 @@
+import path from 'node:path'
+import * as fc from 'fast-check'
+import { describe, test } from 'vitest'
+import { reRedactOne } from '../../src/cli-re-redact.js'
+import { DEFAULT_CONFIG } from '../../src/config.js'
+import { writeCassetteFile } from '../../src/io.js'
+import { serialize } from '../../src/serialize.js'
+import type { CassetteFile, Recording } from '../../src/types.js'
+import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const valueArb = fc.oneof(
+  fc.string({ maxLength: 30 }).filter((s) => !s.includes('\n')),
+  fc.constant(SAMPLE_GITHUB_PAT_CLASSIC),
+  fc.constant(`Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`),
+)
+
+const callArb = fc.record({
+  command: fc
+    .string({ minLength: 1, maxLength: 10 })
+    .filter((s) => !s.includes('\n') && s.trim().length > 0),
+  args: fc.array(valueArb, { maxLength: 4 }),
+  cwd: fc.option(
+    fc.string({ minLength: 0, maxLength: 20 }).filter((s) => !s.includes('\n')),
+    { nil: null },
+  ),
+  env: fc.dictionary(
+    fc.string({ minLength: 1, maxLength: 10 }).filter((s) => /^[A-Z_]+$/.test(s)),
+    valueArb,
+    { maxKeys: 3 },
+  ),
+  stdin: fc.constant(null),
+})
+
+const resultArb = fc.record({
+  stdoutLines: fc.array(valueArb, { maxLength: 3 }),
+  stderrLines: fc.array(valueArb, { maxLength: 3 }),
+  allLines: fc.option(fc.array(valueArb, { maxLength: 3 }), { nil: null }),
+  exitCode: fc.integer({ min: 0, max: 255 }),
+  signal: fc.option(fc.constantFrom('SIGTERM', 'SIGINT'), { nil: null }),
+  durationMs: fc.integer({ min: 0, max: 10_000 }),
+  aborted: fc.boolean(),
+})
+
+const recordingArb: fc.Arbitrary<Recording> = fc.record({
+  call: callArb,
+  result: resultArb,
+  redactions: fc.constant([]),
+})
+
+const cassetteArb: fc.Arbitrary<CassetteFile> = fc.record({
+  version: fc.constant(2 as const),
+  recordedBy: fc.constant(null),
+  recordings: fc.array(recordingArb, { minLength: 1, maxLength: 3 }),
+})
+
+describe('re-redact: full-cassette idempotence', () => {
+  const tmp = useTmpDir('shell-cassette-rr-prop-')
+
+  test('reRedactOne(reRedactOne(C)) reports zero new redactions on the second pass', async () => {
+    await fc.assert(
+      fc.asyncProperty(cassetteArb, async (cassette) => {
+        const cassettePath = path.join(tmp.ref(), `c-${Math.random().toString(36).slice(2)}.json`)
+        await writeCassetteFile(cassettePath, serialize(cassette))
+
+        await reRedactOne(cassettePath, DEFAULT_CONFIG.redact, false)
+        const second = await reRedactOne(cassettePath, DEFAULT_CONFIG.redact, false)
+
+        return second.newRedactions === 0
+      }),
+      { numRuns: 20 },
+    )
+  })
+
+  test('dry-run twice reports identical newRedactions counts', async () => {
+    await fc.assert(
+      fc.asyncProperty(cassetteArb, async (cassette) => {
+        const cassettePath = path.join(tmp.ref(), `d-${Math.random().toString(36).slice(2)}.json`)
+        await writeCassetteFile(cassettePath, serialize(cassette))
+
+        const first = await reRedactOne(cassettePath, DEFAULT_CONFIG.redact, true)
+        const second = await reRedactOne(cassettePath, DEFAULT_CONFIG.redact, true)
+
+        return first.newRedactions === second.newRedactions
+      }),
+      { numRuns: 20 },
+    )
+  })
+})

--- a/tests/property/redact.property.test.ts
+++ b/tests/property/redact.property.test.ts
@@ -13,6 +13,10 @@ import type {
   RedactionEntry,
   RedactSource,
 } from '../../src/types.js'
+import {
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_CLASSIC_2,
+} from '../helpers/credential-fixtures.js'
 
 const baseConfig: RedactConfig = {
   bundledPatterns: true,
@@ -127,8 +131,8 @@ describe('redact: suppress short-circuit', () => {
 
 describe('BUNDLED_PATTERNS: counter mode emits unique-per-rule placeholders', () => {
   test('two distinct credential matches produce :1 and :2 in counted mode', () => {
-    const t1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
-    const t2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+    const t1 = SAMPLE_GITHUB_PAT_CLASSIC
+    const t2 = SAMPLE_GITHUB_PAT_CLASSIC_2
     const counters = new Map<string, number>()
     const r1 = redact({ source: 'args', value: t1 }, baseConfig, { counted: true, counters })
     const r2 = redact({ source: 'args', value: t2 }, baseConfig, { counted: true, counters })
@@ -156,11 +160,10 @@ describe('redact: counter monotonicity', () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 1000 }), (seed) => {
         const counters = new Map<string, number>([['args:github-pat-classic', seed]])
-        const r = redact(
-          { source: 'args', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
-          baseConfig,
-          { counted: true, counters },
-        )
+        const r = redact({ source: 'args', value: SAMPLE_GITHUB_PAT_CLASSIC }, baseConfig, {
+          counted: true,
+          counters,
+        })
         const match = r.output.match(/<redacted:args:github-pat-classic:(\d+)>/)
         if (!match) return false
         return Number.parseInt(match[1] ?? '0', 10) > seed

--- a/tests/property/redact.property.test.ts
+++ b/tests/property/redact.property.test.ts
@@ -298,3 +298,68 @@ describe('seedCountersFromCassette', () => {
     )
   })
 })
+
+const PATH_OR_WHITESPACE_REGEX = /[/\\: ]/
+
+describe('redact: length-warning threshold and path heuristic', () => {
+  test('warning fires iff (no rule fired) AND (output > threshold) AND NOT path-heuristic-suppressed', () => {
+    fc.assert(
+      fc.property(
+        sourceArb,
+        fc.string({ maxLength: 200 }),
+        fc.boolean(),
+        (source, value, pathHeuristic) => {
+          const config: RedactConfig = { ...baseConfig, warnPathHeuristic: pathHeuristic }
+          const r = redact({ source, value }, config, { counted: false })
+
+          const noRuleFired = r.output === value
+          if (!noRuleFired) {
+            // Mutual exclusion: rule fired, so warnings must be empty.
+            return r.warnings.length === 0
+          }
+
+          const exceedsThreshold = r.output.length > config.warnLengthThreshold
+          const suppressedByHeuristic = pathHeuristic && PATH_OR_WHITESPACE_REGEX.test(r.output)
+          const expectWarning = exceedsThreshold && !suppressedByHeuristic
+          return r.warnings.length > 0 === expectWarning
+        },
+      ),
+    )
+  })
+
+  test('warning never fires when a bundled rule matches (mutual exclusion, explicit)', () => {
+    fc.assert(
+      fc.property(sourceArb, (source) => {
+        const r = redact({ source, value: SAMPLE_GITHUB_PAT_CLASSIC }, baseConfig, {
+          counted: false,
+        })
+        return r.entries.length > 0 && r.warnings.length === 0
+      }),
+    )
+  })
+
+  test('value contains a path-or-whitespace char + heuristic enabled: no warning even when long', () => {
+    const safeAlphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_'.split(
+      '',
+    )
+    const safeChunkArb = fc
+      .array(fc.constantFrom(...safeAlphabet), { minLength: 50, maxLength: 100 })
+      .map((cs) => cs.join(''))
+    const pathCharArb = fc.constantFrom('/', '\\', ':', ' ')
+    fc.assert(
+      fc.property(sourceArb, safeChunkArb, pathCharArb, (source, chunk, pathChar) => {
+        const value = chunk + pathChar + chunk
+        const r = redact(
+          { source, value },
+          { ...baseConfig, warnPathHeuristic: true },
+          {
+            counted: false,
+          },
+        )
+        const noRuleFired = r.output === value
+        if (!noRuleFired) return true
+        return r.warnings.length === 0
+      }),
+    )
+  })
+})

--- a/tests/property/scan-record-symmetry.property.test.ts
+++ b/tests/property/scan-record-symmetry.property.test.ts
@@ -6,17 +6,43 @@
  * forward direction of that guarantee for every bundled rule and for the
  * env-key-match path.
  */
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
 import * as fc from 'fast-check'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { scanOne } from '../../src/cli-scan.js'
 import { writeCassetteFile } from '../../src/io.js'
 import { BUNDLED_PATTERNS } from '../../src/redact.js'
 import { ENV_KEY_MATCH_RULE } from '../../src/redact-pipeline.js'
 import { serialize } from '../../src/serialize.js'
 import type { CassetteFile, RedactConfig, RedactSource } from '../../src/types.js'
+import {
+  SAMPLE_ANTHROPIC_API_KEY,
+  SAMPLE_AWS_ACCESS_KEY_ID,
+  SAMPLE_DIGITALOCEAN_PAT,
+  SAMPLE_DISCORD_BOT_TOKEN,
+  SAMPLE_GITHUB_OAUTH,
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_FINE_GRAINED,
+  SAMPLE_GITHUB_REFRESH,
+  SAMPLE_GITHUB_SERVER_TO_SERVER,
+  SAMPLE_GITHUB_USER_TO_SERVER,
+  SAMPLE_GITLAB_PAT,
+  SAMPLE_GOOGLE_API_KEY,
+  SAMPLE_HUGGINGFACE_TOKEN,
+  SAMPLE_MAILGUN_API_KEY,
+  SAMPLE_NPM_TOKEN,
+  SAMPLE_OPENAI_API_KEY,
+  SAMPLE_PYPI_TOKEN,
+  SAMPLE_SENDGRID_API_KEY,
+  SAMPLE_SLACK_TOKEN,
+  SAMPLE_SLACK_WEBHOOK_URL,
+  SAMPLE_SQUARE_PRODUCTION_TOKEN,
+  SAMPLE_STRIPE_RESTRICTED_LIVE,
+  SAMPLE_STRIPE_RESTRICTED_TEST,
+  SAMPLE_STRIPE_SECRET_LIVE,
+  SAMPLE_STRIPE_SECRET_TEST,
+} from '../helpers/credential-fixtures.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const baseConfig: RedactConfig = {
   bundledPatterns: true,
@@ -27,13 +53,7 @@ const baseConfig: RedactConfig = {
   warnPathHeuristic: true,
 }
 
-let tmp: string
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'sc-symmetry-'))
-})
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
-})
+const tmpDir = useTmpDir('sc-symmetry-')
 
 /**
  * Build a minimal v2 cassette with one recording containing `value` at the
@@ -69,31 +89,31 @@ function buildCassette(source: RedactSource, value: string): CassetteFile {
  * it doesn't; we are not fuzzing the pattern itself here).
  */
 const RULE_SAMPLES: Record<string, string> = {
-  'github-pat-classic': 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-  'github-pat-fine-grained': `github_pat_${'A'.repeat(82)}`,
-  'github-oauth': `gho_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
-  'github-user-to-server': `ghu_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
-  'github-server-to-server': `ghs_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
-  'github-refresh': `ghr_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
-  'aws-access-key-id': 'AKIA0123456789ABCDEF',
-  'stripe-secret-live': `sk_live_${'a'.repeat(24)}`,
-  'stripe-secret-test': `sk_test_${'a'.repeat(24)}`,
-  'stripe-restricted-live': `rk_live_${'a'.repeat(24)}`,
-  'stripe-restricted-test': `rk_test_${'a'.repeat(24)}`,
-  'anthropic-api-key': `sk-ant-api03-${'a'.repeat(80)}`,
-  'openai-api-key': `sk-${'a'.repeat(48)}`,
-  'google-api-key': `AIza${'a'.repeat(35)}`,
-  'slack-token': `xoxb-1234567890`,
-  'slack-webhook-url': 'https://hooks.slack.com/services/T0AB12CDE/B0FG34HIJ/0123456789ABCDEF',
-  'gitlab-pat': `glpat-${'a'.repeat(20)}`,
-  'npm-token': `npm_${'a'.repeat(36)}`,
-  'digitalocean-pat': `dop_v1_${'0'.repeat(64)}`,
-  'sendgrid-api-key': `SG.${'a'.repeat(22)}.${'a'.repeat(43)}`,
-  'mailgun-api-key': `key-${'0'.repeat(32)}`,
-  'huggingface-token': `hf_${'a'.repeat(34)}`,
-  'pypi-token': `pypi-AgE${'a'.repeat(50)}`,
-  'discord-bot-token': `M${'a'.repeat(23)}.${'a'.repeat(6)}.${'a'.repeat(27)}`,
-  'square-production-token': `EAAA${'a'.repeat(60)}`,
+  'github-pat-classic': SAMPLE_GITHUB_PAT_CLASSIC,
+  'github-pat-fine-grained': SAMPLE_GITHUB_PAT_FINE_GRAINED,
+  'github-oauth': SAMPLE_GITHUB_OAUTH,
+  'github-user-to-server': SAMPLE_GITHUB_USER_TO_SERVER,
+  'github-server-to-server': SAMPLE_GITHUB_SERVER_TO_SERVER,
+  'github-refresh': SAMPLE_GITHUB_REFRESH,
+  'aws-access-key-id': SAMPLE_AWS_ACCESS_KEY_ID,
+  'stripe-secret-live': SAMPLE_STRIPE_SECRET_LIVE,
+  'stripe-secret-test': SAMPLE_STRIPE_SECRET_TEST,
+  'stripe-restricted-live': SAMPLE_STRIPE_RESTRICTED_LIVE,
+  'stripe-restricted-test': SAMPLE_STRIPE_RESTRICTED_TEST,
+  'anthropic-api-key': SAMPLE_ANTHROPIC_API_KEY,
+  'openai-api-key': SAMPLE_OPENAI_API_KEY,
+  'google-api-key': SAMPLE_GOOGLE_API_KEY,
+  'slack-token': SAMPLE_SLACK_TOKEN,
+  'slack-webhook-url': SAMPLE_SLACK_WEBHOOK_URL,
+  'gitlab-pat': SAMPLE_GITLAB_PAT,
+  'npm-token': SAMPLE_NPM_TOKEN,
+  'digitalocean-pat': SAMPLE_DIGITALOCEAN_PAT,
+  'sendgrid-api-key': SAMPLE_SENDGRID_API_KEY,
+  'mailgun-api-key': SAMPLE_MAILGUN_API_KEY,
+  'huggingface-token': SAMPLE_HUGGINGFACE_TOKEN,
+  'pypi-token': SAMPLE_PYPI_TOKEN,
+  'discord-bot-token': SAMPLE_DISCORD_BOT_TOKEN,
+  'square-production-token': SAMPLE_SQUARE_PRODUCTION_TOKEN,
 }
 
 describe('per-rule forward symmetry: redact fires implies scan finds', () => {
@@ -102,7 +122,7 @@ describe('per-rule forward symmetry: redact fires implies scan finds', () => {
       const sample = RULE_SAMPLES[rule.name]
       expect(sample, `missing sample for rule: ${rule.name}`).toBeDefined()
 
-      const cassettePath = path.join(tmp, `rule-${rule.name}.json`)
+      const cassettePath = path.join(tmpDir.ref(), `rule-${rule.name}.json`)
       const cassette = buildCassette('args', sample)
       await writeCassetteFile(cassettePath, serialize(cassette))
 
@@ -120,12 +140,12 @@ describe('per-rule forward symmetry: redact fires implies scan finds', () => {
 })
 
 describe('per-source coverage: github-pat-classic across all 5 sources', () => {
-  const PAT = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+  const PAT = SAMPLE_GITHUB_PAT_CLASSIC
   const SOURCES: RedactSource[] = ['args', 'stdout', 'stderr', 'allLines']
 
   for (const source of SOURCES) {
     test(`github-pat-classic at source=${source} is reported by scan`, async () => {
-      const cassettePath = path.join(tmp, `source-${source}.json`)
+      const cassettePath = path.join(tmpDir.ref(), `source-${source}.json`)
       const cassette = buildCassette(source, PAT)
       await writeCassetteFile(cassettePath, serialize(cassette))
 
@@ -142,7 +162,7 @@ describe('per-source coverage: github-pat-classic across all 5 sources', () => {
   test('github-pat-classic at source=env (non-curated-key) is reported by scan', async () => {
     // Use a key that does NOT match the curated env-key list so the pattern
     // path fires (not the env-key-match path).
-    const cassettePath = path.join(tmp, 'source-env-pattern.json')
+    const cassettePath = path.join(tmpDir.ref(), 'source-env-pattern.json')
     const recording = {
       call: {
         command: 'echo',
@@ -191,7 +211,7 @@ describe('env-key-match symmetry: opaque values under curated env keys are repor
   for (const { key } of CURATED_KEY_CASES) {
     test(`opaque value under ${key} produces env-key-match finding`, async () => {
       const opaqueValue = 'opaque-format-not-matching-any-regex'
-      const cassettePath = path.join(tmp, `env-key-${key}.json`)
+      const cassettePath = path.join(tmpDir.ref(), `env-key-${key}.json`)
       const recording = {
         call: {
           command: 'echo',
@@ -242,7 +262,10 @@ describe('negative direction: clean values produce no findings (best effort)', (
           return !credentialPrefixes.test(s) && !containsWebhookUrl(s) && !containsDiscordShape(s)
         }),
         async (value) => {
-          const cassettePath = path.join(tmp, `neg-${Math.random().toString(36).slice(2)}.json`)
+          const cassettePath = path.join(
+            tmpDir.ref(),
+            `neg-${Math.random().toString(36).slice(2)}.json`,
+          )
           const cassette = buildCassette('args', value)
           await writeCassetteFile(cassettePath, serialize(cassette))
 

--- a/tests/property/scan-record-symmetry.property.test.ts
+++ b/tests/property/scan-record-symmetry.property.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Property test: scan vs record symmetry.
+ *
+ * The load-bearing security guarantee: if record mode would have redacted a
+ * value, scan must report that value as a finding. These tests verify the
+ * forward direction of that guarantee for every bundled rule and for the
+ * env-key-match path.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import * as fc from 'fast-check'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { scanOne } from '../../src/cli-scan.js'
+import { writeCassetteFile } from '../../src/io.js'
+import { BUNDLED_PATTERNS } from '../../src/redact.js'
+import { ENV_KEY_MATCH_RULE } from '../../src/redact-pipeline.js'
+import { serialize } from '../../src/serialize.js'
+import type { CassetteFile, RedactConfig, RedactSource } from '../../src/types.js'
+
+const baseConfig: RedactConfig = {
+  bundledPatterns: true,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+}
+
+let tmp: string
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'sc-symmetry-'))
+})
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+/**
+ * Build a minimal v2 cassette with one recording containing `value` at the
+ * given source location.
+ */
+function buildCassette(source: RedactSource, value: string): CassetteFile {
+  const recording = {
+    call: {
+      command: 'echo',
+      args: source === 'args' ? [value] : [],
+      cwd: null,
+      env: source === 'env' ? { SOME_KEY: value } : {},
+      stdin: null,
+    },
+    result: {
+      stdoutLines: source === 'stdout' ? [value] : [],
+      stderrLines: source === 'stderr' ? [value] : [],
+      allLines: source === 'allLines' ? [value] : null,
+      exitCode: 0,
+      signal: null,
+      durationMs: 10,
+      aborted: false,
+    },
+    redactions: [],
+  }
+  return { version: 2, recordedBy: null, recordings: [recording] }
+}
+
+/**
+ * Known-valid sample per bundled rule, derived from the per-rule regression
+ * fixtures in tests/unit/redact-patterns.test.ts. One sample per rule is
+ * sufficient for the forward-symmetry property (the pattern either fires or
+ * it doesn't; we are not fuzzing the pattern itself here).
+ */
+const RULE_SAMPLES: Record<string, string> = {
+  'github-pat-classic': 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
+  'github-pat-fine-grained': `github_pat_${'A'.repeat(82)}`,
+  'github-oauth': `gho_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
+  'github-user-to-server': `ghu_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
+  'github-server-to-server': `ghs_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
+  'github-refresh': `ghr_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`,
+  'aws-access-key-id': 'AKIA0123456789ABCDEF',
+  'stripe-secret-live': `sk_live_${'a'.repeat(24)}`,
+  'stripe-secret-test': `sk_test_${'a'.repeat(24)}`,
+  'stripe-restricted-live': `rk_live_${'a'.repeat(24)}`,
+  'stripe-restricted-test': `rk_test_${'a'.repeat(24)}`,
+  'anthropic-api-key': `sk-ant-api03-${'a'.repeat(80)}`,
+  'openai-api-key': `sk-${'a'.repeat(48)}`,
+  'google-api-key': `AIza${'a'.repeat(35)}`,
+  'slack-token': `xoxb-1234567890`,
+  'slack-webhook-url': 'https://hooks.slack.com/services/T0AB12CDE/B0FG34HIJ/0123456789ABCDEF',
+  'gitlab-pat': `glpat-${'a'.repeat(20)}`,
+  'npm-token': `npm_${'a'.repeat(36)}`,
+  'digitalocean-pat': `dop_v1_${'0'.repeat(64)}`,
+  'sendgrid-api-key': `SG.${'a'.repeat(22)}.${'a'.repeat(43)}`,
+  'mailgun-api-key': `key-${'0'.repeat(32)}`,
+  'huggingface-token': `hf_${'a'.repeat(34)}`,
+  'pypi-token': `pypi-AgE${'a'.repeat(50)}`,
+  'discord-bot-token': `M${'a'.repeat(23)}.${'a'.repeat(6)}.${'a'.repeat(27)}`,
+  'square-production-token': `EAAA${'a'.repeat(60)}`,
+}
+
+describe('per-rule forward symmetry: redact fires implies scan finds', () => {
+  test('all 25 bundled patterns: placing credential in args yields a scan finding with matching rule name', async () => {
+    for (const rule of BUNDLED_PATTERNS) {
+      const sample = RULE_SAMPLES[rule.name]
+      expect(sample, `missing sample for rule: ${rule.name}`).toBeDefined()
+
+      const cassettePath = path.join(tmp, `rule-${rule.name}.json`)
+      const cassette = buildCassette('args', sample)
+      await writeCassetteFile(cassettePath, serialize(cassette))
+
+      const result = await scanOne(cassettePath, baseConfig, false)
+
+      expect(result.status, `rule ${rule.name}: expected dirty`).toBe('dirty')
+      const finding = result.findings?.find((f) => f.rule === rule.name)
+      expect(
+        finding,
+        `rule ${rule.name}: no finding with matching rule name. findings: ${JSON.stringify(result.findings)}`,
+      ).toBeDefined()
+      expect(finding?.source).toBe('args')
+    }
+  })
+})
+
+describe('per-source coverage: github-pat-classic across all 5 sources', () => {
+  const PAT = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+  const SOURCES: RedactSource[] = ['args', 'stdout', 'stderr', 'allLines']
+
+  for (const source of SOURCES) {
+    test(`github-pat-classic at source=${source} is reported by scan`, async () => {
+      const cassettePath = path.join(tmp, `source-${source}.json`)
+      const cassette = buildCassette(source, PAT)
+      await writeCassetteFile(cassettePath, serialize(cassette))
+
+      const result = await scanOne(cassettePath, baseConfig, false)
+
+      expect(result.status).toBe('dirty')
+      const finding = result.findings?.find(
+        (f) => f.rule === 'github-pat-classic' && f.source === source,
+      )
+      expect(finding, `no finding at source=${source}`).toBeDefined()
+    })
+  }
+
+  test('github-pat-classic at source=env (non-curated-key) is reported by scan', async () => {
+    // Use a key that does NOT match the curated env-key list so the pattern
+    // path fires (not the env-key-match path).
+    const cassettePath = path.join(tmp, 'source-env-pattern.json')
+    const recording = {
+      call: {
+        command: 'echo',
+        args: [],
+        cwd: null,
+        env: { SOME_ENV_VAR: PAT },
+        stdin: null,
+      },
+      result: {
+        stdoutLines: [],
+        stderrLines: [],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 10,
+        aborted: false,
+      },
+      redactions: [],
+    }
+    const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [recording] }
+    await writeCassetteFile(cassettePath, serialize(cassette))
+
+    const result = await scanOne(cassettePath, baseConfig, false)
+
+    expect(result.status).toBe('dirty')
+    const finding = result.findings?.find(
+      (f) => f.rule === 'github-pat-classic' && f.source === 'env',
+    )
+    expect(finding, 'no github-pat-classic finding in env via pattern path').toBeDefined()
+  })
+})
+
+describe('env-key-match symmetry: opaque values under curated env keys are reported', () => {
+  // These values do NOT match any regex pattern but will trigger via env-key-match
+  // because the key contains a curated substring.
+  const CURATED_KEY_CASES: Array<{ key: string; curatedSubstring: string }> = [
+    { key: 'GITHUB_TOKEN', curatedSubstring: 'TOKEN' },
+    { key: 'GH_TOKEN', curatedSubstring: 'TOKEN' },
+    { key: 'MY_SECRET', curatedSubstring: 'SECRET' },
+    { key: 'DB_PASSWORD', curatedSubstring: 'PASSWORD' },
+    { key: 'AWS_SECRET_ACCESS_KEY', curatedSubstring: 'SECRET' },
+    { key: 'SOME_API_KEY', curatedSubstring: 'API_KEY' },
+    { key: 'MY_JWT', curatedSubstring: 'JWT' },
+  ]
+
+  for (const { key } of CURATED_KEY_CASES) {
+    test(`opaque value under ${key} produces env-key-match finding`, async () => {
+      const opaqueValue = 'opaque-format-not-matching-any-regex'
+      const cassettePath = path.join(tmp, `env-key-${key}.json`)
+      const recording = {
+        call: {
+          command: 'echo',
+          args: [],
+          cwd: null,
+          env: { [key]: opaqueValue },
+          stdin: null,
+        },
+        result: {
+          stdoutLines: [],
+          stderrLines: [],
+          allLines: null,
+          exitCode: 0,
+          signal: null,
+          durationMs: 10,
+          aborted: false,
+        },
+        redactions: [],
+      }
+      const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [recording] }
+      await writeCassetteFile(cassettePath, serialize(cassette))
+
+      const result = await scanOne(cassettePath, baseConfig, false)
+
+      expect(result.status, `key ${key}: expected dirty`).toBe('dirty')
+      const finding = result.findings?.find(
+        (f) => f.source === 'env' && f.rule === ENV_KEY_MATCH_RULE,
+      )
+      expect(finding, `key ${key}: no env-key-match finding`).toBeDefined()
+    })
+  }
+})
+
+describe('negative direction: clean values produce no findings (best effort)', () => {
+  test('random short strings without credential shapes produce no findings', async () => {
+    // Filter aggressively: exclude strings matching any bundled pattern prefix
+    // or containing curated env-key substrings (which would fire via a different path).
+    // This is intentionally loose; we're testing that scan doesn't false-positive
+    // on genuinely innocent strings.
+    const credentialPrefixes =
+      /^(ghp_|github_pat_|gho_|ghu_|ghs_|ghr_|AKIA|ASIA|AROA|AIDA|AGPA|ANPA|ANVA|APKA|ABIA|ACCA|sk_live_|sk_test_|rk_live_|rk_test_|sk-ant-|sk-|AIza|xox[baprso]-|glpat-|npm_|dop_v1_|SG\.|key-[a-f0-9]{32}|hf_|pypi-AgE|EAAA)/
+    const containsWebhookUrl = (s: string) => s.includes('hooks.slack.com')
+    const containsDiscordShape = (s: string) => /^[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6}\./.test(s)
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1, maxLength: 20 }).filter((s) => {
+          return !credentialPrefixes.test(s) && !containsWebhookUrl(s) && !containsDiscordShape(s)
+        }),
+        async (value) => {
+          const cassettePath = path.join(tmp, `neg-${Math.random().toString(36).slice(2)}.json`)
+          const cassette = buildCassette('args', value)
+          await writeCassetteFile(cassettePath, serialize(cassette))
+
+          const result = await scanOne(cassettePath, baseConfig, false)
+          return result.status === 'clean'
+        },
+      ),
+      { numRuns: 50 },
+    )
+  })
+})

--- a/tests/unit/cli-walk.test.ts
+++ b/tests/unit/cli-walk.test.ts
@@ -1,81 +1,78 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { walkCassettes } from '../../src/cli-walk.js'
 import { CassetteIOError } from '../../src/errors.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
-let tmp: string
-
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-walk-'))
-})
-
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
-})
+const tmpDir = useTmpDir('shell-cassette-walk-')
 
 describe('walkCassettes', () => {
   test('single existing file path returned as-is', async () => {
-    const cassettePath = path.join(tmp, 'foo.json')
+    const cassettePath = path.join(tmpDir.ref(), 'foo.json')
     await writeFile(cassettePath, JSON.stringify({ version: 2, recordings: [] }))
     const result = await walkCassettes([cassettePath])
     expect(result).toEqual([cassettePath])
   })
 
   test('directory walked for *.json files matching cassette schema', async () => {
-    const a = path.join(tmp, 'a.json')
-    const b = path.join(tmp, 'b.json')
-    const c = path.join(tmp, 'c.json')
+    const a = path.join(tmpDir.ref(), 'a.json')
+    const b = path.join(tmpDir.ref(), 'b.json')
+    const c = path.join(tmpDir.ref(), 'c.json')
     await writeFile(a, JSON.stringify({ version: 1, recordings: [] }))
     await writeFile(b, JSON.stringify({ version: 2, recordings: [] }))
     await writeFile(c, JSON.stringify({ unrelated: true })) // not a cassette
-    const result = await walkCassettes([tmp])
+    const result = await walkCassettes([tmpDir.ref()])
     expect(result.sort()).toEqual([a, b].sort())
   })
 
   test('directory walked recursively', async () => {
-    const subdir = path.join(tmp, 'sub')
+    const subdir = path.join(tmpDir.ref(), 'sub')
     await mkdir(subdir, { recursive: true })
     const nested = path.join(subdir, 'nested.json')
     await writeFile(nested, JSON.stringify({ version: 2, recordings: [] }))
-    const result = await walkCassettes([tmp])
+    const result = await walkCassettes([tmpDir.ref()])
     expect(result).toContain(nested)
   })
 
   test('mixed paths: file + directory de-duplicated', async () => {
-    const a = path.join(tmp, 'a.json')
+    const a = path.join(tmpDir.ref(), 'a.json')
     await writeFile(a, JSON.stringify({ version: 2, recordings: [] }))
-    const result = await walkCassettes([a, tmp])
+    const result = await walkCassettes([a, tmpDir.ref()])
     expect(result.length).toBe(1)
     expect(result[0]).toBe(a)
   })
 
   test('non-existent path throws CassetteIOError', async () => {
-    await expect(walkCassettes([path.join(tmp, 'nope.json')])).rejects.toThrow(CassetteIOError)
+    await expect(walkCassettes([path.join(tmpDir.ref(), 'nope.json')])).rejects.toThrow(
+      CassetteIOError,
+    )
   })
 
   test('non-cassette JSON in dir is silently skipped', async () => {
-    await writeFile(path.join(tmp, 'package.json'), JSON.stringify({ name: 'foo' }))
-    const result = await walkCassettes([tmp])
+    await writeFile(path.join(tmpDir.ref(), 'package.json'), JSON.stringify({ name: 'foo' }))
+    const result = await walkCassettes([tmpDir.ref()])
     expect(result).toEqual([])
   })
 
   test('malformed JSON in dir is silently skipped (not a cassette)', async () => {
-    await writeFile(path.join(tmp, 'broken.json'), '{invalid json')
-    const result = await walkCassettes([tmp])
+    await writeFile(path.join(tmpDir.ref(), 'broken.json'), '{invalid json')
+    const result = await walkCassettes([tmpDir.ref()])
     expect(result).toEqual([])
   })
 
   test('non-.json files in dir are skipped', async () => {
-    await writeFile(path.join(tmp, 'readme.txt'), 'hello')
-    const result = await walkCassettes([tmp])
+    await writeFile(path.join(tmpDir.ref(), 'readme.txt'), 'hello')
+    const result = await walkCassettes([tmpDir.ref()])
     expect(result).toEqual([])
   })
 
   test('JSON file with version field other than 1 or 2 in dir is skipped', async () => {
-    await writeFile(path.join(tmp, 'v3.json'), JSON.stringify({ version: 3, recordings: [] }))
-    const result = await walkCassettes([tmp])
+    await writeFile(
+      path.join(tmpDir.ref(), 'v3.json'),
+      JSON.stringify({ version: 3, recordings: [] }),
+    )
+    const result = await walkCassettes([tmpDir.ref()])
     expect(result).toEqual([])
   })
 
@@ -87,7 +84,7 @@ describe('walkCassettes', () => {
   test('explicit file path bypasses cassette filter (caller knows what they want)', async () => {
     // This test verifies the design choice: explicit paths are trusted.
     // Walking a directory filters; passing a file directly does not.
-    const explicit = path.join(tmp, 'config.json')
+    const explicit = path.join(tmpDir.ref(), 'config.json')
     await writeFile(explicit, JSON.stringify({ name: 'package' }))
     const result = await walkCassettes([explicit])
     expect(result).toEqual([explicit])

--- a/tests/unit/recorder.test.ts
+++ b/tests/unit/recorder.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { DEFAULT_CONFIG } from '../../src/config.js'
 import { record } from '../../src/recorder.js'
-import type { Call, CassetteSession, Result } from '../../src/types.js'
+import type { Call, CassetteSession } from '../../src/types.js'
+import { makeResult } from '../helpers/recording.js'
 
 const baseSession = (): CassetteSession => ({
   name: 'test',
@@ -26,15 +27,7 @@ const callOf = (env: Record<string, string> = {}): Call => ({
   stdin: null,
 })
 
-const resultOf = (): Result => ({
-  stdoutLines: ['ok', ''],
-  stderrLines: [''],
-  allLines: null,
-  exitCode: 0,
-  signal: null,
-  durationMs: 5,
-  aborted: false,
-})
+const resultOf = () => makeResult({ stdoutLines: ['ok', ''], stderrLines: [''], durationMs: 5 })
 
 describe('record', () => {
   test('appends a recording to session.newRecordings', () => {

--- a/tests/unit/redact-patterns.test.ts
+++ b/tests/unit/redact-patterns.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from 'vitest'
 import { BUNDLED_PATTERNS } from '../../src/redact-patterns.js'
+import {
+  SAMPLE_ANTHROPIC_API_KEY,
+  SAMPLE_GITHUB_OAUTH,
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_FINE_GRAINED,
+  SAMPLE_GITHUB_REFRESH,
+  SAMPLE_GITHUB_SERVER_TO_SERVER,
+  SAMPLE_GITHUB_USER_TO_SERVER,
+  SAMPLE_OPENAI_API_KEY,
+} from '../helpers/credential-fixtures.js'
 
 describe('BUNDLED_PATTERNS', () => {
   test('exports exactly 25 rules', () => {
@@ -44,28 +54,23 @@ describe('per-rule regression fixtures', () => {
   }
 
   test('github-pat-classic', () => {
-    expect(matches('github-pat-classic', 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(true)
+    expect(matches('github-pat-classic', SAMPLE_GITHUB_PAT_CLASSIC)).toBe(true)
     expect(matches('github-pat-classic', 'ghp_TooShort')).toBe(false)
-    expect(matches('github-pat-classic', 'gha_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')).toBe(false)
+    expect(matches('github-pat-classic', `gha_${SAMPLE_GITHUB_PAT_CLASSIC.slice(4)}`)).toBe(false)
   })
 
   test('github-pat-fine-grained', () => {
-    const sample = `github_pat_${'A'.repeat(82)}`
-    expect(matches('github-pat-fine-grained', sample)).toBe(true)
+    expect(matches('github-pat-fine-grained', SAMPLE_GITHUB_PAT_FINE_GRAINED)).toBe(true)
     expect(matches('github-pat-fine-grained', 'github_pat_TOOSHORT')).toBe(false)
     // off-by-one: 81 chars is one short
     expect(matches('github-pat-fine-grained', `github_pat_${'A'.repeat(81)}`)).toBe(false)
   })
 
   test('github-oauth, user-to-server, server-to-server, refresh', () => {
-    expect(matches('github-oauth', `gho_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`)).toBe(true)
-    expect(matches('github-user-to-server', `ghu_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`)).toBe(
-      true,
-    )
-    expect(
-      matches('github-server-to-server', `ghs_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`),
-    ).toBe(true)
-    expect(matches('github-refresh', `ghr_${'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'}`)).toBe(true)
+    expect(matches('github-oauth', SAMPLE_GITHUB_OAUTH)).toBe(true)
+    expect(matches('github-user-to-server', SAMPLE_GITHUB_USER_TO_SERVER)).toBe(true)
+    expect(matches('github-server-to-server', SAMPLE_GITHUB_SERVER_TO_SERVER)).toBe(true)
+    expect(matches('github-refresh', SAMPLE_GITHUB_REFRESH)).toBe(true)
     // off-by-one short for each (35 chars instead of 36)
     expect(matches('github-oauth', `gho_${'a'.repeat(35)}`)).toBe(false)
     expect(matches('github-user-to-server', `ghu_${'a'.repeat(35)}`)).toBe(false)
@@ -107,7 +112,7 @@ describe('per-rule regression fixtures', () => {
   })
 
   test('openai-api-key with all prefix variants', () => {
-    expect(matches('openai-api-key', `sk-${'a'.repeat(48)}`)).toBe(true)
+    expect(matches('openai-api-key', SAMPLE_OPENAI_API_KEY)).toBe(true)
     expect(matches('openai-api-key', `sk-proj-${'a'.repeat(48)}`)).toBe(true)
     expect(matches('openai-api-key', `sk-svcacct-${'a'.repeat(48)}`)).toBe(true)
     expect(matches('openai-api-key', `sk-admin-${'a'.repeat(48)}`)).toBe(true)
@@ -117,7 +122,7 @@ describe('per-rule regression fixtures', () => {
   })
 
   test('anthropic-api-key with all prefix variants', () => {
-    expect(matches('anthropic-api-key', `sk-ant-api03-${'a'.repeat(80)}`)).toBe(true)
+    expect(matches('anthropic-api-key', SAMPLE_ANTHROPIC_API_KEY)).toBe(true)
     expect(matches('anthropic-api-key', `sk-ant-sid01-${'a'.repeat(80)}`)).toBe(true)
     expect(matches('anthropic-api-key', `sk-ant-admin01-${'a'.repeat(80)}`)).toBe(true)
     expect(matches('anthropic-api-key', `sk-ant-other-${'a'.repeat(80)}`)).toBe(false)

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import { runPipeline, seedCountersFromCassette, stripCounter } from '../../src/redact-pipeline.js'
 import type { CassetteFile, RedactConfig } from '../../src/types.js'
+import {
+  SAMPLE_AWS_ACCESS_KEY_ID,
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_CLASSIC_2,
+} from '../helpers/credential-fixtures.js'
 
 const baseConfig: RedactConfig = {
   bundledPatterns: false,
@@ -18,11 +23,11 @@ describe('redact-pipeline: suppress short-circuit', () => {
       suppressPatterns: [/^FAKE_/],
     }
     const result = runPipeline(
-      { source: 'env', value: 'FAKE_ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
+      { source: 'env', value: `FAKE_${SAMPLE_GITHUB_PAT_CLASSIC}` },
       config,
       { counted: false },
     )
-    expect(result.output).toBe('FAKE_ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    expect(result.output).toBe(`FAKE_${SAMPLE_GITHUB_PAT_CLASSIC}`)
     expect(result.entries).toEqual([])
     expect(result.warnings).toEqual([])
   })
@@ -64,7 +69,7 @@ describe('redact-pipeline: suppress short-circuit', () => {
 describe('redact-pipeline: bundled patterns', () => {
   test('bundle disabled: no rules apply even when value matches a bundled pattern', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: false }
-    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const value = SAMPLE_GITHUB_PAT_CLASSIC
     const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
     expect(result.output).toBe(value)
     expect(result.entries).toEqual([])
@@ -72,7 +77,7 @@ describe('redact-pipeline: bundled patterns', () => {
 
   test('bundle enabled, stripped mode: replaces match with stripped placeholder', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
-    const value = 'token: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 end'
+    const value = `token: ${SAMPLE_GITHUB_PAT_CLASSIC} end`
     const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
     expect(result.output).toBe('token: <redacted:stdout:github-pat-classic> end')
     expect(result.entries).toEqual([{ rule: 'github-pat-classic', source: 'stdout', count: 1 }])
@@ -80,8 +85,8 @@ describe('redact-pipeline: bundled patterns', () => {
 
   test('bundle enabled, multiple matches in one value: each replaced; count reflects all', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
-    const t1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
-    const t2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+    const t1 = SAMPLE_GITHUB_PAT_CLASSIC
+    const t2 = SAMPLE_GITHUB_PAT_CLASSIC_2
     const value = `a ${t1} b ${t2} c`
     const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
     expect(result.output).toBe(
@@ -215,7 +220,7 @@ describe('redact-pipeline: custom rules', () => {
       bundledPatterns: true,
       customPatterns: [{ name: 'my-fake', pattern: /TEST_TOKEN_[A-Z0-9]+/ }],
     }
-    const value = 'gh: ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 / fake: TEST_TOKEN_ABC'
+    const value = `gh: ${SAMPLE_GITHUB_PAT_CLASSIC} / fake: TEST_TOKEN_ABC`
     const result = runPipeline({ source: 'args', value }, config, { counted: false })
     expect(result.output).toContain('<redacted:args:github-pat-classic>')
     expect(result.output).toContain('<redacted:args:my-fake>')
@@ -319,7 +324,7 @@ describe('redact-pipeline: length warning', () => {
       warnLengthThreshold: 10,
       warnPathHeuristic: true,
     }
-    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const value = SAMPLE_GITHUB_PAT_CLASSIC
     const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
     expect(result.warnings).toEqual([])
   })
@@ -329,8 +334,8 @@ describe('redact-pipeline: counter management', () => {
   test('counted mode increments per emission within a session', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const counters = new Map<string, number>()
-    const value1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
-    const value2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+    const value1 = SAMPLE_GITHUB_PAT_CLASSIC
+    const value2 = SAMPLE_GITHUB_PAT_CLASSIC_2
 
     const r1 = runPipeline({ source: 'env', value: value1 }, config, { counted: true, counters })
     expect(r1.output).toBe('<redacted:env:github-pat-classic:1>')
@@ -342,7 +347,7 @@ describe('redact-pipeline: counter management', () => {
   test('counter scope is per (source, rule)', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const counters = new Map<string, number>()
-    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const value = SAMPLE_GITHUB_PAT_CLASSIC
 
     const r1 = runPipeline({ source: 'env', value }, config, { counted: true, counters })
     expect(r1.output).toBe('<redacted:env:github-pat-classic:1>')
@@ -350,7 +355,7 @@ describe('redact-pipeline: counter management', () => {
     const r2 = runPipeline({ source: 'stdout', value }, config, { counted: true, counters })
     expect(r2.output).toBe('<redacted:stdout:github-pat-classic:1>')
 
-    const aws = 'AKIA0123456789ABCDEF'
+    const aws = SAMPLE_AWS_ACCESS_KEY_ID
     const r3 = runPipeline({ source: 'env', value: aws }, config, { counted: true, counters })
     expect(r3.output).toBe('<redacted:env:aws-access-key-id:1>')
   })
@@ -358,8 +363,8 @@ describe('redact-pipeline: counter management', () => {
   test('multiple matches in single value increment counter for each', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const counters = new Map<string, number>()
-    const t1 = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
-    const t2 = 'ghp_ZYXwvuTSRqponMLKjihgfeDCBA0987654321'
+    const t1 = SAMPLE_GITHUB_PAT_CLASSIC
+    const t2 = SAMPLE_GITHUB_PAT_CLASSIC_2
     const value = `${t1} and ${t2}`
     const result = runPipeline({ source: 'stdout', value }, config, { counted: true, counters })
     expect(result.output).toBe(
@@ -369,7 +374,7 @@ describe('redact-pipeline: counter management', () => {
 
   test('stripped mode produces same output regardless of counter state', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
-    const value = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890'
+    const value = SAMPLE_GITHUB_PAT_CLASSIC
     const r1 = runPipeline({ source: 'args', value }, config, { counted: false })
     const r2 = runPipeline({ source: 'args', value }, config, { counted: false })
     expect(r1.output).toBe(r2.output)

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { BUNDLED_PATTERNS, redact } from '../../src/redact.js'
 import type { RedactConfig } from '../../src/types.js'
+import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
 
 const baseConfig: RedactConfig = {
   bundledPatterns: false,
@@ -13,19 +14,17 @@ const baseConfig: RedactConfig = {
 
 describe('public redact() wraps pipeline', () => {
   test('bundledPatterns: false — input unchanged for credential-shaped value', () => {
-    const r = redact(
-      { source: 'env', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' },
-      baseConfig,
-      { counted: false },
-    )
-    expect(r.output).toBe('ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890')
+    const r = redact({ source: 'env', value: SAMPLE_GITHUB_PAT_CLASSIC }, baseConfig, {
+      counted: false,
+    })
+    expect(r.output).toBe(SAMPLE_GITHUB_PAT_CLASSIC)
     expect(r.entries).toEqual([])
     expect(r.warnings).toEqual([])
   })
 
   test('counted: false — emits placeholder without counter', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
-    const r = redact({ source: 'env', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' }, config, {
+    const r = redact({ source: 'env', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
       counted: false,
     })
     expect(r.output).toBe('<redacted:env:github-pat-classic>')
@@ -34,7 +33,7 @@ describe('public redact() wraps pipeline', () => {
   test('counted: true — increments counter and returns counted placeholder', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const counters = new Map<string, number>()
-    const r = redact({ source: 'env', value: 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' }, config, {
+    const r = redact({ source: 'env', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
       counted: true,
       counters,
     })

--- a/tests/unit/serialize.test.ts
+++ b/tests/unit/serialize.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { BinaryOutputError, CassetteCorruptError } from '../../src/errors.js'
 import { deserialize, serialize } from '../../src/serialize.js'
 import type { CassetteFile } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
 
 const fixture = (name: string) => readFileSync(`tests/fixtures/cassettes/${name}.json`, 'utf8')
 
@@ -40,25 +41,10 @@ describe('serialize', () => {
       version: 2,
       recordedBy: null,
       recordings: [
-        {
-          call: {
-            command: 'echo',
-            args: ['hello'],
-            cwd: null,
-            env: {},
-            stdin: null,
-          },
-          result: {
-            stdoutLines: ['hello', ''],
-            stderrLines: [''],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
-            durationMs: 5,
-            aborted: false,
-          },
-          redactions: [],
-        },
+        makeRecording({
+          call: { command: 'echo', args: ['hello'], cwd: null, env: {}, stdin: null },
+          result: { stdoutLines: ['hello', ''], stderrLines: [''], durationMs: 5 },
+        }),
       ],
     }
     const json = serialize(file)
@@ -81,19 +67,10 @@ describe('serialize', () => {
       version: 2,
       recordedBy: null,
       recordings: [
-        {
+        makeRecording({
           call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
-          result: {
-            stdoutLines: ['line1', 'line2', ''],
-            stderrLines: [''],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
-            durationMs: 1,
-            aborted: false,
-          },
-          redactions: [],
-        },
+          result: { stdoutLines: ['line1', 'line2', ''], stderrLines: [''], durationMs: 1 },
+        }),
       ],
     }
     const round = deserialize(serialize(file))
@@ -105,19 +82,17 @@ describe('serialize', () => {
       version: 2,
       recordedBy: null,
       recordings: [
-        {
+        makeRecording({
           call: { command: 'sleep', args: ['10'], cwd: null, env: {}, stdin: null },
           result: {
             stdoutLines: [''],
             stderrLines: [''],
-            allLines: null,
             exitCode: 1,
             signal: 'SIGTERM',
             durationMs: 42,
             aborted: true,
           },
-          redactions: [],
-        },
+        }),
       ],
     }
     const round = deserialize(serialize(file))
@@ -151,19 +126,15 @@ describe('serialize', () => {
       version: 2,
       recordedBy: null,
       recordings: [
-        {
+        makeRecording({
           call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
           result: {
             stdoutLines: ['out', ''],
             stderrLines: ['err', ''],
             allLines: ['out', 'err', ''],
-            exitCode: 0,
-            signal: null,
             durationMs: 1,
-            aborted: false,
           },
-          redactions: [],
-        },
+        }),
       ],
     }
     const round = deserialize(serialize(file))
@@ -175,19 +146,14 @@ describe('serialize', () => {
       version: 2,
       recordedBy: null,
       recordings: [
-        {
+        makeRecording({
           call: { command: 'x', args: [], cwd: null, env: {}, stdin: null },
           result: {
             stdoutLines: [Buffer.from([0xff, 0xfe]) as unknown as string],
             stderrLines: [''],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
             durationMs: 1,
-            aborted: false,
           },
-          redactions: [],
-        },
+        }),
       ],
     } as CassetteFile
     expect(() => serialize(bad)).toThrow(BinaryOutputError)

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { Recording } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
 import { makeSession } from '../helpers/session.js'
 
 vi.mock('tinyexec', () => ({
@@ -103,19 +103,10 @@ describe('tinyexec adapter', () => {
   test('synthesize emits aborted=true from a recording with aborted=true', async () => {
     // signal=null and aborted=true isolates the aborted-passthrough path from
     // the killed-derivation path (synthesize computes killed = signal !== null).
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'sleep', args: ['10'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: [''],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 1,
-        signal: null,
-        durationMs: 0,
-        aborted: true,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: [''], stderrLines: [''], exitCode: 1, aborted: true },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -147,19 +138,10 @@ describe('tinyexec adapter', () => {
   })
 
   test('synthesize returns tinyexec-shaped result on replay', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: ['hi'],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: ['hi'], stderrLines: [''] },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -177,19 +159,10 @@ describe('tinyexec adapter', () => {
   })
 
   test('synthesize honors throwOnError when exit code is non-zero', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'false', args: [], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: [''],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 1,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: [''], stderrLines: [''], exitCode: 1 },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -200,19 +173,10 @@ describe('tinyexec adapter', () => {
   })
 
   test('synthesize does NOT throw on non-zero by default (inverse of execa)', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'false', args: [], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: [''],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 1,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: [''], stderrLines: [''], exitCode: 1 },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -224,19 +188,10 @@ describe('tinyexec adapter', () => {
   })
 
   test('synthesize result.process is null on replay', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: ['hi'],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: ['hi'], stderrLines: [''] },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -248,19 +203,10 @@ describe('tinyexec adapter', () => {
   })
 
   test('synthesize result.pipe() throws UnsupportedOptionError', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: ['hi'],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: ['hi'], stderrLines: [''] },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -272,19 +218,10 @@ describe('tinyexec adapter', () => {
   })
 
   test('synthesize async iteration throws UnsupportedOptionError', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: ['hi'],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: ['hi'], stderrLines: [''] },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })

--- a/tests/unit/use-cassette.test.ts
+++ b/tests/unit/use-cassette.test.ts
@@ -1,24 +1,15 @@
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import type { Canonicalize } from '../../src/types.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('useCassette - argcount dispatch', () => {
-  let tmp: string
-
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-test-'))
-  })
-
-  afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true })
-  })
+  const tmpDir = useTmpDir()
 
   test('2-arg form: useCassette(path, fn) works (no options)', async () => {
     let called = false
-    await useCassette(path.join(tmp, 'a.json'), async () => {
+    await useCassette(path.join(tmpDir.ref(), 'a.json'), async () => {
       called = true
     })
     expect(called).toBe(true)
@@ -27,15 +18,19 @@ describe('useCassette - argcount dispatch', () => {
   test('3-arg form: useCassette(path, options, fn) works (with options)', async () => {
     let called = false
     const customCanonicalize: Canonicalize = (call) => ({ command: call.command })
-    await useCassette(path.join(tmp, 'b.json'), { canonicalize: customCanonicalize }, async () => {
-      called = true
-    })
+    await useCassette(
+      path.join(tmpDir.ref(), 'b.json'),
+      { canonicalize: customCanonicalize },
+      async () => {
+        called = true
+      },
+    )
     expect(called).toBe(true)
   })
 
   test('3-arg form with empty options object', async () => {
     let called = false
-    await useCassette(path.join(tmp, 'c.json'), {}, async () => {
+    await useCassette(path.join(tmpDir.ref(), 'c.json'), {}, async () => {
       called = true
     })
     expect(called).toBe(true)

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -6,8 +6,8 @@ import {
   UnsupportedOptionError,
 } from '../../src/errors.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { Recording } from '../../src/types.js'
 import { type RunnerHooks, runWrapped } from '../../src/wrapper.js'
+import { makeRecording } from '../helpers/recording.js'
 import { makeSession } from '../helpers/session.js'
 
 type FakeOpts = { fake?: true }
@@ -130,19 +130,10 @@ describe('runWrapped (envelope)', () => {
   })
 
   test('replay path returns synthesized result on match', async () => {
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: ['hi', ''],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: ['hi', ''], stderrLines: [''] },
+    })
     const session = makeSession({
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },
     })
@@ -205,19 +196,10 @@ describe('runWrapped (envelope)', () => {
 
   test('auto matcher miss without ack: AckRequiredError message includes matcher-miss context', async () => {
     // Existing recording for `git status`; we'll call `git log` so the matcher misses.
-    const recording: Recording = {
+    const recording = makeRecording({
       call: { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null },
-      result: {
-        stdoutLines: ['', ''],
-        stderrLines: [''],
-        allLines: null,
-        exitCode: 0,
-        signal: null,
-        durationMs: 0,
-        aborted: false,
-      },
-      redactions: [],
-    }
+      result: { stdoutLines: ['', ''], stderrLines: [''] },
+    })
     const session = makeSession({
       scopeDefault: 'auto',
       loadedFile: { version: 1, recordedBy: null, recordings: [recording] },


### PR DESCRIPTION
## What Changed

Pre-validation bug bash. Three groups of changes in one PR.

### Group A: type restructure + plain-Error removal

`wrapper.ts:153` had `ensureMatcher` throwing plain Error for an unreachable null-matcher case. `plugin.ts:28` had a similar plain Error for `task.file?.filepath`.

- Site 1 (`wrapper.ts`): split `CassetteSession` into a discriminated union, `PendingSession` (matcher: null, loadedFile: null) and `LoadedSession` (matcher: MatcherStateLike, loadedFile: CassetteFile | null). `ensureSessionLoaded(session): Promise<LoadedSession>` does the lazy-load and returns the typed reference. The throw is gone.
- Site 2 (`plugin.ts`): vitest's task type is external; we cannot restructure it. Throw a typed `ShellCassetteError` instead.
- Latent bug fixed: lazy-load condition moved from `loadedFile === null` to `matcher === null`. For brand-new cassettes (no file on disk), the old condition re-entered the load block on every wrapper call. Now it runs exactly once.

Polish folded in: dropped an unnecessary fast-path cast in `ensureSessionLoaded`; tightened the `makeSession` test helper docstring to document the PendingSession-branch matcher-override behavior.

### Group B: scan vs record symmetry property test

`tests/property/scan-record-symmetry.property.test.ts` (new) asserts the load-bearing security guarantee: every value record mode would redact is reported as a finding by scan, and vice versa.

- per-rule forward symmetry: iterates all 25 bundled patterns; places a vetted sample in args; verifies scan reports `dirty` with matching rule name.
- per-source coverage: `github-pat-classic` across env, args, stdout, stderr, allLines.
- env-key-match symmetry: opaque values under curated env keys produce findings with `rule='env-key-match'` (the env-key-match path that fixed an earlier scan gap).
- negative direction: filtered random short strings produce no findings.

Exports `scanOne` from `src/cli-scan.ts` solely to drive scan from the test without spawning the binary. Internal-test consumer; no public API expansion.

No symmetry bugs found across the 25 bundled patterns and the env-key-match path.

### Group C: test infrastructure helpers

Three mechanical refactors, no behavior change:

- `tests/helpers/recording.ts`: `makeRecording` / `makeResult` factories with sensible defaults. Replaces ad-hoc local helpers (`recordingOf`, `resultOf`) and inline `Result` literals across 7 test files. Future schema-additive fields only need a single default-update site.
- `tests/helpers/tmp-dir.ts`: `useTmpDir(prefix?)` registers `beforeEach`/`afterEach` internally and returns `{ ref(): string }`. Replaces the duplicated `let tmp: string` + `mkdtemp` + `rm` lifecycle previously hand-coded in 13 test files.
- `tests/helpers/credential-fixtures.ts`: 27 `SAMPLE_*` constants covering the 25 bundled rules. Replaces scattered string literals across 10 test files. `tests/fixtures/cassettes/v2-dirty.json` left literal (fixture JSON is the test).

## Related Issues

Closes:

- #26 (duplicate of #55)
- #43 (test factories)
- #55 (plain Error in `wrapper.ts`)
- #58 (mkdtemp helper)
- #59 (credential fixtures)
- #67 (re-redact full-cassette idempotence property)
- #68 (scan vs record symmetry)
- #69 (length-warning threshold and path heuristic property)

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (478 passed, 1 platform-skip; +14 from main, all from Group B)
- [x] `npm run build` produces clean dist/
- [x] No `throw new Error(...)` remaining in `src/`
- [x] CI: ubuntu-latest passes, windows-latest passes, tarball-smoke passes