### PR TITLE
feat: add SuppressedEntry type and serialize wiring for _suppressed

### DIFF
--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -269,9 +269,7 @@ function reRedactRecording(
       call: { ...rec.call, env, args },
       result: { ...rec.result, stdoutLines, stderrLines, allLines },
       redactions: aggregated,
-      // v0.5: re-redact preserves any prior skip decisions verbatim. The
-      // body re-write skips matches whose hash is in this list (added in
-      // a later milestone); for now, propagate as-is.
+      // suppressed is user intent; never mutated by re-redact.
       suppressed: rec.suppressed,
     },
     newCountInRecording: newCount,

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -269,6 +269,10 @@ function reRedactRecording(
       call: { ...rec.call, env, args },
       result: { ...rec.result, stdoutLines, stderrLines, allLines },
       redactions: aggregated,
+      // v0.5: re-redact preserves any prior skip decisions verbatim. The
+      // body re-write skips matches whose hash is in this list (added in
+      // a later milestone); for now, propagate as-is.
+      suppressed: rec.suppressed,
     },
     newCountInRecording: newCount,
   }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -7,7 +7,7 @@ import type { Call, CassetteSession, Recording, RedactSource, Result } from './t
 export function record(call: Call, result: Result, session: CassetteSession): void {
   if (!session.redactEnabled) {
     // Per-cassette override: bypass the redact pipeline entirely.
-    session.newRecordings.push({ call, result, redactions: [] })
+    session.newRecordings.push({ call, result, redactions: [], suppressed: [] })
     return
   }
 
@@ -25,6 +25,7 @@ export function record(call: Call, result: Result, session: CassetteSession): vo
     call: redactedCall,
     result: redactedResult,
     redactions: aggregated,
+    suppressed: [],
   })
 }
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,5 +1,5 @@
 import { BinaryOutputError, CassetteCorruptError } from './errors.js'
-import type { CassetteFile, Recording, RedactionEntry } from './types.js'
+import type { CassetteFile, Recording, RedactionEntry, SuppressedEntry } from './types.js'
 
 const SCHEMA_VERSION = 2
 
