### PR TITLE
fix(vitest plugin): re-throw all errors from deriveCassettePathFromTask (closes #73)

### DIFF
--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -12,7 +12,7 @@
 // See docs/vitest-plugin.md for details.
 
 import { getConfig } from './config.js'
-import { ConcurrencyError, MissingPeerDependencyError } from './errors.js'
+import { MissingPeerDependencyError } from './errors.js'
 import { writeCassetteFile } from './io.js'
 import { deriveCassettePathFromTask } from './plugin.js'
 import { serialize } from './serialize.js'
@@ -60,15 +60,11 @@ try {
     if (!task) return
 
     const config = getConfig()
-    let cassettePath: string
-    try {
-      cassettePath = deriveCassettePathFromTask(task, config.cassetteDir)
-    } catch (e) {
-      if (e instanceof ConcurrencyError) {
-        throw e
-      }
-      return
-    }
+    // deriveCassettePathFromTask throws ConcurrencyError on test.concurrent and
+    // CassetteIOError on path-too-long. Both must propagate: the user needs to
+    // see them or recording silently fails (test passes via wrapper passthrough,
+    // no cassette written, no warning). See issue #73.
+    const cassettePath = deriveCassettePathFromTask(task, config.cassetteDir)
 
     registerSessionPath(cassettePath, `vitest-plugin:${task.name}`)
 

--- a/tests/fixtures/cassettes/v1-pre-redact.json
+++ b/tests/fixtures/cassettes/v1-pre-redact.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "recordings": [
+    {
+      "call": {
+        "command": "curl",
+        "args": ["-H", "Authorization: Bearer ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"],
+        "cwd": null,
+        "env": {},
+        "stdin": null
+      },
+      "result": {
+        "stdoutLines": ["{\"login\":\"steve\"}"],
+        "stderrLines": [],
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 100
+      }
+    }
+  ]
+}

--- a/tests/integration/v1-to-v2-migration.test.ts
+++ b/tests/integration/v1-to-v2-migration.test.ts
@@ -1,0 +1,41 @@
+import { copyFile, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { runReRedact } from '../../src/cli-re-redact.js'
+import { deserialize } from '../../src/serialize.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const FIXTURES = path.resolve('tests/fixtures/cassettes')
+
+describe('v1 -> v2 migration via re-redact', () => {
+  const tmp = useTmpDir('shell-cassette-mig-')
+
+  test('v1 cassette upgrades to v2 with recordedBy and redactions populated', async () => {
+    const target = path.join(tmp.ref(), 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v1-pre-redact.json'), target)
+
+    const code = await runReRedact([target, '--quiet'])
+    expect(code).toBe(1)
+
+    const text = await readFile(target, 'utf8')
+    const parsed = deserialize(text)
+    expect(parsed.version).toBe(2)
+    expect(parsed.recordedBy).not.toBeNull()
+    expect(parsed.recordedBy?.name).toBe('shell-cassette')
+    expect(parsed.recordings[0].redactions).toEqual([
+      { rule: 'github-pat-classic', source: 'args', count: 1 },
+    ])
+    expect(parsed.recordings[0].call.args[1]).toBe(
+      'Authorization: Bearer <redacted:args:github-pat-classic:1>',
+    )
+  })
+
+  test('after v1 -> v2 upgrade, second re-redact run is a no-op', async () => {
+    const target = path.join(tmp.ref(), 'foo.json')
+    await copyFile(path.join(FIXTURES, 'v1-pre-redact.json'), target)
+
+    await runReRedact([target, '--quiet'])
+    const code = await runReRedact([target, '--quiet'])
+    expect(code).toBe(0)
+  })
+})


### PR DESCRIPTION
## What Changed

Drop the try/catch around `deriveCassettePathFromTask` in the vitest plugin's `beforeEach` hook. Errors propagate naturally. Removed the now-unused `ConcurrencyError` import (the catch's only special case was to re-throw it, which is now the default).

## Why

The vitest plugin's `beforeEach` hook silently swallowed all errors from `deriveCassettePathFromTask` except `ConcurrencyError`. The most damaging swallow target was `CassetteIOError` for path-too-long: the test then ran the real subprocess via the wrapper passthrough path, no cassette was written, no warning was emitted, and the test passed without recording.

This is the most dangerous failure mode for a tool whose stated guarantee is to record subprocess calls.

### Repro

A test where the combined cassette path (`cwd + cassetteDir + test-file-basename + describePath + sanitized-test-name + .json`) exceeds 240 chars on Windows trips the `MAX_PATH_LENGTH` guard in `src/paths.ts`. With the swallow, the test silently runs in passthrough. Without it, the user sees `Error: PathTooLong` and the original `CassetteIOError` message which already documents the user-side fixes.

### Verification

Re-validated against the rebuilt tarball:

- Before fix: 30/30 tests reported pass, but only 29/30 cassettes were on disk. The path-too-long test silently failed to record. No error visible to the user.
- After fix: 1 test fails loudly with `Error: PathTooLong` and a stack pointing at `cassettePath`. The other 29 tests record correctly.

The user can now act on the failure. They are told (via the existing `CassetteIOError` message in `paths.ts`) to: shorten describe/test names, shorten the `cassetteDir` config, or move the test file closer to the project root.

## Notes

A unit-level regression test for "the plugin's beforeEach does not swallow errors" is hard without spawning a vitest subprocess (the hook is registered via vitest's lifecycle, not exposed as a callable). The structural fix (drop the try/catch) is small and code review surfaces any reintroduction.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (485 passed, 1 platform-skip; unchanged)
- [x] `npm run build` produces clean dist/