### PR TITLE
docs: README, redact-patterns, troubleshooting, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-XX-XX
+
+### BREAKING CHANGES
+
+- **Cassette schema bumped from version 1 to version 2.** v0.3 readers reject v2 cassettes with `CassetteCorruptError`; v0.4 readers accept both v1 and v2. v1 cassettes are upgradeable in place via `shell-cassette re-redact <path>`.
+- **The v0.2/v0.3 `redactEnv()` function is removed.** Use `redact()` for the unified pipeline, or rely on the recorder to apply redaction transparently at record time.
+- **`Config.redactEnvKeys` is renamed to `Config.redact.envKeys`** under the new composed `RedactConfig` shape. Migration:
+  ```diff
+  - export default { redactEnvKeys: ['STRIPE_API_KEY'] }
+  + export default { redact: { envKeys: ['STRIPE_API_KEY'] } }
+  ```
+- The cassette `_warning` field message is updated to reflect new coverage and residual risks.
+
+### Added
+
+- **25 bundled credential pattern rules** (see `docs/redact-patterns.md`). Default ON. Applies to env values, args, stdout lines, stderr lines, and `allLines`. Covers GitHub (6 token shapes), AWS access key IDs, Stripe (4), OpenAI, Anthropic, Google, Slack (token + webhook URL), GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI, Discord, Square. Rule names are API-stable: locked at v0.4 and never renamed.
+- **User-supplied custom rules** via `Config.redact.customPatterns: RedactRule[]`. Each rule has a kebab-case `name`, a `pattern` (regex or `(s) => string` function), and an optional `description`. Same five-source coverage as the bundle.
+- **Suppress list** via `Config.redact.suppressPatterns: RegExp[]`. Checked first, before bundle and custom rules. A suppressed value is exempt from all rules and from the long-value warning.
+- **Per-cassette redaction override**: `useCassette(name, { redact: false }, fn)`. Coarse-grained; per-stream toggling not supported.
+- **Long-value warning threshold tuned from 100 to 40 chars** with a new `warnPathHeuristic` (default true) that suppresses warnings on values containing `/`, `\`, `:`, or whitespace. Both tunable via `Config.redact.warnLengthThreshold` and `Config.redact.warnPathHeuristic`.
+- **Rule-tagged placeholders with counters**: `<redacted:source:rule-name:N>`. Counter scope is per-cassette per (source, rule), incremented per occurrence.
+- **Schema v2 fields**: top-level `recordedBy: { name, version }` and per-recording `redactions: [{ rule, source, count }]`. Both are additive; v0.3 readers ignore unknown top-level fields but reject the version bump (hence the breaking change).
+- **`BUNDLED_PATTERNS` constant exported** from the main entry for user composition.
+- **New CLI binary `shell-cassette`** with `scan` and `re-redact` subcommands. `scan` is read-only and reports unredacted findings; `re-redact` re-applies the current rules to existing cassettes (idempotent). Exit codes per command are documented in `--help`.
+- **`shell-cassette/vite-plugin` export** with `shellCassetteAlias({ adapters })`. Vite/Vitest plugin that redirects bare `tinyexec` / `execa` imports to shell-cassette's adapters with an importer guard so shell-cassette's own internal imports resolve to the real package. Closes [#84](https://github.com/slgoodrich/shell-cassette/issues/84).
+- **`shell-cassette/tinyexec` exports `exec` as an alias for `x`.** Mirrors tinyexec's own dual export; users who import `{ exec }` from `tinyexec` can redirect without renaming. Closes [#77](https://github.com/slgoodrich/shell-cassette/issues/77).
+- **`shell-cassette/tinyexec` exports `xSync` as a stub** that throws a clear error pointing to async `x` or v0.5. Sync subprocess wrapping requires synchronous lazy-load support; tracked in [#82](https://github.com/slgoodrich/shell-cassette/issues/82).
+- **Property-based tests** for redaction idempotence, scan/record symmetry, and re-redact determinism.
+
+### Changed
+
+- **The default redaction pipeline now runs against env values, args, stdout, stderr, and `allLines`** (was env-only in v0.2/v0.3). Existing cassettes recorded under v0.2/v0.3 retain their original (unredacted) content; run `shell-cassette re-redact <path>` to apply v0.4 rules in place.
+- **The canonicalize pipeline strips counter-tagged placeholders for args before deep-equal matching.** Cassettes with redacted args replay correctly across runs (placeholder counters can drift between cassette versions; the canonical form is counter-stripped).
+- **The ack-gate message enumerates coverage** (bundled rules, curated env keys, custom rules) and explicit residual-risk gaps (AWS Secret Access Keys, JWTs, encoded credentials, binary, cwd, stdin).
+- **`result.process` on tinyexec replay throws a clear `ShellCassetteError`** instead of silently returning `null`. Tests that read `result.process.stdout` / `.stderr` / `.stdin` get pointed at `result.stdout` / `result.stderr` (the buffered fields) or `SHELL_CASSETTE_MODE=passthrough`. Closes [#83](https://github.com/slgoodrich/shell-cassette/issues/83).
+- **Cassette path-too-long errors propagate loudly** instead of being swallowed by the path resolver. Closes [#73](https://github.com/slgoodrich/shell-cassette/issues/73).
+
+### Notes
+
+- **Documented residual gaps** in the redaction surface: AWS Secret Access Keys (caught only by length warning), JWTs (default-off; opt-in via custom rule), encoded credentials (`Authorization: Basic ...`, base64 YAML/JSON), binary output (`BinaryOutputError`), `cwd` values, subprocess `stdin` (until v0.5). See README's "Not redacted (residual risks)" section and `docs/troubleshooting.md` "Residual risks and gaps in v0.4 redaction".
+- **v0.5 will add `show`, `review`, `prune` CLIs** to the same binary, plus the `_suppressed` schema field for `review`'s persistent skip semantics.
+- **Cassettes recorded by v0.4 are NOT loadable by v0.3.** v0.3's deserializer rejects the schema version. v0.4 still loads v0.3 cassettes; mixed-version teams should pin to v0.4 across the team.
+
 ## [0.3.0] - 2026-04-26
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Node.js](https://img.shields.io/node/v/shell-cassette.svg)](https://www.npmjs.com/package/shell-cassette)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> Polly.js for shell commands. Record subprocess output once, replay deterministically forever.
+> Polly.js for shell commands. Record subprocess output once, replay deterministically forever. Credential redaction on by default, with `shell-cassette scan` as a pre-commit safety check.
+
+> **Migrating from v0.3?** v0.4 ships breaking changes. See the [migration callout](#migrating-from-v03) below or [CHANGELOG](CHANGELOG.md#040---2026-xx-xx).
 
 ## Why
 
@@ -16,7 +18,7 @@ You're choosing between two bad options:
 - **Run real subprocesses every test.** Slow, flaky, depends on your machine, doesn't work offline.
 - **Hand-roll mocks.** Fast and deterministic, but you're guessing what the real subprocess returns. Mocks drift; the test passes when reality wouldn't.
 
-shell-cassette is the third option: **real subprocess output captured once, replayed deterministically forever.** Real like a subprocess, fast like a mock.
+shell-cassette is the third option: **real subprocess output captured once, replayed deterministically forever.** Real like a subprocess, fast like a mock. With 25 bundled credential patterns redacting on every record, plus `shell-cassette scan` to verify before commit.
 
 What this unlocks:
 
@@ -25,6 +27,7 @@ What this unlocks:
 - **Offline development.** Tests work on a plane, in a coffee shop, when GitHub is down.
 - **Failure-path testing.** Hand-edit `exitCode: 137` in the cassette and watch your error handler run, every time.
 - **Speed, as a side effect.** Cassette reads are milliseconds; real subprocesses are seconds. The multiplier scales with how heavy your subprocess work is. See [Real-world results](#real-world-results) for measurements on specific projects.
+- **Credentials stay out of cassettes.** Bundled detection for GitHub, AWS, Stripe, OpenAI, Anthropic, Slack, npm, and 18 others. Verify with `npx shell-cassette scan` before every commit.
 
 ### Is this for you?
 
@@ -154,28 +157,222 @@ Set via `SHELL_CASSETTE_MODE=record|replay|passthrough|auto`. `CI=true` forces `
 
 ## Security: redaction
 
-shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`. The ack gate forces a conscious "I know what gets redacted and what doesn't" decision before any cassette lands on disk.
+shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`. The ack gate forces a conscious "I know what gets redacted and what doesn't" decision before any cassette lands on disk. Recording is the only mode that requires it; replay needs nothing.
 
-By default, env var values are redacted when KEY contains: `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `APIKEY`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`, `AUTH_TOKEN`, `BEARER_TOKEN`, `JWT`. Substring match, case-insensitive.
+### Redacted by default
 
-shell-cassette does **NOT** redact:
+shell-cassette ships **25 bundled credential patterns**, applied to env values, args, stdout lines, stderr lines, and `allLines`. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format:
 
-- stdout / stderr content
-- command args
-- env vars with non-curated names (`STRIPE_KEY`, `OPENAI_KEY`, etc.; extend via `redact.envKeys` config)
-- paths in cwd
+- **GitHub** (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `github_pat_`)
+- **AWS access key IDs** (`AKIA`, `ASIA`, `AROA`, `AIDA`, `AGPA`, `ANPA`, `ANVA`, `APKA`, `ABIA`, `ACCA`)
+- **Stripe** (`sk_live_`, `sk_test_`, `rk_live_`, `rk_test_`)
+- **OpenAI** (`sk-`, `sk-proj-`, `sk-svcacct-`, `sk-admin-`)
+- **Anthropic** (`sk-ant-api03-`, `sk-ant-sid01-`, `sk-ant-admin01-`)
+- **Google** (`AIza`)
+- **Slack** (`xoxb-`, `xoxp-`, `xoxa-`, `xoxr-`, `xoxs-`, `xoxo-`, plus `https://hooks.slack.com/services/...` webhook URLs)
+- **GitLab** (`glpat-`)
+- **npm** (`npm_`)
+- **DigitalOcean** (`dop_v1_`)
+- **SendGrid** (`SG.<22>.<43>`)
+- **Mailgun** (`key-<32 hex>`)
+- **Hugging Face** (`hf_`)
+- **PyPI** (`pypi-AgE`)
+- **Discord** (three-segment base64 bot tokens)
+- **Square** (`EAAA`)
 
-**Always review cassettes before committing.** Pattern-based detection for stdout/stderr/args (GitHub PATs, AWS keys, Stripe keys, etc.) isn't built yet. Review by eye.
+Full reference table with provider docs in [docs/redact-patterns.md](docs/redact-patterns.md). Rule names are API-stable: locked at v0.4 and never renamed.
 