@@ -37,7 +37,7 @@ export function serialize(file: CassetteFile): string {
 }
 
 function orderRecording(rec: Recording) {
-  return {
+  const ordered: Record<string, unknown> = {
     call: {
       command: rec.call.command,
       args: rec.call.args,
@@ -56,6 +56,12 @@ function orderRecording(rec: Recording) {
     },
     _redactions: rec.redactions,
   }
+  // Omit _suppressed when empty: saves ~20 bytes per recording for the
+  // common case (cassettes that have not been through review).
+  if (rec.suppressed.length > 0) {
+    ordered._suppressed = rec.suppressed
+  }
+  return ordered
 }
 
 function validateBeforeSerialize(file: CassetteFile): void {
@@ -132,8 +138,9 @@ export function deserialize(text: string): CassetteFile {
   }
 }
 
-// On disk, `allLines`, `aborted`, and `_redactions` may be absent (cassettes
-// recorded before those fields existed). All default during normalization.
+// On disk, `allLines`, `aborted`, `_redactions`, and `_suppressed` may be
+// absent (cassettes recorded before those fields existed). All default
+// during normalization.
 type LegacyRecording = {
   call: Recording['call']
   result: Omit<Recording['result'], 'allLines' | 'aborted'> & {
@@ -141,6 +148,7 @@ type LegacyRecording = {
     aborted?: boolean
   }
   _redactions?: RedactionEntry[]
+  _suppressed?: SuppressedEntry[]
 }
 
 function normalizeRecording(rec: LegacyRecording): Recording {
@@ -152,9 +160,6 @@ function normalizeRecording(rec: LegacyRecording): Recording {
       aborted: rec.result.aborted ?? false,
     },
     redactions: rec._redactions ?? [],
-    // v0.5: `_suppressed` round-trip is wired in a later milestone (M2/M3
-    // schema add). For now, default to `[]` on load so v0.4 cassettes
-    // (and v0.5 recordings until persistence lands) load cleanly.
-    suppressed: [],
+    suppressed: rec._suppressed ?? [],
   }
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -152,5 +152,9 @@ function normalizeRecording(rec: LegacyRecording): Recording {
       aborted: rec.result.aborted ?? false,
     },
     redactions: rec._redactions ?? [],
+    // v0.5: `_suppressed` round-trip is wired in a later milestone (M2/M3
+    // schema add). For now, default to `[]` on load so v0.4 cassettes
+    // (and v0.5 recordings until persistence lands) load cleanly.
+    suppressed: [],
   }
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -37,7 +37,7 @@ export function serialize(file: CassetteFile): string {
 }
 
 function orderRecording(rec: Recording) {
-  const ordered: Record<string, unknown> = {
+  return {
     call: {
       command: rec.call.command,
       args: rec.call.args,
@@ -55,13 +55,8 @@ function orderRecording(rec: Recording) {
       aborted: rec.result.aborted,
     },
     _redactions: rec.redactions,
+    ...(rec.suppressed.length > 0 ? { _suppressed: rec.suppressed } : {}),
   }
-  // Omit _suppressed when empty: saves ~20 bytes per recording for the
-  // common case (cassettes that have not been through review).
-  if (rec.suppressed.length > 0) {
-    ordered._suppressed = rec.suppressed
-  }
-  return ordered
 }
 
 function validateBeforeSerialize(file: CassetteFile): void {
@@ -138,9 +133,8 @@ export function deserialize(text: string): CassetteFile {
   }
 }
 
-// On disk, `allLines`, `aborted`, `_redactions`, and `_suppressed` may be
-// absent (cassettes recorded before those fields existed). All default
-// during normalization.
+// Fields added after the v2 schema landed are optional on disk;
+// normalizeRecording fills defaults.
 type LegacyRecording = {
   call: Recording['call']
   result: Omit<Recording['result'], 'allLines' | 'aborted'> & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,14 @@ export type Recording = {
    * computation without walking the body.
    */
   redactions: RedactionEntry[]
+  /**
+   * Per-recording skip decisions written by `shell-cassette review`'s
+   * `(s)kip` action. v0.5 additive on v2 schema; v0.4 cassettes load with
+   * `[]`. Consulted by `re-redact` and `review`'s pre-scan: any match
+   * whose `matchHash` is in this list is left as-is in the body and not
+   * re-flagged.
+   */
+  suppressed: SuppressedEntry[]
 }
 
 export type CassetteFile = {
@@ -78,6 +86,24 @@ export type RedactionEntry = {
   rule: string // matches RedactRule.name
   source: RedactSource
   count: number // number of placeholder occurrences for this (source, rule) in this recording
+}
+
+/**
+ * One entry per match that the user explicitly chose to skip during
+ * `shell-cassette review`. Persisted as the `_suppressed` JSON field on
+ * each cassette recording. Both `re-redact` and `review`'s own pre-scan
+ * consult this list and skip matches whose `matchHash` appears in any
+ * recording's `suppressed` array, so the user's prior decision sticks
+ * across runs.
+ *
+ * `position` is informational only (used by `show` and review's listing).
+ * Skip semantics key off `matchHash`, not position.
+ */
+export type SuppressedEntry = {
+  source: RedactSource
+  rule: string // matches RedactRule.name; or 'custom' for replace decisions
+  position: string // source-specific: '<line>:<col>' | '<argIndex>:<col>' | '<KEY>:<col>'
+  matchHash: string // 'sha256:<64 hex chars>'
 }
 
 export type RedactConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,10 +34,8 @@ export type Recording = {
   redactions: RedactionEntry[]
   /**
    * Per-recording skip decisions written by `shell-cassette review`'s
-   * `(s)kip` action. v0.5 additive on v2 schema; v0.4 cassettes load with
-   * `[]`. Consulted by `re-redact` and `review`'s pre-scan: any match
-   * whose `matchHash` is in this list is left as-is in the body and not
-   * re-flagged.
+   * `(s)kip` action. `re-redact` and `review`'s pre-scan skip any match
+   * whose `matchHash` appears here, so user decisions stick across runs.
    */
   suppressed: SuppressedEntry[]
 }
@@ -90,11 +88,9 @@ export type RedactionEntry = {
 
 /**
  * One entry per match that the user explicitly chose to skip during
- * `shell-cassette review`. Persisted as the `_suppressed` JSON field on
- * each cassette recording. Both `re-redact` and `review`'s own pre-scan
- * consult this list and skip matches whose `matchHash` appears in any
- * recording's `suppressed` array, so the user's prior decision sticks
- * across runs.
+ * `shell-cassette review`. `re-redact` and `review`'s pre-scan skip
+ * matches whose `matchHash` appears in any recording's `suppressed`
+ * array, so the user's prior decision sticks across runs.
  *
  * `position` is informational only (used by `show` and review's listing).
  * Skip semantics key off `matchHash`, not position.

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -36,4 +36,5 @@ export const recordingOf = (
     ...resultOverrides,
   },
   redactions: [],
+  suppressed: [],
 })

--- a/tests/helpers/recording.ts
+++ b/tests/helpers/recording.ts
@@ -37,6 +37,7 @@ export function makeRecording(
     },
     result: makeResult(resultOverrides),
     redactions: [],
+    suppressed: [],
     ...rest,
   }
 }

--- a/tests/integration/recorder-redact.test.ts
+++ b/tests/integration/recorder-redact.test.ts
@@ -143,6 +143,7 @@ describe('recorder applies redaction across all 5 sources', () => {
             aborted: false,
           },
           redactions: [{ rule: 'github-pat-classic', source: 'args', count: 3 }],
+          suppressed: [],
         },
       ],
     }

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -38,7 +38,12 @@ const dummyResult: Result = {
   aborted: false,
 }
 
-const recOf = (call: Call): Recording => ({ call, result: dummyResult, redactions: [] })
+const recOf = (call: Call): Recording => ({
+  call,
+  result: dummyResult,
+  redactions: [],
+  suppressed: [],
+})
 
 describe('normalizeTmpPath properties', () => {
   test('idempotence: normalizeTmpPath(normalizeTmpPath(s)) === normalizeTmpPath(s)', () => {

--- a/tests/property/re-redact-idempotence.property.test.ts
+++ b/tests/property/re-redact-idempotence.property.test.ts
@@ -46,6 +46,7 @@ const recordingArb: fc.Arbitrary<Recording> = fc.record({
   call: callArb,
   result: resultArb,
   redactions: fc.constant([]),
+  suppressed: fc.constant([]),
 })
 
 const cassetteArb: fc.Arbitrary<CassetteFile> = fc.record({

--- a/tests/property/redact.property.test.ts
+++ b/tests/property/redact.property.test.ts
@@ -248,6 +248,7 @@ const recordingArb: fc.Arbitrary<Recording> = fc.record({
     aborted: fc.boolean(),
   }),
   redactions: fc.array(redactionEntryArb, { maxLength: 4 }),
+  suppressed: fc.constant([]),
 })
 
 const cassetteArb: fc.Arbitrary<CassetteFile> = fc.record({

--- a/tests/property/scan-record-symmetry.property.test.ts
+++ b/tests/property/scan-record-symmetry.property.test.ts
@@ -232,6 +232,7 @@ describe('env-key-match symmetry: opaque values under curated env keys are repor
           aborted: false,
         },
         redactions: [],
+        suppressed: [],
       }
       const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [recording] }
       await writeCassetteFile(cassettePath, serialize(cassette))

--- a/tests/property/scan-record-symmetry.property.test.ts
+++ b/tests/property/scan-record-symmetry.property.test.ts
@@ -78,6 +78,7 @@ function buildCassette(source: RedactSource, value: string): CassetteFile {
       aborted: false,
     },
     redactions: [],
+    suppressed: [],
   }
   return { version: 2, recordedBy: null, recordings: [recording] }
 }
@@ -181,6 +182,7 @@ describe('per-source coverage: github-pat-classic across all 5 sources', () => {
         aborted: false,
       },
       redactions: [],
+      suppressed: [],
     }
     const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [recording] }
     await writeCassetteFile(cassettePath, serialize(cassette))

--- a/tests/property/serialize.property.test.ts
+++ b/tests/property/serialize.property.test.ts
@@ -69,6 +69,7 @@ const genRecording: fc.Arbitrary<Recording> = fc.record({
   call: genCall,
   result: genResult,
   redactions: fc.array(genRedactionEntry, { maxLength: 3 }),
+  suppressed: fc.constant([]),
 })
 
 // fc.tuple(int, int, int).map(([M, m, p]) => `${M}.${m}.${p}`) generates

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -437,6 +437,7 @@ const emptyRec = (): CassetteFile['recordings'][number] => ({
     aborted: false,
   },
   redactions: [],
+  suppressed: [],
 })
 
 describe('seedCountersFromCassette', () => {
@@ -564,6 +565,7 @@ describe('seedCountersFromCassette', () => {
             aborted: false,
           },
           redactions: [{ rule: 'r', source: 'env', count: 2 }],
+          suppressed: [],
         },
         {
           call: { command: 'curl', args: [], cwd: null, env: {}, stdin: null },
@@ -577,6 +579,7 @@ describe('seedCountersFromCassette', () => {
             aborted: false,
           },
           redactions: [{ rule: 'r', source: 'env', count: 5 }],
+          suppressed: [],
         },
       ],
     }

--- a/tests/unit/serialize-suppressed.test.ts
+++ b/tests/unit/serialize-suppressed.test.ts
@@ -1,60 +1,38 @@
 import { describe, expect, test } from 'vitest'
 import { deserialize, serialize } from '../../src/serialize.js'
 import type { CassetteFile, SuppressedEntry } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
 
-describe('serialize/deserialize: _suppressed field (v0.5 additive)', () => {
-  const baseRecording = {
-    call: {
-      command: 'gh',
-      args: ['repo', 'view'],
-      cwd: null,
-      env: {},
-      stdin: null,
-    },
-    result: {
-      stdoutLines: ['ok'],
-      stderrLines: [],
-      allLines: null,
-      exitCode: 0,
-      signal: null,
-      durationMs: 100,
-      aborted: false,
-    },
-    redactions: [],
-  }
+describe('serialize/deserialize: _suppressed field', () => {
+  const baseRecording = makeRecording({
+    call: { command: 'gh', args: ['repo', 'view'], cwd: null, env: {}, stdin: null },
+    result: { stdoutLines: ['ok'], durationMs: 100 },
+  })
 
   test('serialize emits _suppressed when non-empty', () => {
     const suppressed: SuppressedEntry[] = [
-      {
-        source: 'stdout',
-        rule: 'github-pat-classic',
-        position: '1:5',
-        matchHash: 'sha256:abc123',
-      },
+      { source: 'stdout', rule: 'github-pat-classic', position: '1:5', matchHash: 'sha256:abc123' },
     ]
     const file: CassetteFile = {
       version: 2,
       recordedBy: { name: 'shell-cassette', version: '0.5.0' },
       recordings: [{ ...baseRecording, suppressed }],
     }
-    const json = serialize(file)
-    const parsed = JSON.parse(json)
+    const parsed = JSON.parse(serialize(file))
     expect(parsed.recordings[0]._suppressed).toEqual(suppressed)
   })
 
-  test('serialize OMITS _suppressed when empty (saves bytes)', () => {
+  test('serialize omits _suppressed when empty', () => {
     const file: CassetteFile = {
       version: 2,
       recordedBy: { name: 'shell-cassette', version: '0.5.0' },
-      recordings: [{ ...baseRecording, suppressed: [] }],
+      recordings: [baseRecording],
     }
-    const json = serialize(file)
-    const parsed = JSON.parse(json)
+    const parsed = JSON.parse(serialize(file))
     expect('_suppressed' in parsed.recordings[0]).toBe(false)
   })
 
   test('deserialize defaults missing _suppressed to []', () => {
-    // Simulates a v0.4 cassette that predates the field
     const v04Json = JSON.stringify({
       version: 2,
       _recorded_by: { name: 'shell-cassette', version: '0.4.0' },

--- a/tests/unit/serialize-suppressed.test.ts
+++ b/tests/unit/serialize-suppressed.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { deserialize, serialize } from '../../src/serialize.js'
+import type { CassetteFile, SuppressedEntry } from '../../src/types.js'
+
+describe('serialize/deserialize: _suppressed field (v0.5 additive)', () => {
+  const baseRecording = {
+    call: {
+      command: 'gh',
+      args: ['repo', 'view'],
+      cwd: null,
+      env: {},
+      stdin: null,
+    },
+    result: {
+      stdoutLines: ['ok'],
+      stderrLines: [],
+      allLines: null,
+      exitCode: 0,
+      signal: null,
+      durationMs: 100,
+      aborted: false,
+    },
+    redactions: [],
+  }
+
+  test('serialize emits _suppressed when non-empty', () => {
+    const suppressed: SuppressedEntry[] = [
+      {
+        source: 'stdout',
+        rule: 'github-pat-classic',
+        position: '1:5',
+        matchHash: 'sha256:abc123',
+      },
+    ]
+    const file: CassetteFile = {
+      version: 2,
+      recordedBy: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [{ ...baseRecording, suppressed }],
+    }
+    const json = serialize(file)
+    const parsed = JSON.parse(json)
+    expect(parsed.recordings[0]._suppressed).toEqual(suppressed)
+  })
+
+  test('serialize OMITS _suppressed when empty (saves bytes)', () => {
+    const file: CassetteFile = {
+      version: 2,
+      recordedBy: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [{ ...baseRecording, suppressed: [] }],
+    }
+    const json = serialize(file)
+    const parsed = JSON.parse(json)
+    expect('_suppressed' in parsed.recordings[0]).toBe(false)
+  })
+
+  test('deserialize defaults missing _suppressed to []', () => {
+    // Simulates a v0.4 cassette that predates the field
+    const v04Json = JSON.stringify({
+      version: 2,
+      _recorded_by: { name: 'shell-cassette', version: '0.4.0' },
+      recordings: [
+        {
+          call: baseRecording.call,
+          result: baseRecording.result,
+          _redactions: [],
+        },
+      ],
+    })
+    const file = deserialize(v04Json)
+    expect(file.recordings[0].suppressed).toEqual([])
+  })
+
+  test('round-trip preserves non-empty _suppressed', () => {
+    const suppressed: SuppressedEntry[] = [
+      { source: 'args', rule: 'openai-api-key', position: '0:8', matchHash: 'sha256:xyz' },
+      { source: 'stdout', rule: 'custom', position: '3:0', matchHash: 'sha256:def' },
+    ]
+    const file: CassetteFile = {
+      version: 2,
+      recordedBy: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [{ ...baseRecording, suppressed }],
+    }
+    const round = deserialize(serialize(file))
+    expect(round.recordings[0].suppressed).toEqual(suppressed)
+  })
+})

--- a/tests/unit/serialize-v2.test.ts
+++ b/tests/unit/serialize-v2.test.ts
@@ -19,6 +19,7 @@ const minimalV2: CassetteFile = {
         aborted: false,
       },
       redactions: [],
+      suppressed: [],
     },
   ],
 }


### PR DESCRIPTION
## What Changed

Additive schema field that the `review` subcommand needs (and that `re-redact` will consult).

- `SuppressedEntry` type added to `src/types.ts`. Four fields: `source`, `rule`, `position`, `matchHash` (sha256 hex).
- `Recording.suppressed: SuppressedEntry[]` required field, additive sibling to `redactions`. Populated as `[]` at every construction site.
- JSON wiring: `orderRecording` emits `_suppressed` only when non-empty (saves bytes for cassettes that have not been through review). `normalizeRecording` defaults to `[]` for cassettes that predate the field.
- No schema version bump (stays at v2, additive). Older readers ignore the new key; newer readers populate it.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` green
- [x] `npm test` (494 passed, 1 skipped (pre-existing); 4 new tests in `tests/unit/serialize-suppressed.test.ts`)
- [x] `npm run build` clean

## Notes

The new tests cover: serialize emits `_suppressed` when non-empty, omits when empty, deserialize tolerates missing field, round-trip preserves entries.