### PR TITLE
fix: bin entry split + tinyexec hardening + vite-plugin helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     "./config": {
       "types": "./dist/config.d.ts",
       "default": "./dist/config.js"
+    },
+    "./vite-plugin": {
+      "types": "./dist/vite-plugin.d.ts",
+      "default": "./dist/vite-plugin.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=18"
   },
   "bin": {
-    "shell-cassette": "./dist/cli.js"
+    "shell-cassette": "./dist/bin.js"
   },
   "exports": {
     ".": {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { main } from './cli.js'
+/**
+ * Bin entry point for the `shell-cassette` CLI. Exists separately from
+ * `cli.ts` so we don't need a fragile self-detect to decide whether to
+ * execute. `cli.ts` exports `main`; this file calls it unconditionally.
+ *
+ * package.json#bin points at this file.
+ */
+import { stderr } from './cli-output.js'
+
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    stderr(`error: ${(e as Error).message}`)
+    process.exit(2)
+  })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-import { fileURLToPath } from 'node:url'
 import { stderr, stdout } from './cli-output.js'
 import { runReRedact } from './cli-re-redact.js'
 import { runScan } from './cli-scan.js'
@@ -61,16 +59,4 @@ export async function main(argv: readonly string[]): Promise<number> {
       stderr(`error: unknown command '${args.command}'\n${HELP}`)
       return 2
   }
-}
-
-// Auto-execute when invoked as the entry point (not when imported by tests)
-const isMain = process.argv[1] === fileURLToPath(import.meta.url)
-
-if (isMain) {
-  main(process.argv.slice(2))
-    .then((code) => process.exit(code))
-    .catch((e) => {
-      stderr(`error: ${(e as Error).message}`)
-      process.exit(2)
-    })
 }

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -126,3 +126,11 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
   // or calling sync-only ProcessApi methods, must use real execution.
   return result as unknown as TinyResult
 }
+
+/**
+ * Alias for `x`. tinyexec exports both names (they reference the same callable);
+ * mirroring that here lets users redirect `import { exec } from 'tinyexec'` to
+ * `import { exec } from 'shell-cassette/tinyexec'` without renaming at every
+ * call site. Closes #77.
+ */
+export const exec = x

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -1,5 +1,5 @@
 import type { Options, Result as TinyResult } from 'tinyexec'
-import { MissingPeerDependencyError, UnsupportedOptionError } from './errors.js'
+import { MissingPeerDependencyError, ShellCassetteError, UnsupportedOptionError } from './errors.js'
 import { validateOptions } from './options-tinyexec.js'
 import type { Call, Result as CassetteResult, Recording } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
@@ -95,7 +95,6 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
     pid: -1,
     aborted: rec.result.aborted,
     killed,
-    process: null,
     pipe: () => {
       throw new UnsupportedOptionError(
         'tinyexec result.pipe() not supported on replay (no live subprocess). Tracked in backlog.',
@@ -120,10 +119,31 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
     )
   }
 
+  // Attach `process` as a throwing getter AFTER the throwOnError branch so
+  // Object.assign(error, result) above does not trigger the throw by reading
+  // the getter while copying enumerable properties. Reads on the success path
+  // surface a clear error instead of a confusing TypeError on a downstream
+  // property access. shell-cassette cannot synthesize a live ChildProcess
+  // from a cassette; tests that need streaming or sync stdio must use
+  // SHELL_CASSETTE_MODE=passthrough. Closes #83.
+  Object.defineProperty(result, 'process', {
+    enumerable: true,
+    configurable: true,
+    get(): never {
+      throw new ShellCassetteError(
+        'result.process is not available in replay mode. shell-cassette synthesizes ' +
+          'subprocess results from cassettes; no live ChildProcess exists. ' +
+          'Tests that read result.process.stdout / .stderr / .stdin streams must ' +
+          'either run with SHELL_CASSETTE_MODE=passthrough, or refactor to read ' +
+          'result.stdout / result.stderr (the buffered fields).',
+      )
+    },
+  })
+
   // The synthesized object lacks tinyexec's full structural shape (no `then`/`spawn`
-  // fields from ExecProcess; `process` is null instead of ChildProcess | undefined).
-  // Documented replay limit: code reading these fields synchronously before await,
-  // or calling sync-only ProcessApi methods, must use real execution.
+  // fields from ExecProcess; `process` is a throwing getter rather than a live
+  // ChildProcess). Documented replay limit: code reading these fields synchronously
+  // before await, or calling sync-only ProcessApi methods, must use real execution.
   return result as unknown as TinyResult
 }
 
@@ -134,3 +154,23 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
  * call site. Closes #77.
  */
 export const exec = x
