### PR TITLE
test: v1 to v2 cassette migration via re-redact

### DIFF
--- a/tests/fixtures/cassettes/v1-pre-redact.json
+++ b/tests/fixtures/cassettes/v1-pre-redact.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "recordings": [
+    {
+      "call": {
+        "command": "curl",
+        "args": ["-H", "Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": ["{\"login\":\"steve\"}"],
+        "stderrLines": [],
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 100
+      }
+    }
+  ]
+}

--- a/tests/integration/v1-to-v2-migration.test.ts
+++ b/tests/integration/v1-to-v2-migration.test.ts
@@ -1,0 +1,41 @@
+import { copyFile, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { runReRedact } from '../../src/cli-re-redact.js'
+import { deserialize } from '../../src/serialize.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+describe('v1 -> v2 migration via re-redact', () => {
+  const tmp = useTmpDir('shell-cassette-mig-')
+
+  test('v1 cassette upgrades to v2 with recordedBy and redactions populated', async () => {
+    const target = path.join(tmp.ref(), 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v1-pre-redact.json'), target)
+
+    const code = await runReRedact([target, '--quiet'])
+    expect(code).toBe(1)
+
+    const text = await readFile(target, 'utf8')
+    const parsed = deserialize(text)
+    expect(parsed.version).toBe(2)
+    expect(parsed.recordedBy).not.toBeNull()
+    expect(parsed.recordedBy?.name).toBe('shell-cassette')
+    expect(parsed.recordings[0].redactions).toEqual([
+      { rule: 'github-pat-classic', source: 'args', count: 1 },
+    ])
+    expect(parsed.recordings[0].call.args[1]).toBe(
+      'Authorization: Bearer <redacted:args:github-pat-classic:1>',
+    )
+  })
+
+  test('after v1 -> v2 upgrade, second re-redact run is a no-op', async () => {
+    const target = path.join(tmp.ref(), 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v1-pre-redact.json'), target)
+
+    await runReRedact([target, '--quiet'])
+    const code = await runReRedact([target, '--quiet'])
+    expect(code).toBe(0)
+  })
+})


### PR DESCRIPTION
## What Changed

- `tests/fixtures/cassettes/v1-pre-redact.json` (new): cassette shape from before v2 with an unredacted GitHub PAT in args. No version 2 metadata fields.
- `tests/integration/v1-to-v2-migration.test.ts` (new): two tests
  - v1 cassette upgrades to v2 with `recordedBy` and per-recording redactions populated.
  - Second re-redact pass on the upgraded cassette is a no-op (idempotence holds across the version transition).

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (485 passed, 1 platform-skip; +2 from main)
- [x] `npm run build` produces clean dist/