### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-XX-XX
+## [0.4.0] - 2026-04-28
 
 ### BREAKING CHANGES
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-cassette",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-cassette",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-cassette",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Polly.js, but for shell commands. Record subprocess calls once, replay them deterministically forever.",
   "keywords": [
     "subprocess",


### PR DESCRIPTION
## What Changed

v0.4.0 release.

Comprehensive credential redaction infrastructure plus CLI tooling. See [CHANGELOG](CHANGELOG.md#040---2026-04-28) for full notes.

Headlines:

- 25 bundled credential patterns (GitHub family, AWS, Stripe, OpenAI, Anthropic, Google, Slack, GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI, Discord, Square).
- Redaction applies to env values, args, stdout, stderr, allLines (was env-only).
- `shell-cassette` CLI with `scan` (pre-commit safety check) and `re-redact` (re-apply rules to existing cassettes; idempotent, upgrades v1 to v2).
- Schema v2 with `_recorded_by` and per-recording `_redactions` metadata.
- New public exports: `redact`, `BUNDLED_PATTERNS`, redact types.
- New subpath: `shell-cassette/vite-plugin` for the importer-conditioned alias helper.

## Breaking changes

- Schema v2: v0.3 readers reject v2 cassettes with `CassetteCorruptError`. v0.4 reads both. Run `shell-cassette re-redact <path>` to upgrade.
- `redactEnv()` removed; use `redact()`.
- `Config.redactEnvKeys` renamed to `Config.redact.envKeys`.

See README "Migrating from v0.3" callout for migration patterns.

## Validation

- 494 internal tests passing (unit + integration + e2e + property + plugin lifecycle).
- All 25 bundled patterns proven end-to-end against the published tarball.
- Real-world full-coverage validation against `unjs/nypm` (161 tests, 91 cassettes, ~800x test-phase replay speedup), `sveltejs/cli` (4 tests, 4 cassettes, ~17x), and `lerna-lite` (broader 1656-test suite passes 99.5% with the SC tinyexec alias active in passthrough).

## Bugs surfaced and fixed during the cycle

All closed prior to release:

- #73 silent passthrough when path-too-long (vitest plugin)
- #75 CLI bin shim invocation silent exit (npm/pnpm/yarn shims)
- #77 tinyexec adapter exec alias missing
- #82 xSync silent undefined export
- #83 result.process null/TypeError on replay
- #84 vite alias self-loop

## Open issues at ship

Three backlog items:

- #72 broader rule adoption (gitleaks/betterleaks etc)
- #78 length-warning UX (ANSI strip + Windows env suppress)
- #81 cassettesRoot config for deep monorepos

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` passes (494 passed, 1 platform-skip)
- [x] `npm run build` clean
- [x] Binary smoke: `node dist/bin.js --version` prints `0.4.0`
- [x] Binary smoke: scan on clean fixture exits 0; scan on dirty fixture exits 1 with finding

## Notes

Post-merge release flow:

1. Pull main, tag from main: `git tag -a v0.4.0 -m "v0.4.0"` and `git push origin v0.4.0`
2. `npm run build && npm publish`
3. Verify: `npm view shell-cassette version` reports `0.4.0`
4. `gh release create v0.4.0 --notes "v0.4.0 - credential redaction infrastructure. See CHANGELOG."`