+
+/**
+ * Stub for tinyexec's sync subprocess entry point. Wrapping sync execution
+ * requires synchronous lazy-load support, which is planned for v0.5 (#82).
+ *
+ * For v0.4, calling xSync through this adapter throws a clear error instead
+ * of failing silently or returning undefined. Users with sync subprocess
+ * tests should either:
+ * - Import xSync directly from `tinyexec` (those calls bypass shell-cassette)
+ * - Refactor to use async `x` (recommended; gets cassette coverage)
+ * - Wait for v0.5
+ */
+export function xSync(): never {
+  throw new ShellCassetteError(
+    'shell-cassette/tinyexec.xSync is not yet wrapped (tracked in #82). ' +
+      'Sync subprocess wrapping requires synchronous lazy-load support, planned for v0.5. ' +
+      'For now: use async `x` (recommended; gets cassette coverage), or import xSync ' +
+      'directly from `tinyexec` (those calls will not be cassetted).',
+  )
+}

--- a/src/vite-plugin.ts
+++ b/src/vite-plugin.ts
@@ -1,0 +1,85 @@
+/**
+ * Vite/Vitest plugin helper that redirects imports of subprocess libraries
+ * (tinyexec, execa) to their shell-cassette adapters, with the importer
+ * conditioned so shell-cassette's OWN internal imports of those libraries
+ * are not redirected. Without this guard, a naive `resolve.alias: { tinyexec:
+ * 'shell-cassette/tinyexec' }` config makes shell-cassette's adapter resolve
+ * itself, causing an infinite import loop or runtime crash.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { defineConfig } from 'vitest/config'
+ * import { shellCassetteAlias } from 'shell-cassette/vite-plugin'
+ *
+ * export default defineConfig({
+ *   plugins: [shellCassetteAlias({ adapters: ['tinyexec'] })],
+ *   test: {
+ *     setupFiles: ['shell-cassette/vitest'],
+ *   },
+ * })
+ * ```
+ *
+ * Closes #84.
+ */
+
+import { ShellCassetteError } from './errors.js'
+
+const VALID_ADAPTERS = ['execa', 'tinyexec'] as const
+type Adapter = (typeof VALID_ADAPTERS)[number]
+
+export type ShellCassetteAliasOptions = {
+  /**
+   * Subprocess libraries to redirect through shell-cassette adapters. Each
+   * entry must be the bare module name as imported in user code. Default:
+   * ['tinyexec'] (shell-cassette's most common adapter).
+   */
+  adapters?: readonly Adapter[]
+}
+
+/**
+ * Minimal duck-typed plugin shape. Mirrors the subset of vite/rollup's Plugin
+ * type that we actually use. Avoids a hard dependency on vite types so this
+ * helper works for any rollup-compatible bundler that consumes the plugin.
+ */
+type PluginShape = {
+  name: string
+  enforce?: 'pre' | 'post'
+  resolveId: (
+    this: {
+      resolve: (id: string, importer?: string) => Promise<{ id: string } | null>
+    },
+    id: string,
+    importer: string | undefined,
+  ) => Promise<string | null>
+}
+
+/**
+ * Build a vite/rollup plugin that redirects bare imports of `adapters` to
+ * the matching `shell-cassette/<adapter>` paths, EXCEPT when the importer
+ * is itself part of shell-cassette (avoids the self-loop).
+ */
+export function shellCassetteAlias(options: ShellCassetteAliasOptions = {}): PluginShape {
+  const adapters = options.adapters ?? ['tinyexec']
+  for (const a of adapters) {
+    if (!VALID_ADAPTERS.includes(a)) {
+      throw new ShellCassetteError(
+        `shellCassetteAlias: unknown adapter "${a}". Supported: ${VALID_ADAPTERS.join(', ')}.`,
+      )
+    }
+  }
+  const adapterSet: ReadonlySet<string> = new Set(adapters)
+
+  return {
+    name: 'shell-cassette-alias',
+    enforce: 'pre',
+    async resolveId(id, importer) {
+      if (!adapterSet.has(id)) return null
+      // Don't redirect imports made BY shell-cassette itself; that would
+      // cause shell-cassette/<adapter> to re-resolve to itself, infinite loop.
+      if (importer?.includes('shell-cassette')) return null
+      const resolved = await this.resolve(`shell-cassette/${id}`, importer)
+      return resolved ? resolved.id : null
+    },
+  }
+}

--- a/tests/e2e/cli-binary.test.ts
+++ b/tests/e2e/cli-binary.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { execa } from 'execa'
 import { describe, expect, test } from 'vitest'
 
-const CLI_BIN = path.resolve('dist/cli.js')
+const CLI_BIN = path.resolve('dist/bin.js')
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
 
 // Skip the suite if dist isn't built so local `npm test` works without a prior

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -8,11 +8,23 @@ vi.mock('tinyexec', () => ({
 }))
 
 const { x: realXMock } = await import('tinyexec')