-End-of-run summaries surface redaction events on every record:
+Each redaction replaces the credential with a counter-tagged placeholder: `<redacted:source:rule-name:N>`. The counter is per-cassette per (source, rule). Diff-friendly: re-recording a cassette with the same secrets produces identical placeholders.
+
+### Redacted with config
+
+- **Curated env keys.** Env values are redacted when the KEY contains `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `APIKEY`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`, `AUTH_TOKEN`, `BEARER_TOKEN`, `JWT` (substring match, case-insensitive).
+- **User-extended env keys.** Add your own to `Config.redact.envKeys` (substring match, same semantics).
+- **Custom rules.** `Config.redact.customPatterns: RedactRule[]`. Project-specific shapes the bundle doesn't cover.
+- **Suppress list.** `Config.redact.suppressPatterns: RegExp[]`. Values matching a suppress pattern are exempt from all rules and the long-value warning.
+
+```ts
+// shell-cassette.config.mjs
+export default {
+  redact: {
+    envKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+    customPatterns: [
+      { name: 'my-internal-token', pattern: /MYINT-[A-Z0-9]{32}/ },
+    ],
+    suppressPatterns: [/^FAKE_/],
+  },
+}
+```
+
+### Not redacted (residual risks)
+
+shell-cassette redacts what it can detect with 100% reliability and warns on suspicious-looking unredacted values. Some shapes can't be detected reliably:
+
+- **AWS Secret Access Keys.** 40-char base64, no documented prefix. Caught by the long-value warning at length 40+ when the value isn't path-shaped. Add the env key to `redact.envKeys` if your tests carry one as an env var.
+- **JWTs.** Many JWTs in the wild are public ID tokens or JWKS responses, not bearer secrets. Default-off; opt-in via a custom rule when your JWTs are bearer-shaped.
+- **Encoded credentials.** `Authorization: Basic <base64>` headers, base64-encoded YAML/JSON secrets. shell-cassette doesn't decode. Add a custom rule if relevant.
+- **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8.
+- **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
+- **Subprocess `stdin`.** Not captured in v0.4. v0.5 will capture stdin and apply the same pipeline.
+
+Workarounds for each gap are in [docs/troubleshooting.md](docs/troubleshooting.md#residual-risks-and-gaps-in-v04-redaction).
+
+### Long-value warnings
+
+Values 40+ characters that did NOT match any rule emit a warning at record time. The warning is logged but the value is NOT redacted (shell-cassette can't pattern-match an unknown shape safely). The threshold (default 40) and a path heuristic (skip warning when the value contains `/`, `\`, `:`, or whitespace) are tunable via `Config.redact.warnLengthThreshold` and `Config.redact.warnPathHeuristic`.
+
+End-of-run summaries make redaction events visible:
 
 ```
 shell-cassette: cassette saved (3 recordings, 1 redaction, 2 warnings): /path/to/cassette.json
   redacted: GH_TOKEN
-  ⚠️  STRIPE_API_KEY: long value (104 chars), not in curated/configured list - may contain a credential...
+  warning: STRIPE_API_KEY: long value (104 chars), not in curated/configured list, may contain a credential...
 ```
 
-Each cassette JSON also contains a `_warning` field reminding code reviewers to check before committing.
+Each cassette JSON also contains a top-level `_warning` field reminding reviewers to scan before committing.
+
+## Pre-commit hook
+
+The `shell-cassette scan` CLI walks cassette files (or directories) and reports any unredacted findings. Run it as a pre-commit hook to block credentials from ever landing in a commit.
+
+**husky:**
+
+```bash
+# .husky/pre-commit
+npx shell-cassette scan tests/__cassettes__/
+```
+
+**lefthook:**
+
+```yaml
+# lefthook.yml
+pre-commit:
+  commands:
+    cassette-scan:
+      run: npx shell-cassette scan tests/__cassettes__/
+```
+
+Exit codes:
+
+- `0` - all cassettes clean, commit proceeds.
+- `1` - at least one cassette has unredacted findings, commit is blocked.
+- `2` - error (missing path, malformed cassette, conflicting flags).
+
+When the hook blocks: review the listed findings, run `npx shell-cassette re-redact tests/__cassettes__/` to re-apply current rules, and commit again.
+
+## CLI usage
+
+shell-cassette ships a `shell-cassette` binary with two subcommands.
+
+### `scan`
+
+Read-only. Walks cassette paths and reports unredacted findings.
+
+```bash
+npx shell-cassette scan tests/__cassettes__/
+npx shell-cassette scan path/to/single-cassette.json
+npx shell-cassette scan --json tests/__cassettes__/   # structured output for tooling
+npx shell-cassette scan --quiet tests/__cassettes__/  # exit code only
+```
+
+Common flags:
+
+| Flag | Behavior |
+|---|---|
+| `--json` | Structured output (locked schema, `scanVersion: 1`). |
+| `--quiet` | Suppress stdout; use the exit code only. |
+| `--include-match` | With `--json`, include raw match values. UNSAFE for piping; use only for local debugging. |
+| `--config <path>` | Override config discovery. |
+| `--no-bundled` | Skip bundled patterns; check user rules and suppress list only. |
+| `--no-color` / `--color=always` | Color override. |
+
+Example output:
+
+```
+tests/__cassettes__/login.test.ts/test-1.json: 2 unredacted finding(s)
+  [rec0-stdout-1:0-github-pat-classic]: ghp_aBcD1234... (40 chars)
+  [rec0-env-GH_TOKEN:0-env-key-match]: ghp_aBcD1234... (40 chars)
+
+1 cassette(s) scanned, 1 dirty, 0 error(s).
+```
+
+Exit `0` clean, `1` dirty, `2` error.
+
+### `re-redact`
+
+Re-applies the current redaction rules to existing cassettes. Idempotent: running twice yields identical output. Use this when the bundle expands or when you add a custom rule and want to upgrade existing cassettes.
+
+```bash
+npx shell-cassette re-redact tests/__cassettes__/
+npx shell-cassette re-redact --dry-run tests/__cassettes__/   # preview
+npx shell-cassette re-redact path/to/single-cassette.json
+```
+
+Existing placeholders are preserved; new findings get counters at `max(existing) + 1` per (source, rule). v1 cassettes are upgraded to v2 in place.
+
+Common flags:
+
+| Flag | Behavior |
+|---|---|
+| `--dry-run` | Preview changes without writing. |
+| `--quiet` | Suppress stdout summary. |
+| `--config <path>` | Override config discovery. |
+| `--no-bundled` | Skip bundled patterns. |
+| `--no-color` / `--color=always` | Color override. |
+
+Exit `0` no new redactions, `1` at least one cassette modified (or would be in dry-run), `2` error.
+
+### Ack-gate workflow
+
+Recording requires `SHELL_CASSETTE_ACK_REDACTION=true`. Replay does not. Typical flow:
+
+```bash
+# First run, record cassettes
+SHELL_CASSETTE_ACK_REDACTION=true npm test
+
+# Verify before commit
+npx shell-cassette scan tests/__cassettes__/
+
+# Subsequent runs replay automatically
+npm test
+
+# CI forces replay-strict
+npm test  # CI=true is set by your CI provider
+```
+
+Run `shell-cassette --help`, `shell-cassette scan --help`, and `shell-cassette re-redact --help` for the full flag list.
+
+## Adapter quirks
+
+A few v0.4 specifics worth knowing:
+
+- **`shell-cassette/tinyexec` exports `exec` as an alias for `x`.** Mirrors tinyexec's own dual export so `import { exec } from 'tinyexec'` redirects to `import { exec } from 'shell-cassette/tinyexec'` without renaming.
+- **`shell-cassette/tinyexec.xSync` throws.** Sync subprocess wrapping requires synchronous lazy-load support, planned for v0.5. Use async `x` (recommended), or import `xSync` directly from `tinyexec` (those calls bypass shell-cassette).
+- **`result.process` on tinyexec replay throws** a clear `ShellCassetteError`. Tests reading `result.process.stdout` / `.stderr` / `.stdin` should switch to the buffered `result.stdout` / `result.stderr` fields, or run with `SHELL_CASSETTE_MODE=passthrough`.
+
+See [docs/tinyexec.md](docs/tinyexec.md) for the full set of replay limits.
+
+## Vite/Vitest plugin: redirecting bare imports
+
+If your tests import `tinyexec` (or `execa`) bare and you don't want to rewrite every call site to `shell-cassette/tinyexec`, use the vite plugin to redirect imports at resolution time:
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+import { shellCassetteAlias } from 'shell-cassette/vite-plugin'
+
+export default defineConfig({
+  plugins: [shellCassetteAlias({ adapters: ['tinyexec'] })],
+  test: {
+    setupFiles: ['shell-cassette/vitest'],
+    server: { deps: { inline: ['shell-cassette'] } },
+  },
+})
+```
+
+The plugin redirects bare `tinyexec` imports from your test code to `shell-cassette/tinyexec`, but skips redirection when the importer is itself part of shell-cassette (so shell-cassette's internal `import 'tinyexec'` resolves to the real package). Without that guard, a naive `resolve.alias` self-loops.
+
+`adapters` defaults to `['tinyexec']`. Pass `['execa']` or `['tinyexec', 'execa']` if you wrap the other library or both.
 
 ## Configuration
 
@@ -188,9 +385,25 @@ export default {
   // Where cassettes live (default '__cassettes__', relative to test file)
   cassetteDir: '__cassettes__',
 
-  // Adds to the curated env-key redaction list (substring, case-insensitive)
   redact: {
+    // Bundled credential patterns (default: true). Set false to skip the bundle.
+    bundledPatterns: true,
+
+    // Extends the curated env-key match list (substring, case-insensitive).
     envKeys: ['STRIPE_API_KEY', 'OPENAI_API_KEY'],
+
+    // Project-specific credential shapes the bundle doesn't cover.
+    customPatterns: [
+      { name: 'my-internal-token', pattern: /MYINT-[A-Z0-9]{32}/ },
+    ],
+
+    // Values matching any suppress pattern are exempt from all rules.
+    suppressPatterns: [/^FAKE_/],
+
+    // Long-value warning threshold (default 40 chars). Path heuristic skips
+    // values containing `/`, `\`, `:`, or whitespace.
+    warnLengthThreshold: 40,
+    warnPathHeuristic: true,
   },
 
   // Custom canonicalize fn (default: defaultCanonicalize, command exact +
@@ -202,6 +415,8 @@ export default {
   }),
 }
 ```
+
+Full reference for the redact config is in [docs/redact-patterns.md](docs/redact-patterns.md).
 
 ## Customizing matching
 
@@ -251,16 +466,40 @@ The default canonicalize is conservative. These patterns are NOT normalized. Wri
 | Custom `$TMPDIR` outside the standard set (e.g., `/scratch/...`) | Compose your own pattern alongside `defaultCanonicalize` |
 | `process.cwd()` substrings inside args | Custom canonicalize that replaces `call.cwd ?? ''` with a token |
 
+## Migrating from v0.3
+
+v0.4 ships breaking changes around redaction and the cassette schema. The full list lives in the [CHANGELOG](CHANGELOG.md#040---2026-xx-xx); the practical migration steps are:
+
+1. **Update your config.** `Config.redactEnvKeys` moved under the new composed `Config.redact` shape:
+   ```diff
+   - export default { redactEnvKeys: ['STRIPE_API_KEY'] }
+   + export default { redact: { envKeys: ['STRIPE_API_KEY'] } }
+   ```
+2. **Remove any direct calls to `redactEnv()`.** The function is removed. The recorder applies redaction transparently at record time; if you need ad-hoc redaction in your code, use the exported `redact()` instead.
+3. **Upgrade existing cassettes.** v0.4 bumps the cassette schema from version 1 to version 2. v0.4 reads both; v0.3 readers reject v2. If you've already recorded under v0.3 and want v0.4's redaction applied to them in place:
+   ```bash
+   npx shell-cassette re-redact tests/__cassettes__/
+   ```
+   Idempotent; running twice yields identical output.
+4. **Add the pre-commit hook.** v0.4 ships the `shell-cassette scan` CLI; wire it as a pre-commit hook (see [Pre-commit hook](#pre-commit-hook) above).
+5. **Review residual gaps.** v0.4's bundle covers 25 credential shapes but does not cover AWS Secret Access Keys, JWTs, or encoded credentials. Check the [Not redacted (residual risks)](#not-redacted-residual-risks) section and [docs/troubleshooting.md](docs/troubleshooting.md#residual-risks-and-gaps-in-v04-redaction); add custom rules for project-specific shapes if needed.
+
+Mixed-version teams should pin to v0.4 across the team. Cassettes recorded by v0.4 are not loadable by v0.3.
+
 ## Common gotchas
 
 If you hit one of these, see [docs/troubleshooting.md](docs/troubleshooting.md):
 
-- `VitestPluginRegistrationError` ("Vitest failed to find the runner") → add `deps.inline: ['shell-cassette']`
-- `MissingPeerDependencyError` → install the runner peer dep (execa, tinyexec, or vitest)
-- `NoActiveSessionError` → in CI=true replay mode without a session bound; wrap with `useCassette` or import the vitest plugin
-- `AckRequiredError` with "auto mode: no recording matched..." → matcher missed; check cassette
-- `__cassettes__/` showing up as a test fixture → exclude alongside `__snapshots__/`
-- `vi.mock('tinyexec')` infinite loop → redirect at the import level instead
+- `VitestPluginRegistrationError` ("Vitest failed to find the runner") -> add `deps.inline: ['shell-cassette']`
+- `MissingPeerDependencyError` -> install the runner peer dep (execa, tinyexec, or vitest)
+- `NoActiveSessionError` -> in CI=true replay mode without a session bound; wrap with `useCassette` or import the vitest plugin
+- `NoActiveSessionError` from `beforeAll` / `beforeEach` -> setup runs outside the per-test session; use real `tinyexec` / `execa` in setup, or `SHELL_CASSETTE_MODE=passthrough` for setup-only flows
+- `AckRequiredError` with "auto mode: no recording matched..." -> matcher missed; check cassette
+- `__cassettes__/` showing up as a test fixture -> exclude alongside `__snapshots__/`
+- `vi.mock('tinyexec')` infinite loop -> redirect at the import level, or use `shellCassetteAlias` from `shell-cassette/vite-plugin`
+- Naive `resolve.alias: { tinyexec: 'shell-cassette/tinyexec' }` self-loops -> use `shellCassetteAlias` instead (importer guard included)
+- Test passes in record but fails in replay asserting on filesystem state -> shell-cassette captures subprocess I/O, not subprocess side effects; refactor to assert on stdout, or use `SHELL_CASSETTE_MODE=passthrough`
+- "cassette path exceeds 240 chars" -> shorten describe / test names, shorten `cassetteDir`, or move test files closer to the project root
 
 ## What this doesn't do
 

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ If you hit one of these, see [docs/troubleshooting.md](docs/troubleshooting.md):
 
 ## What this doesn't do
 
-Two patterns shell-cassette is not a fit for. These aren't on a roadmap. They're outside the design.
+Two patterns shell-cassette is not a fit for. 
 
 **Mock-for-assertion patterns.** shell-cassette captures and replays subprocess **output**, not subprocess invocations. Tests that assert on **which command was called** (`expect(execMock).toHaveBeenCalledWith('git', ['commit', ...])`) are testing the wrong abstraction layer. Use `vi.mock` for that pattern; it's a different concern. Examples in the wild: `prettier/pretty-quick`, `antfu/ni`, `jinghaihan/pncat`.
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,23 @@ shell-cassette is for **output-assertion** tests: spawn a subprocess, capture st
 
 ## Real-world results
 
+### Each claim, what proves it
+
+Every claim in [What this unlocks](#why) is backed by a concrete demonstration. The table below maps claim to evidence.
+
+| Claim | What was demonstrated |
+|---|---|
+| Reproducible CI failures | One subprocess call recorded, then replayed 10 times in sequence. All 10 replays produce byte-identical stdout, stderr, and exitCode. If any external variance leaked through, at least one of the ten would diverge. |
+| Determinism | Same demo as above. The recorded subprocess output drives every replay regardless of host node version, system clock, or locale. |
+| Offline development | Subprocess script written to a temp file, recorded, then the script file is **deleted before replay**. A pre-replay sanity check uses Node's built-in `child_process` to confirm a real exec would now fail with ENOENT. Replay still returns the recorded output. The cassette is the only place the bytes can come from. |
+| Failure-path testing | Successful subprocess (`exitCode: 0`) recorded. Cassette JSON read, mutated to `exitCode: 137`, written back. Replay throws an ExecaError-shaped object with `exitCode === 137`, `failed === true`. The user's `try/catch` runs. With `reject: false`, replay returns the same shape without throwing. |
+| Speed | Per-call: ~75ms record vs ~1.2ms replay on a trivial node-eval workload (60x). Full suite: unjs/nypm 211.72s record vs 0.263s replay (805x). See speedup table below. |
+| Credentials stay out | All 25 bundled patterns plus 5 curated env-key substrings exercised end-to-end. 30 cassettes recorded, scanned with `shell-cassette scan`, 0 dirty. The host's `LM_STUDIO_API_KEY` was caught by `API_KEY` substring match on every recording. Pattern reference: [docs/redact-patterns.md](docs/redact-patterns.md). |
+
+Demonstrations live in the validation harness alongside the project. The first four are new in v0.4 (`determinism`, `offline`, `failure-path`); credentials and full-suite speed have been validated since v0.3 (M9-M10) and v0.4 M14 respectively.
+
+### Speedup measurements
+
 Three projects measured on Windows + Node 23.11 against v0.4. Point measurements, not benchmarks: directional only.
 
 | Project | Tests / cassettes | Test-phase speedup | Wall speedup | Notes |

--- a/README.md
+++ b/README.md
@@ -516,15 +516,19 @@ shell-cassette is for **output-assertion** tests: spawn a subprocess, capture st
 
 ## Real-world results
 
-Three projects measured so far on Windows + Node 23. Point measurements, not benchmarks: directional only.
+Three projects measured on Windows + Node 23.11 against v0.4. Point measurements, not benchmarks: directional only.
 
-| Project | Test execution speedup | Wall speedup | Notes |
-|---|---:|---:|---|
-| [cacjs/cac](https://github.com/cacjs/cac) | ~90x | ~4x | 17 tests, light subprocess (`node example.ts`) |
-| [antfu/taze](https://github.com/antfu/taze) | ~200x | ~5x | 2 tests, medium subprocess (CLI with network fetch) |
-| [import-js/eslint-import-resolver-typescript](https://github.com/import-js/eslint-import-resolver-typescript) | ~1700x | ~55x | 13 tests, heavy subprocess (`yarn eslint` per fixture) |
+| Project | Tests / cassettes | Test-phase speedup | Wall speedup | Notes |
+|---|---:|---:|---:|---|
+| [unjs/nypm](https://github.com/unjs/nypm) | 161 / 91 | ~800x | ~110x | Full vitest suite under the auto-cassette plugin. 8 package-manager fixtures (npm, pnpm, yarn-classic, yarn-berry, deno, plus workspace variants). 22 env-key-match redactions caught on the host's `LM_STUDIO_API_KEY`. |
+| [lerna-lite/lerna-lite](https://github.com/lerna-lite/lerna-lite) | 13 / 12 | ~6x | n/a | SC-wrapped subset across `core` and `version` packages. The broader 1656-test monorepo suite passes **99.5%** unchanged with the SC alias active in passthrough; the remaining 0.48% trace to a documented `child.process` streaming-access mismatch. |
+| [sveltejs/cli](https://github.com/sveltejs/cli) (`sv` cli pkg) | 4 / 4 | ~17x | ~17x | Smallest measured. Proves the vitest plugin auto-binds without source patching when the project's source has a usable DI seam. One well-designed test replayed at ~40x. |
 
-Wall-time speedup is bounded by vitest startup (~300-400ms regardless of mode). Test execution speedup scales with subprocess work per test: the heavier the subprocess, the bigger the multiplier.
+Wall-time speedup is bounded by vitest startup (~300-400ms regardless of mode). Test-phase speedup scales with subprocess work per test: the heavier the subprocess, the bigger the multiplier.
+
+**What "speedup" means here.** Record runs the real subprocess once, replay reads the cassette. The multiplier is record test-phase divided by replay test-phase. Wall-time speedup includes vitest startup and is the smaller number. Both numbers vary with machine state, Node version, and background load.
+
+**What "tests / cassettes" means here.** Not every test in a project's suite cleanly cassettes: tests that assert on subprocess side effects (filesystem state, network calls outside subprocess) can't replay because the side effect didn't happen. Tests reading `result.process.stdout` synchronously hit the same limit. The test count is the suite's full execution count under SC; the cassette count is what records cleanly. Tests outside the cassettable surface either fall to passthrough or fail in replay with actionable errors. See [docs/troubleshooting.md](docs/troubleshooting.md) for patterns and workarounds.
 
 ## License
 

--- a/docs/redact-patterns.md
+++ b/docs/redact-patterns.md
@@ -1,0 +1,118 @@
+# Bundled redaction patterns
+
+shell-cassette ships 25 default-on credential patterns. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format. Rule names are API-stable: they ship locked at v0.4 and are never renamed. New patterns may be added additively in any version; removing or renaming a rule name is a breaking change.
+
+For ambiguous credential shapes (AWS Secret Access Keys, JWTs, generic 32-hex tokens), the bundle deliberately does not include a pattern. The long-value warning catches them at length 40+ when they don't look like a path. Custom rules cover the rest.
+
+## Pattern table
+
+| Rule name | Provider | Prefix | Length | Doc |
+|---|---|---|---|---|
+| `github-pat-classic` | GitHub | `ghp_` | 36 char body | https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/ |
+| `github-pat-fine-grained` | GitHub | `github_pat_` | 82 char body | (same) |
+| `github-oauth` | GitHub | `gho_` | 36 | (same) |
+| `github-user-to-server` | GitHub | `ghu_` | 36 | (same) |
+| `github-server-to-server` | GitHub | `ghs_` | 36 | (same) |
+| `github-refresh` | GitHub | `ghr_` | 36 | (same) |
+| `aws-access-key-id` | AWS | `AKIA` / `ASIA` / `AROA` / `AIDA` / `AGPA` / `ANPA` / `ANVA` / `APKA` / `ABIA` / `ACCA` | 16 char body | https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html |
+| `stripe-secret-live` | Stripe | `sk_live_` | 24+ | https://stripe.com/docs/keys |
+| `stripe-secret-test` | Stripe | `sk_test_` | 24+ | (same) |
+| `stripe-restricted-live` | Stripe | `rk_live_` | 24+ | (same) |
+| `stripe-restricted-test` | Stripe | `rk_test_` | 24+ | (same) |
+| `anthropic-api-key` | Anthropic | `sk-ant-(api03\|sid01\|admin01)-` | 80+ | https://docs.anthropic.com/en/api/getting-started |
+| `openai-api-key` | OpenAI | `sk-` (also `sk-proj-`, `sk-svcacct-`, `sk-admin-`) | 40+ | https://platform.openai.com/docs/api-reference/authentication |
+| `google-api-key` | Google | `AIza` | 35 | https://cloud.google.com/api-keys/docs/overview |
+| `slack-token` | Slack | `xox[baprso]-` | 10+ | https://api.slack.com/authentication/token-types |
+| `slack-webhook-url` | Slack | `https://hooks.slack.com/services/T*/B*/*` | structured | (same) |
+| `gitlab-pat` | GitLab | `glpat-` | 20 | https://docs.gitlab.com/ee/security/token_overview.html |
+| `npm-token` | npm | `npm_` | 36 | https://docs.npmjs.com/about-access-tokens |
+| `digitalocean-pat` | DigitalOcean | `dop_v1_` | 64 hex | https://docs.digitalocean.com/reference/api/create-personal-access-token/ |
+| `sendgrid-api-key` | SendGrid | `SG.` | 22 + `.` + 43 | https://docs.sendgrid.com/api-reference/api-keys/create-api-keys |
+| `mailgun-api-key` | Mailgun | `key-` | 32 hex | https://documentation.mailgun.com/en/latest/api-intro.html#authentication |
+| `huggingface-token` | Hugging Face | `hf_` | 34 | https://huggingface.co/docs/hub/security-tokens |
+| `pypi-token` | PyPI | `pypi-AgE` | 50+ | https://pypi.org/help/#apitoken |
+| `discord-bot-token` | Discord | `[MN]` | 23 + `.` + 6 + `.` + 27+ | https://discord.com/developers/docs/reference#authentication |
+| `square-production-token` | Square | `EAAA` | 60+ | https://developer.squareup.com/docs/build-basics/access-tokens |
+
+Patterns apply to env values, args, stdout lines, stderr lines, and `allLines`. The same pattern is shared across all five sources; the placeholder records which source it fired in: `<redacted:source:rule-name:N>`.
+
+## Adding a custom rule
+
+If your project uses a credential format not in the bundle, add a custom rule:
+
+```ts
+// shell-cassette.config.mjs
+export default {
+  redact: {
+    customPatterns: [
+      {
+        name: 'my-internal-token',
+        pattern: /MYINT-[A-Z0-9]{32}/,
+        description: 'Internal company API token',
+      },
+    ],
+  },
+}
+```
+
+Notes:
+
+- The `g` flag is normalized internally; supplying a regex with or without `g` works the same.
+- `name` must be lowercase kebab-case (`/^[a-z][a-z0-9-]*$/`). It appears in placeholder strings: `<redacted:source:my-internal-token:N>`.
+- `pattern` may also be a function `(s: string) => string` for advanced cases (e.g., conditional replacement). Function-typed patterns can NOT be position-scanned by `shell-cassette scan`; prefer regex when possible.
+- Custom rules apply to the same five sources as bundled rules.
+
+## Suppressing false positives
+
+If a bundled pattern triggers on a value you know is not a credential (a fake-looking test fixture, a deterministic UUID, etc.), add it to `suppressPatterns`. Suppress patterns are checked FIRST, before bundle and custom rules:
+
+```ts
+// shell-cassette.config.mjs
+export default {
+  redact: {
+    suppressPatterns: [
+      /^FAKE_/,                 // values starting with FAKE_ are exempt from all rules
+      /AKIA0000000000000000/,   // a specific test fixture token
+    ],
+  },
+}
+```
+
+A suppressed value is also exempt from the long-value warning.
+
+## Disabling the bundle
+
+To opt out of bundled detection entirely (custom rules and suppress list still apply):
+
+```ts
+export default {
+  redact: {
+    bundledPatterns: false,
+    customPatterns: [/* your own */],
+  },
+}
+```
+
+This is rarely the right answer. If a single bundled rule misfires, suppress that specific value. Disabling the bundle removes coverage for every other provider.
+
+## Long-value warnings (length-based, not pattern-based)
+
+Values 40+ characters long that did NOT match any rule emit a warning at record time. The warning is logged but the value is NOT redacted; shell-cassette can't pattern-match an unknown shape safely.
+
+The threshold (default 40) and a path heuristic (skip warning when value contains `/`, `\`, `:`, or whitespace) are tunable in config:
+
+```ts
+export default {
+  redact: {
+    warnLengthThreshold: 40,    // default
+    warnPathHeuristic: true,    // default
+  },
+}
+```
+
+The 40-char threshold catches GitHub PATs, OpenAI keys, Stripe restricted, AWS Secret Access Keys without nagging on common path-shaped env vars. Tune lower (e.g., 24) if your workload has shorter unknown-shape secrets; tune higher if you see noise.
+
+## See also
+
+- [README](../README.md) for the redaction credibility section, ack-gate behavior, and pre-commit hook recipe.
+- [troubleshooting.md](troubleshooting.md) for residual risks, scan/re-redact workflows, and when to use `useCassette({ redact: false })`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -169,12 +169,220 @@ The curated list (`TOKEN`, `SECRET`, `PASSWORD`, etc.) catches the common cases.
 
 ## What shell-cassette does NOT redact
 
-Worth being explicit so nothing gets committed by accident:
+shell-cassette v0.4 redacts what it can detect with 100% reliability and warns on suspicious-looking unredacted values. The bundle covers 25 prefix-anchored credential formats (GitHub, AWS access key IDs, Stripe, OpenAI, Anthropic, Slack, npm, etc.; see [docs/redact-patterns.md](redact-patterns.md)) plus curated env-key matching plus your own custom rules. What it doesn't redact is below.
 
-- **stdout content** - if `git log` prints a token, shell-cassette captures it verbatim
-- **stderr content** - same
-- **command args** - `--token=ghp_xxx` lives in `call.args`, not redacted
-- **env vars with non-curated names** - anything not matching a curated keyword stays as-is. shell-cassette emits a warning if the value is over 100 chars, but doesn't redact.
-- **paths in cwd** - `/Users/yourname/projects/foo` stays in the cassette
+### Residual risks and gaps in v0.4 redaction
 
-**Always review cassettes before committing.** Pattern-based detection for stdout/stderr/args (GitHub PATs, AWS keys, Stripe keys, etc.) isn't built yet - review by eye.
+- **AWS Secret Access Keys.** 40-char base64 with no documented prefix. Indistinguishable from generic hashes/UUIDs/build IDs by pattern alone. The long-value warning catches them at length 40+ when the value doesn't look like a path. If you ship cassettes that may contain AWS Secret Access Keys, add them to `redact.envKeys` (so the env value is whole-value redacted by key match) or write a project-specific custom rule.
+- **JWTs.** Many JWTs in the wild are public ID tokens or JWKS responses, not bearer secrets. Bundling JWT detection produces false positives on routine OAuth flows. Opt-in via a custom rule when your JWTs are bearer-shaped:
+  ```ts
+  customPatterns: [{
+    name: 'jwt-bearer',
+    pattern: /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+  }]
+  ```
+- **Encoded credentials.** `Authorization: Basic <base64>` headers and base64-encoded YAML/JSON secrets pass through. shell-cassette doesn't decode. Add a custom rule if your test surface includes them.
+- **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8. Out of scope for v0.4.
+- **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
+- **Subprocess `stdin`.** Not captured in v0.4; nothing on disk to redact. v0.5 will capture stdin and apply the same pipeline.
+
+Each gap has a workaround: long-value warning catches length anomalies, custom rules cover project-specific shapes, suppress patterns silence known fixtures, and `useCassette({ redact: false })` disables the pipeline for cassettes that legitimately need raw values (DO NOT commit those).
+
+### Always run `shell-cassette scan` before committing
+
+The scan CLI walks cassette files (or directories) and reports unredacted findings. Exit code is 1 when any cassette has findings. See "Verifying cassettes are safe" below for the pre-commit hook recipe.
+
+## Verifying cassettes are safe
+
+Run `shell-cassette scan` on every cassette before committing:
+
+```bash
+npx shell-cassette scan tests/__cassettes__/
+```
+
+Exit codes:
+
+- `0` - all cassettes clean
+- `1` - at least one cassette has findings (commit should be blocked)
+- `2` - error (missing path, malformed cassette, conflicting flags)
+
+The scanner reports what `record` mode would have redacted. A clean exit means: every env value with a curated key name is already a placeholder, every bundled pattern that fires on a value in env/args/stdout/stderr/allLines is already a placeholder, and every custom rule you've configured is already applied.
+
+Useful flags:
+
+- `--json` - structured output for CI gating or reporting tools.
+- `--quiet` - suppress stdout (use the exit code only).
+- `--config <path>` - override config discovery.
+- `--no-bundled` - check ONLY user rules and suppress list.
+
+Pair the scan with the [pre-commit hook recipe in the README](../README.md#pre-commit-hook).
+
+## Migrating cassettes when the bundle expands
+
+When you upgrade shell-cassette, run `shell-cassette re-redact` to re-apply the current rules to existing cassettes:
+
+```bash
+npx shell-cassette re-redact tests/__cassettes__/
+```
+
+Idempotent: running twice yields identical output. Existing placeholders are preserved; new findings get counters at `max(existing) + 1` per (source, rule). v1 cassettes are upgraded to v2 in place.
+
+Use `--dry-run` to preview without writing:
+
+```bash
+npx shell-cassette re-redact --dry-run tests/__cassettes__/
+```
+
+Exit codes:
+
+- `0` - no new redactions applied (cassettes already covered)
+- `1` - at least one cassette modified (or would be modified in dry-run)
+- `2` - error
+
+After upgrading, commit the modified cassettes alongside the version bump. Reviewers should diff to confirm only placeholder expansion, not value changes.
+
+## When stdout contains a credential the test asserts on
+
+If your test asserts on stdout content that legitimately contains a credential (e.g., an OAuth flow test that prints a token), the v0.4 default pipeline replaces the credential with a placeholder. The replayed stdout your test sees is the placeholder, not the credential.
+
+Two options, in order of preference:
+
+1. **Restructure the test not to assert on the credential string.** Assert on shape (`/^ghp_[A-Za-z0-9]{36}$/`) or on a different observable (exit code, surrounding text). Most credential-printing tests don't actually need exact-match.
+2. **Disable redaction for that specific cassette via `useCassette({ redact: false })`:**
+   ```ts
+   await useCassette('./cassettes/oauth-flow.json', { redact: false }, async () => {
+     const r = await execa('my-cli', ['login'])
+     expect(r.stdout).toContain('ghp_actual_token_value')
+   })
+   ```
+   The cassette WILL contain plaintext credentials. Do NOT commit it. Add the path to `.gitignore`, or move the cassette outside the repo.
+
+`{ redact: false }` is intentionally per-cassette, not per-stream. shell-cassette doesn't support "redact env but not stdout" scoping; the choice is binary.
+
+## Tests asserting on subprocess side effects (filesystem, network, etc.)
+
+shell-cassette is a VCR-style recorder: it captures what the subprocess returned (stdout, stderr, exit code, signal), not what the subprocess did to the world. If your test runs a subprocess for its side effects, replay returns the recorded result but the side effects do not happen.
+
+**Symptom:** test passes during record, fails during replay with assertion errors on filesystem state, network state, database rows, etc.
+
+```ts
+test('npm install creates node_modules', async () => {
+  await execa('npm', ['install'])
+  expect(existsSync('node_modules')).toBe(true) // FAILS in replay
+})
+```
+
+**Root cause:** the `npm install` recording captures stdout (`added 230 packages`) and exit code 0. On replay, shell-cassette returns that recorded result without spawning npm. `node_modules/` is never created. The `existsSync` assertion sees the non-mutated state.
+
+**Mitigations, in order of preference:**
+
+1. **Refactor the test to assert on stdout, not on side effects.** `expect(stdout).toContain('added 230 packages')`. The recorded subprocess output is what shell-cassette can deliver deterministically.
+2. **Use `SHELL_CASSETTE_MODE=passthrough` for tests that genuinely need real side effects.** This bypasses shell-cassette and runs the real subprocess. You lose determinism for that test but get the actual mutation. Pair with a hermetic temp directory so the side effect is contained.
+3. **Move the side effect outside the cassette session.** Setup code that creates fixtures (e.g., `git init` to initialize a fresh repo) should run as real subprocess work BEFORE any `useCassette` or vitest plugin scope is active. Reserve cassetted calls for the actual code-under-test.
+
+This is not a bug in shell-cassette and not a redaction concern; `useCassette({ redact: false })` does NOT help here (different concern). The VCR model only captures I/O at the subprocess boundary.
+
+## `NoActiveSessionError` from `beforeAll` / `beforeEach` setup
+
+When tests use vitest's `beforeAll` or `beforeEach` to subprocess-set-up fixture state (e.g., `git init` for a temp repo), that setup runs OUTSIDE any active cassette session. The vitest plugin opens a session per `test`, not per setup hook. If the setup imports from `shell-cassette/execa` or `shell-cassette/tinyexec` (or routes through `shellCassetteAlias` from `shell-cassette/vite-plugin`), the wrapper sees no active session.
+
+**Symptom:** `NoActiveSessionError: shell-cassette is in replay mode but no active cassette session is bound`, raised from a `beforeAll` or `beforeEach` body, despite cassettes existing on disk for the test cases.
+
+**Root cause:** setup hooks run before the per-test session opens. With `CI=true` (which forces `replay`), the wrapper refuses to passthrough; it throws.
+
+**Fixes:**
+
+- **Use REAL `tinyexec` / `execa` in setup; reserve the SC-wrapped imports for test bodies.** Import `import { x } from 'tinyexec'` directly inside `beforeAll` for fixture creation; import `import { x } from 'shell-cassette/tinyexec'` in the test files. If you use `shellCassetteAlias` to redirect bare imports, the alias only affects imports under your `tests/` (or wherever the alias is scoped); restructure the alias scope to exclude your fixture-setup files, or import the real package via a path that bypasses the alias.
+- **Set `SHELL_CASSETTE_MODE=passthrough` for setup-only flows.** If a whole test file is fixture-heavy and you don't want any of it cassetted, set the env var at the top of the file or via a setup file that runs before vitest dispatches.
+- **Move the setup into the test body inside `useCassette`.** Tests that need their setup inside a session can call `useCassette` explicitly and place the setup work inside the callback.
+
+This pattern matters most when using `shellCassetteAlias` to retrofit shell-cassette into an existing project: bare imports of `tinyexec` get redirected, and setup helpers can no longer reach the real subprocess unless explicitly carved out.
+
+## Module-level subprocess caches break per-test cassettes
+
+Source code that memoizes a subprocess result at module level (`const hasCorepack = cached(() => x('corepack', ['--version']))`) records into the FIRST test's cassette. If vitest reloads the module per test, replay misses for subsequent tests because the cached call only fires once per module instance.
+
+**Symptom:** tests pass during record, fail intermittently during replay with `ReplayMissError` for a subprocess call your test code does not appear to make directly.
+
+**Root cause:** the cache lives at module scope. The first time the module is imported during a test run, the cached function fires and records into whatever session is active at that moment. Subsequent test sessions don't see that recording in their own cassettes; the cache also doesn't fire again because the module is loaded.
+
+**Mitigations:**
+
+1. **Refactor to avoid module-level subprocess caches.** Move the cache into a per-test-or-per-call lifecycle (e.g., a function arg, a request-scoped object). Cleanest fix.
+2. **`vi.resetModules()` between tests.** Forces vitest to re-import modules, which re-fires the cache once per test inside that test's session. Works but adds overhead.
+3. **Use a single shared cassette per test file.** If the cached subprocess call genuinely should fire once per file, scope cassettes to the file (not the test) so all tests share the same recording. Requires custom path logic.
+
+shell-cassette can't auto-detect this pattern. The `_redactions` schema field and the path resolver work per-recording; a module-level cache is invisible to them. Tracked in [#76](https://github.com/slgoodrich/shell-cassette/issues/76); future work may add a shared-cassette mode.
+
+## Naive `resolve.alias` self-loops; use `shellCassetteAlias`
+
+If you redirect `tinyexec` (or `execa`) imports to shell-cassette's adapter via vite's `resolve.alias`, the naive form self-loops:
+
+```ts
+// BROKEN: shell-cassette's adapter ALSO imports `tinyexec`,
+// the alias catches that import too, infinite loop
+export default defineConfig({
+  resolve: { alias: { tinyexec: 'shell-cassette/tinyexec' } },
+})
+```
+
+shell-cassette ships a vite plugin that adds the importer guard:
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+import { shellCassetteAlias } from 'shell-cassette/vite-plugin'
+
+export default defineConfig({
+  plugins: [shellCassetteAlias({ adapters: ['tinyexec'] })],
+  test: {
+    setupFiles: ['shell-cassette/vitest'],
+  },
+})
+```
+
+The plugin's `resolveId` hook redirects bare `tinyexec` imports from user code, BUT skips redirection when the importer is itself a `shell-cassette/...` file. shell-cassette's internal `import 'tinyexec'` resolves to the real package; user code resolves to the adapter.
+
+`adapters` defaults to `['tinyexec']`. Pass `['execa']` or `['tinyexec', 'execa']` if you wrap the other library or both.
+
+## Cassette path exceeds 240 chars
+
+Windows fails when total path length exceeds 240 chars. shell-cassette's path sanitizer caps test name segments at 80 chars and adds a 6-char hash on collision, but deeply-nested describe blocks plus a long test file path plus a long `cassetteDir` can still overflow.
+
+**Symptom:** error at cassette write time naming the path that exceeded 240 chars.
+
+**Fixes:**
+
+- **Shorten describe / test names.** Cassette path includes describe-chain segments. Three nested 60-char describe blocks alone consume 180 chars.
+- **Shorten `cassetteDir`.** Default is `__cassettes__` (13 chars). If you've configured `tests/integration/__cassettes__/` (32 chars), consider moving cassettes to a shorter root.
+- **Move test files closer to the project root.** A test at `tests/feature.test.ts` produces a shorter cassette path than one at `packages/server/src/__tests__/integration/feature.test.ts`.
+
+A `cassettesRoot` config (project-root-relative cassette directory, decoupling cassette paths from test file location) is tracked in [#81](https://github.com/slgoodrich/shell-cassette/issues/81) for v0.5.
+
+## `xSync` from shell-cassette/tinyexec throws
+
+shell-cassette/tinyexec's `xSync` is a stub that throws a clear error pointing to async `x`:
+
+> shell-cassette/tinyexec.xSync is not yet wrapped (tracked in #82). Sync subprocess wrapping requires synchronous lazy-load support, planned for v0.5.
+
+**Why:** wrapping sync subprocess execution requires synchronous module loading for the peer dep, which shell-cassette doesn't currently support. The async `x` adapter uses top-level await for resolution.
+
+**Options:**
+
+- **Use async `x`** (recommended). Refactor sync call sites to async; you get cassette coverage.
+- **Import `xSync` directly from `tinyexec`.** Those calls bypass shell-cassette and run real subprocess. Acceptable for pre-flight version checks and similar non-determinism-sensitive paths.
+- **Wait for v0.5** ([#82](https://github.com/slgoodrich/shell-cassette/issues/82)).
+
+## `result.process` throws on tinyexec replay
+
+Tests that read `result.process.stdout` (streaming) or `result.process.stderr` (sync inspection) on replay get a clear error:
+
+> result.process is not available in replay mode. shell-cassette synthesizes subprocess results from cassettes; no live ChildProcess exists. Tests that read result.process.stdout / .stderr / .stdin streams must either run with SHELL_CASSETTE_MODE=passthrough, or refactor to read result.stdout / result.stderr (the buffered fields).
+
+**Why:** shell-cassette can't synthesize a live `ChildProcess` from a cassette. The buffered `result.stdout` / `result.stderr` fields ARE synthesized; the live stream object is not.
+
+**Options:**
+
+- **Refactor to use `result.stdout` / `result.stderr`** (the buffered string fields). They contain the full captured output and are deterministic.
+- **`SHELL_CASSETTE_MODE=passthrough`** for tests that genuinely need stream access.
+- **Wait for v0.5**; future work may synthesize a fake stream from buffered output ([#83](https://github.com/slgoodrich/shell-cassette/issues/83)).


### PR DESCRIPTION
## What Changed

### README.md (~280 lines added)

Hero leads with redaction credibility (25 bundled patterns + scan CLI) alongside the speed pitch. New "Redacted by default / Redacted with config / Not redacted (residual risks)" subsections replace the old single Security section; each enumerates exactly what is covered and what is not, with workarounds for each gap. New sections:

- Pre-commit hook (husky + lefthook recipes, exit codes).
- CLI usage covering scan, re-redact, and the ack-gate workflow with example output and common flags.
- Vite/Vitest plugin: redirecting bare imports (`shellCassetteAlias`).
- Adapter quirks calling out exec alias, xSync stub, result.process throwing.
- Migrating from v0.3 (config rename, schema bump, pre-commit hook adoption).
- Common gotchas list expanded for the new failure modes.

### docs/redact-patterns.md (new, 118 lines)

Per-pattern reference table for all 25 bundled rules, with provider doc URLs. Custom-rule and suppress-pattern examples. Bundle-disable explanation. Long-value warning tuning section.

### docs/troubleshooting.md (+222 lines)

Plan-specified additions: "Residual risks and gaps in v0.4 redaction" (AWS Secret Access Keys, JWTs, encoded credentials, binary, cwd, stdin), "Verifying cassettes are safe" (scan CLI), "Migrating cassettes when the bundle expands" (re-redact CLI), "When stdout contains a credential the test asserts on" (`redact:false` workaround).

Validation-finding additions: subprocess side effects, `beforeAll`/`beforeEach` `NoActiveSession`, module-level subprocess caches, `shellCassetteAlias` self-loop pattern, path-too-long fix-side, xSync stub, result.process throwing getter.

### CHANGELOG.md (+43 lines)

v0.4.0 entry with date placeholder (filled at release). Breaking / Added / Changed / Notes structure. Covers schema v2 bump, `redactEnv` removal, `Config.redact` composed shape, 25 bundled patterns, custom rules, suppress list, per-cassette redact override, length-warning tuning, CLI binary, vite-plugin export, tinyexec exec alias and xSync stub, result.process throwing getter, path-too-long propagation.

## Validation findings folded in

- #79 (tests asserting filesystem side effects can't replay) expanded into the broader "Tests asserting on subprocess side effects" section with three mitigation patterns. This PR closes #79.
- #85 (setup helpers split between record/replay) covered by the new "NoActiveSessionError from beforeAll / beforeEach setup" section with three fixes. This PR closes #85.
- #76 partial (module-level subprocess caches break per-test cassettes): new section documents the pattern as a known limitation with three mitigations. Tracked but NOT fully closed; future work may add detection or shared-cassette mode.

## Related Issues

Closes #79, #85.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` passes (53 files, 494 passed, 1 skipped)
- [x] `npm run build` clean
- [x] No em dashes in any of the four files (project hard rule)
- [x] All cross-links between README and docs/* use real anchors
- [x] Code snippets manually traced against current API surface (useCassette signature, Config.redact shape, BUNDLED_PATTERNS export, shellCassetteAlias options, scan/re-redact flag set)