-const { x, exec } = await import('../../src/tinyexec.js')
+const { x, exec, xSync } = await import('../../src/tinyexec.js')
+const { ShellCassetteError } = await import('../../src/errors.js')
 
 describe('tinyexec adapter', () => {
   test('exec is an alias of x', () => {
     expect(exec).toBe(x)
+  })
+
+  test('xSync stub throws ShellCassetteError with v0.5 guidance', () => {
+    expect(() => xSync()).toThrow(ShellCassetteError)
+    try {
+      xSync()
+    } catch (e) {
+      expect((e as Error).message).toContain('xSync')
+      expect((e as Error).message).toContain('v0.5')
+      expect((e as Error).message).toContain('#82')
+    }
   })
 
   beforeEach(() => {
@@ -191,7 +203,7 @@ describe('tinyexec adapter', () => {
     expect(result.exitCode).toBe(1)
   })
 
-  test('synthesize result.process is null on replay', async () => {
+  test('synthesize result.process throws ShellCassetteError on access in replay', async () => {
     const recording = makeRecording({
       call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
       result: { stdoutLines: ['hi'], stderrLines: [''] },
@@ -202,8 +214,16 @@ describe('tinyexec adapter', () => {
     setActiveCassette(session)
     process.env.SHELL_CASSETTE_MODE = 'replay'
 
-    const result = (await x('echo', ['hi'])) as unknown as { process: unknown }
-    expect(result.process).toBeNull()
+    const result = await x('echo', ['hi'])
+    // Reading result.process surfaces a clear shell-cassette error rather
+    // than a confusing TypeError on a downstream property access. Closes #83.
+    expect(() => (result as unknown as { process: unknown }).process).toThrow(ShellCassetteError)
+    try {
+      ;(result as unknown as { process: unknown }).process
+    } catch (e) {
+      expect((e as Error).message).toContain('result.process is not available in replay')
+      expect((e as Error).message).toContain('SHELL_CASSETTE_MODE=passthrough')
+    }
   })
 
   test('synthesize result.pipe() throws UnsupportedOptionError', async () => {

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -8,9 +8,13 @@ vi.mock('tinyexec', () => ({
 }))
 
 const { x: realXMock } = await import('tinyexec')
-const { x } = await import('../../src/tinyexec.js')
+const { x, exec } = await import('../../src/tinyexec.js')
 
 describe('tinyexec adapter', () => {
+  test('exec is an alias of x', () => {
+    expect(exec).toBe(x)
+  })
+
   beforeEach(() => {
     _resetForTesting()
     vi.mocked(realXMock).mockReset()

--- a/tests/unit/vite-plugin.test.ts
+++ b/tests/unit/vite-plugin.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from 'vitest'
+import { ShellCassetteError } from '../../src/errors.js'
+import { shellCassetteAlias } from '../../src/vite-plugin.js'
+
+describe('shellCassetteAlias', () => {
+  test('returns a plugin shape with name and resolveId', () => {
+    const plugin = shellCassetteAlias()
+    expect(plugin.name).toBe('shell-cassette-alias')
+    expect(plugin.enforce).toBe('pre')
+    expect(typeof plugin.resolveId).toBe('function')
+  })
+
+  test('default adapters list is [tinyexec]', async () => {
+    const plugin = shellCassetteAlias()
+    const ctx = {
+      resolve: vi.fn().mockResolvedValue({ id: '/abs/path/to/shell-cassette/tinyexec' }),
+    }
+
+    const tinyexecResult = await plugin.resolveId.call(ctx, 'tinyexec', '/some/user/file.ts')
+    expect(tinyexecResult).toBe('/abs/path/to/shell-cassette/tinyexec')
+    expect(ctx.resolve).toHaveBeenCalledWith('shell-cassette/tinyexec', '/some/user/file.ts')
+
+    // execa is NOT in the default list, so it should pass through unchanged
+    ctx.resolve.mockClear()
+    const execaResult = await plugin.resolveId.call(ctx, 'execa', '/some/user/file.ts')
+    expect(execaResult).toBeNull()
+    expect(ctx.resolve).not.toHaveBeenCalled()
+  })
+
+  test('adapters: ["execa"] redirects execa imports', async () => {
+    const plugin = shellCassetteAlias({ adapters: ['execa'] })
+    const ctx = { resolve: vi.fn().mockResolvedValue({ id: '/abs/path/to/shell-cassette/execa' }) }
+
+    const result = await plugin.resolveId.call(ctx, 'execa', '/user/file.ts')
+    expect(result).toBe('/abs/path/to/shell-cassette/execa')
+    expect(ctx.resolve).toHaveBeenCalledWith('shell-cassette/execa', '/user/file.ts')
+  })
+
+  test('importer-conditioned: shell-cassette internal imports are NOT redirected', async () => {
+    const plugin = shellCassetteAlias({ adapters: ['tinyexec'] })
+    const ctx = { resolve: vi.fn() }
+
+    // Importer is itself part of shell-cassette: should pass through
+    const result = await plugin.resolveId.call(
+      ctx,
+      'tinyexec',
+      '/node_modules/shell-cassette/dist/tinyexec.js',
+    )
+    expect(result).toBeNull()
+    expect(ctx.resolve).not.toHaveBeenCalled()
+  })
+
+  test('non-adapter ids pass through (no redirect)', async () => {
+    const plugin = shellCassetteAlias({ adapters: ['tinyexec'] })
+    const ctx = { resolve: vi.fn() }
+
+    const result = await plugin.resolveId.call(ctx, 'lodash', '/user/file.ts')
+    expect(result).toBeNull()
+    expect(ctx.resolve).not.toHaveBeenCalled()
+  })
+
+  test('rejects unknown adapter names with ShellCassetteError', () => {
+    expect(() => shellCassetteAlias({ adapters: ['nope' as 'tinyexec'] })).toThrow(
+      ShellCassetteError,
+    )
+    try {
+      shellCassetteAlias({ adapters: ['nope' as 'tinyexec'] })
+    } catch (e) {
+      expect((e as Error).message).toContain('unknown adapter "nope"')
+      expect((e as Error).message).toContain('tinyexec')
+      expect((e as Error).message).toContain('execa')
+    }
+  })
+
+  test('null resolve result returns null (does not throw)', async () => {
+    const plugin = shellCassetteAlias({ adapters: ['tinyexec'] })
+    const ctx = { resolve: vi.fn().mockResolvedValue(null) }
+
+    const result = await plugin.resolveId.call(ctx, 'tinyexec', '/user/file.ts')
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## What Changed

Five bug fixes bundled in the release-tail PR. All surfaced during validation.

### #75: split bin entry from cli (release blocker)

- New `src/bin.ts` always executes `main()`; `src/cli.ts` is import-only. `package.json#bin` points at the new entry.
- The old `isMain = process.argv[1] === fileURLToPath(import.meta.url)` failed for npm/pnpm/yarn shims and Windows `.cmd` wrappers. Result: silent exit 0. Splitting the bin file makes the bug structurally impossible.

### #77: tinyexec adapter exec alias

- Re-export `x` as `exec` from `src/tinyexec.ts`. Mirrors tinyexec's own dual export, so user redirects do not require renaming at every call site.

### #82: tinyexec xSync stub

- Users importing `xSync` from `shell-cassette/tinyexec` previously got `undefined` and a confusing runtime crash. Now throws `ShellCassetteError` with explicit guidance and a backlog reference. The full sync wrap (which requires synchronous lazy-load support) stays backlog work.

### #83: tinyexec result.process throwing getter

- Replay previously returned `process: null`; user code reading `result.process.stdout` got `TypeError: Cannot read properties of null`. Now reading `result.process` itself surfaces `ShellCassetteError` with passthrough/refactor guidance.
- Attached via `Object.defineProperty` AFTER the `throwOnError` branch so `Object.assign(error, result)` does not trip the getter while copying enumerable properties.

### #84: ship `shell-cassette/vite-plugin` helper

- New export at `shell-cassette/vite-plugin` providing `shellCassetteAlias({ adapters })`. Returns a vite/rollup plugin that redirects bare imports of execa/tinyexec to the matching adapter, with the importer conditioned so shell-cassette's OWN internal imports are NOT redirected. Without the conditioning, a naive `resolve.alias: { tinyexec: 'shell-cassette/tinyexec' }` self-loops at module resolution.
- Duck-typed plugin shape avoids a hard dep on vite types.

## Smoke tests

```
# #75
npm pack && cd /tmp/sc-bin && npm init -y && npm install <tarball>
npx shell-cassette --version    # prints version (was: silent)

# #84
node -e "import('./dist/vite-plugin.js').then(m => console.log(m.shellCassetteAlias({adapters:['tinyexec']}).name))"
# prints: shell-cassette-alias
```

## Related Issues

Closes #75, #77, #82, #83, #84.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` passes (494 passed, 1 platform-skip; +7 from main)
- [x] `npm run build` clean (`dist/bin.js` and `dist/vite-plugin.js` emitted)
- [x] Manual smoke: `npx shell-cassette --version` works after `npm install <tarball>`
- [x] Manual smoke: vite-plugin export resolves and returns expected plugin shape