### PR TITLE
feat: pipeline skips matches by sha256 hash; re-redact wires _suppressed consultation

### DIFF
--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -15,7 +15,11 @@ import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { writeCassetteFile } from './io.js'
 import { loadCassette } from './loader.js'
 import { redact } from './redact.js'
-import { aggregateEntries, seedCountersFromCassette } from './redact-pipeline.js'
+import {
+  aggregateEntries,
+  collectSuppressedHashes,
+  seedCountersFromCassette,
+} from './redact-pipeline.js'
 import { serialize } from './serialize.js'
 import type { CassetteFile, Recording, RedactConfig, RedactionEntry } from './types.js'
 import { RECORDED_BY } from './version.js'
@@ -193,11 +197,20 @@ export async function reRedactOne(
   // Seed counters from existing placeholders so new findings continue the
   // per-(source, rule) sequence rather than restarting at 1.
   const counters = seedCountersFromCassette(cassette)
+  // User-suppressed match hashes (from `shell-cassette review` skip decisions)
+  // bypass the pipeline so re-redact never re-flags a value the user explicitly
+  // chose to leave verbatim.
+  const suppressedHashes = collectSuppressedHashes(cassette)
   let newCount = 0
   const updatedRecordings: Recording[] = []
 
   for (const rec of cassette.recordings) {
-    const { recording, newCountInRecording } = reRedactRecording(rec, config, counters)
+    const { recording, newCountInRecording } = reRedactRecording(
+      rec,
+      config,
+      counters,
+      suppressedHashes,
+    )
     updatedRecordings.push(recording)
     newCount += newCountInRecording
   }
@@ -218,34 +231,51 @@ function reRedactRecording(
   rec: Recording,
   config: Readonly<RedactConfig>,
   counters: Map<string, number>,
+  suppressedHashes: ReadonlySet<string>,
 ): { recording: Recording; newCountInRecording: number } {
   const newEntries: RedactionEntry[] = []
   let newCount = 0
 
   const env: Record<string, string> = {}
   for (const [key, value] of Object.entries(rec.call.env)) {
-    const r = redact({ source: 'env', value }, config, { counted: true, counters })
+    const r = redact({ source: 'env', value }, config, {
+      counted: true,
+      counters,
+      suppressedHashes,
+    })
     env[key] = r.output
     newEntries.push(...r.entries)
     newCount += r.entries.reduce((s, e) => s + e.count, 0)
   }
 
   const args = rec.call.args.map((arg) => {
-    const r = redact({ source: 'args', value: arg }, config, { counted: true, counters })
+    const r = redact({ source: 'args', value: arg }, config, {
+      counted: true,
+      counters,
+      suppressedHashes,
+    })
     newEntries.push(...r.entries)
     newCount += r.entries.reduce((s, e) => s + e.count, 0)
     return r.output
   })
 
   const stdoutLines = rec.result.stdoutLines.map((line) => {
-    const r = redact({ source: 'stdout', value: line }, config, { counted: true, counters })
+    const r = redact({ source: 'stdout', value: line }, config, {
+      counted: true,
+      counters,
+      suppressedHashes,
+    })
     newEntries.push(...r.entries)
     newCount += r.entries.reduce((s, e) => s + e.count, 0)
     return r.output
   })
 
   const stderrLines = rec.result.stderrLines.map((line) => {
-    const r = redact({ source: 'stderr', value: line }, config, { counted: true, counters })
+    const r = redact({ source: 'stderr', value: line }, config, {
+      counted: true,
+      counters,
+      suppressedHashes,
+    })
     newEntries.push(...r.entries)
     newCount += r.entries.reduce((s, e) => s + e.count, 0)
     return r.output
@@ -253,7 +283,11 @@ function reRedactRecording(
 
   const allLines =
     rec.result.allLines?.map((line) => {
-      const r = redact({ source: 'allLines', value: line }, config, { counted: true, counters })
+      const r = redact({ source: 'allLines', value: line }, config, {
+        counted: true,
+        counters,
+        suppressedHashes,
+      })
       newEntries.push(...r.entries)
       newCount += r.entries.reduce((s, e) => s + e.count, 0)
       return r.output

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -15,7 +15,6 @@
  * Output format is locked at scanVersion: 1. See spec Section 4 for the
  * complete --json shape.
  */
-import { createHash } from 'node:crypto'
 import { color, isTty, previewMatch, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
@@ -23,7 +22,7 @@ import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
-import { ENV_KEY_MATCH_RULE, REDACTION_PLACEHOLDER_PATTERN } from './redact-pipeline.js'
+import { ENV_KEY_MATCH_RULE, matchHash, REDACTION_PLACEHOLDER_PATTERN } from './redact-pipeline.js'
 import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
 
 const SCAN_VERSION = 1
@@ -300,7 +299,7 @@ function findingsForRecording(
         source: 'env',
         rule: ENV_KEY_MATCH_RULE,
         match: includeMatch ? value : undefined,
-        matchHash: `sha256:${createHash('sha256').update(value).digest('hex')}`,
+        matchHash: matchHash(value),
         matchLength: value.length,
         matchPreview: previewMatch(value),
       })
@@ -375,7 +374,7 @@ function scanValue(
         source,
         rule: rule.name,
         match: includeMatch ? matchStr : undefined,
-        matchHash: `sha256:${createHash('sha256').update(matchStr).digest('hex')}`,
+        matchHash: matchHash(matchStr),
         matchLength: matchStr.length,
         matchPreview: previewMatch(matchStr),
       })

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -311,3 +311,21 @@ export function aggregateEntries(entries: readonly RedactionEntry[]): RedactionE
   }
   return [...map.values()]
 }
+
+/**
+ * Build a `Set<string>` of `matchHash` values across every recording's
+ * `suppressed` array. Returned set is suitable to pass into
+ * `RedactOptions.suppressedHashes` so the pipeline skips emission for
+ * matches the user previously chose to skip during `shell-cassette review`.
+ *
+ * Callers: re-redact (every recording's pass) and review (pre-scan + applyDecisions).
+ */
+export function collectSuppressedHashes(cassette: CassetteFile): Set<string> {
+  const out = new Set<string>()
+  for (const rec of cassette.recordings) {
+    for (const entry of rec.suppressed) {
+      out.add(entry.matchHash)
+    }
+  }
+  return out
+}

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -170,8 +170,7 @@ function applyRegexRule(
   // pattern is guaranteed to have g flag (caller ensures it)
   const result = text.replace(pattern, (match) => {
     if (options.suppressedHashes !== undefined) {
-      const hash = `sha256:${createHash('sha256').update(match).digest('hex')}`
-      if (options.suppressedHashes.has(hash)) {
+      if (options.suppressedHashes.has(matchHash(match))) {
         return match // leave verbatim; do not increment counter, do not emit entry
       }
     }
@@ -310,6 +309,17 @@ export function aggregateEntries(entries: readonly RedactionEntry[]): RedactionE
     }
   }
   return [...map.values()]
+}
+
+/**
+ * Content-addressed identity for a redaction match. Producers (scan,
+ * review's pre-scan) write this format into cassette `_suppressed` entries;
+ * consumers (re-redact, review's pre-scan, the pipeline's per-match skip
+ * check) compare against the same format. Single source of truth so
+ * producer and consumer can never drift.
+ */
+export function matchHash(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`
 }
 
 /**

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { ShellCassetteError } from './errors.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
 import type {
@@ -22,8 +23,16 @@ export type RedactInput = {
  * Per `.claude/rules/error_handling.md` "Internal Invariants": restructure
  * types so unreachable states can't be expressed in preference to runtime
  * non-null assertions.
+ *
+ * `suppressedHashes` is optional. When provided, the pipeline computes
+ * sha256 of each match span and skips emission if the hash is in the
+ * set. The recorder and canonicalize callers pass undefined; re-redact
+ * and review's pre-scan pass populated sets built from cassette
+ * `_suppressed` entries.
  */
-export type RedactOptions = { counted: false } | { counted: true; counters: Map<string, number> }
+export type RedactOptions =
+  | { counted: false; suppressedHashes?: ReadonlySet<string> }
+  | { counted: true; counters: Map<string, number>; suppressedHashes?: ReadonlySet<string> }
 
 export type RedactOutput = {
   output: string
@@ -109,6 +118,9 @@ export function runPipeline(
   }
 
   for (const rule of config.customPatterns) {
+    // Function-typed custom rules can't expose individual match spans, so
+    // suppressedHashes does not apply to them. Users who need per-match
+    // skip semantics must use regex-typed rules.
     if (typeof rule.pattern === 'function') {
       const transformed = rule.pattern(output)
       if (transformed !== output) {
@@ -156,7 +168,13 @@ function applyRegexRule(
 ): string {
   let count = 0
   // pattern is guaranteed to have g flag (caller ensures it)
-  const result = text.replace(pattern, () => {
+  const result = text.replace(pattern, (match) => {
+    if (options.suppressedHashes !== undefined) {
+      const hash = `sha256:${createHash('sha256').update(match).digest('hex')}`
+      if (options.suppressedHashes.has(hash)) {
+        return match // leave verbatim; do not increment counter, do not emit entry
+      }
+    }
     count++
     if (options.counted) {
       const key = `${source}:${ruleName}`

--- a/tests/cli/scan.test.ts
+++ b/tests/cli/scan.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { runScan } from '../../src/cli-scan.js'
+import { matchHash } from '../../src/redact-pipeline.js'
 import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
 import { restoreEnv } from '../helpers/env.js'
 
@@ -199,11 +200,7 @@ describe('runScan: matchHash correctness', () => {
     const parsed = JSON.parse(stdoutBuf)
     const finding = parsed.cassettes[0].findings[0]
     // Verify hash independently
-    const { createHash } = await import('node:crypto')
-    const expected = `sha256:${createHash('sha256')
-      .update(finding.match as string)
-      .digest('hex')}`
-    expect(finding.matchHash).toBe(expected)
+    expect(finding.matchHash).toBe(matchHash(finding.match as string))
   })
 })
 

--- a/tests/integration/suppressed-respected.test.ts
+++ b/tests/integration/suppressed-respected.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { reRedactOne } from '../../src/cli-re-redact.js'
-import { collectSuppressedHashes } from '../../src/redact-pipeline.js'
+import { collectSuppressedHashes, matchHash } from '../../src/redact-pipeline.js'
 import { deserialize } from '../../src/serialize.js'
 import type { RedactConfig } from '../../src/types.js'
 
@@ -15,20 +15,19 @@ afterEach(async () => {
   await rm(tmp, { recursive: true, force: true })
 })
 
-const baseConfig: Readonly<RedactConfig> = Object.freeze({
+const baseConfig: RedactConfig = {
   bundledPatterns: true,
   customPatterns: [],
   suppressPatterns: [],
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
-})
+}
 
 describe('re-redact respects _suppressed', () => {
   test('a match whose hash is in _suppressed stays unflagged after re-redact', async () => {
     const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
-    const { createHash } = await import('node:crypto')
-    const hash = `sha256:${createHash('sha256').update(pat).digest('hex')}`
+    const hash = matchHash(pat)
     const cassettePath = path.join(tmp, 'fixture.json')
     const cassette = {
       version: 2,
@@ -68,8 +67,7 @@ describe('re-redact respects _suppressed', () => {
   test('a match NOT in _suppressed still gets re-redacted normally', async () => {
     const skippedPat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
     const otherPat = 'ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-    const { createHash } = await import('node:crypto')
-    const skippedHash = `sha256:${createHash('sha256').update(skippedPat).digest('hex')}`
+    const skippedHash = matchHash(skippedPat)
     const cassettePath = path.join(tmp, 'fixture.json')
     const cassette = {
       version: 2,

--- a/tests/integration/suppressed-respected.test.ts
+++ b/tests/integration/suppressed-respected.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { reRedactOne } from '../../src/cli-re-redact.js'
+import { collectSuppressedHashes } from '../../src/redact-pipeline.js'
+import { deserialize } from '../../src/serialize.js'
+import type { RedactConfig } from '../../src/types.js'
+
+let tmp: string
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-suppressed-'))
+})
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+const baseConfig: Readonly<RedactConfig> = Object.freeze({
+  bundledPatterns: true,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+})
+
+describe('re-redact respects _suppressed', () => {
+  test('a match whose hash is in _suppressed stays unflagged after re-redact', async () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const { createHash } = await import('node:crypto')
+    const hash = `sha256:${createHash('sha256').update(pat).digest('hex')}`
+    const cassettePath = path.join(tmp, 'fixture.json')
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [
+        {
+          call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [pat],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+          _suppressed: [
+            { source: 'stdout', rule: 'github-pat-classic', position: '1:0', matchHash: hash },
+          ],
+        },
+      ],
+    }
+    await writeFile(cassettePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const result = await reRedactOne(cassettePath, baseConfig, false)
+    expect(result.modified).toBe(false)
+    expect(result.newRedactions).toBe(0)
+
+    const loaded = deserialize(await readFile(cassettePath, 'utf8'))
+    expect(loaded.recordings[0]?.result.stdoutLines[0]).toBe(pat)
+    expect(loaded.recordings[0]?.suppressed).toHaveLength(1)
+    expect(collectSuppressedHashes(loaded).has(hash)).toBe(true)
+  })
+
+  test('a match NOT in _suppressed still gets re-redacted normally', async () => {
+    const skippedPat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const otherPat = 'ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+    const { createHash } = await import('node:crypto')
+    const skippedHash = `sha256:${createHash('sha256').update(skippedPat).digest('hex')}`
+    const cassettePath = path.join(tmp, 'fixture.json')
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [
+        {
+          call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [skippedPat, otherPat],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+          _suppressed: [
+            {
+              source: 'stdout',
+              rule: 'github-pat-classic',
+              position: '1:0',
+              matchHash: skippedHash,
+            },
+          ],
+        },
+      ],
+    }
+    await writeFile(cassettePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const result = await reRedactOne(cassettePath, baseConfig, false)
+    expect(result.modified).toBe(true)
+    expect(result.newRedactions).toBe(1)
+
+    const loaded = deserialize(await readFile(cassettePath, 'utf8'))
+    expect(loaded.recordings[0]?.result.stdoutLines[0]).toBe(skippedPat) // skip held
+    expect(loaded.recordings[0]?.result.stdoutLines[1]).toContain('<redacted:') // other got placeholder
+  })
+})

--- a/tests/unit/redact-suppressed.test.ts
+++ b/tests/unit/redact-suppressed.test.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto'
 import { describe, expect, test } from 'vitest'
-import { runPipeline } from '../../src/redact-pipeline.js'
-import type { RedactConfig } from '../../src/types.js'
+import { collectSuppressedHashes, runPipeline } from '../../src/redact-pipeline.js'
+import type { CassetteFile, RedactConfig } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
 
 const minimalConfig: Readonly<RedactConfig> = Object.freeze({
   bundledPatterns: true,
@@ -53,5 +54,56 @@ describe('runPipeline: suppressedHashes', () => {
       suppressedHashes: new Set([sha256(pat)]),
     })
     expect(counters.get('stdout:github-pat-classic')).toBe(5) // unchanged
+  })
+})
+
+describe('collectSuppressedHashes', () => {
+  test('returns empty set for cassette with no _suppressed entries', () => {
+    const file: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [makeRecording()],
+    }
+    expect(collectSuppressedHashes(file).size).toBe(0)
+  })
+
+  test('collects hashes across all recordings', () => {
+    const file: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          suppressed: [
+            { source: 'stdout', rule: 'r1', position: '1:0', matchHash: 'sha256:aaa' },
+            { source: 'stdout', rule: 'r2', position: '2:0', matchHash: 'sha256:bbb' },
+          ],
+        }),
+        makeRecording({
+          suppressed: [{ source: 'args', rule: 'r3', position: '0:0', matchHash: 'sha256:ccc' }],
+        }),
+      ],
+    }
+    const set = collectSuppressedHashes(file)
+    expect(set.size).toBe(3)
+    expect(set.has('sha256:aaa')).toBe(true)
+    expect(set.has('sha256:bbb')).toBe(true)
+    expect(set.has('sha256:ccc')).toBe(true)
+  })
+
+  test('deduplicates the same hash appearing in multiple recordings', () => {
+    const file: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          suppressed: [{ source: 'stdout', rule: 'r', position: '1:0', matchHash: 'sha256:dup' }],
+        }),
+        makeRecording({
+          suppressed: [{ source: 'args', rule: 'r', position: '0:0', matchHash: 'sha256:dup' }],
+        }),
+      ],
+    }
+    const set = collectSuppressedHashes(file)
+    expect(set.size).toBe(1)
   })
 })

--- a/tests/unit/redact-suppressed.test.ts
+++ b/tests/unit/redact-suppressed.test.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, test } from 'vitest'
+import { runPipeline } from '../../src/redact-pipeline.js'
+import type { RedactConfig } from '../../src/types.js'
+
+const minimalConfig: Readonly<RedactConfig> = Object.freeze({
+  bundledPatterns: true,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+})
+
+const sha256 = (s: string) => `sha256:${createHash('sha256').update(s).digest('hex')}`
+
+describe('runPipeline: suppressedHashes', () => {
+  // GitHub PAT classic shape: ghp_ + 36 alphanumerics
+  const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+  const value = `prefix ${pat} suffix`
+
+  test('without suppressedHashes, the bundled rule fires and replaces the PAT', () => {
+    const out = runPipeline({ source: 'stdout', value }, minimalConfig, { counted: false })
+    expect(out.output).not.toContain(pat)
+    expect(out.output).toContain('<redacted:stdout:github-pat-classic>')
+    expect(out.entries.length).toBe(1)
+  })
+
+  test('with the PAT hash in suppressedHashes, the bundled rule SKIPS that match', () => {
+    const out = runPipeline({ source: 'stdout', value }, minimalConfig, {
+      counted: false,
+      suppressedHashes: new Set([sha256(pat)]),
+    })
+    expect(out.output).toBe(value) // unchanged
+    expect(out.entries.length).toBe(0) // no entries emitted
+  })
+
+  test('a different hash in suppressedHashes does NOT skip an unrelated match', () => {
+    const out = runPipeline({ source: 'stdout', value }, minimalConfig, {
+      counted: false,
+      suppressedHashes: new Set([sha256('something-else')]),
+    })
+    expect(out.output).not.toContain(pat)
+    expect(out.entries.length).toBe(1)
+  })
+
+  test('counted mode + suppressedHashes: counter is NOT incremented for skipped matches', () => {
+    const counters = new Map<string, number>()
+    counters.set('stdout:github-pat-classic', 5) // pretend ceiling was 5
+    runPipeline({ source: 'stdout', value }, minimalConfig, {
+      counted: true,
+      counters,
+      suppressedHashes: new Set([sha256(pat)]),
+    })
+    expect(counters.get('stdout:github-pat-classic')).toBe(5) // unchanged
+  })
+})

--- a/tests/unit/redact-suppressed.test.ts
+++ b/tests/unit/redact-suppressed.test.ts
@@ -1,19 +1,16 @@
-import { createHash } from 'node:crypto'
 import { describe, expect, test } from 'vitest'
-import { collectSuppressedHashes, runPipeline } from '../../src/redact-pipeline.js'
+import { collectSuppressedHashes, matchHash, runPipeline } from '../../src/redact-pipeline.js'
 import type { CassetteFile, RedactConfig } from '../../src/types.js'
 import { makeRecording } from '../helpers/recording.js'
 
-const minimalConfig: Readonly<RedactConfig> = Object.freeze({
+const minimalConfig: RedactConfig = {
   bundledPatterns: true,
   customPatterns: [],
   suppressPatterns: [],
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
-})
-
-const sha256 = (s: string) => `sha256:${createHash('sha256').update(s).digest('hex')}`
+}
 
 describe('runPipeline: suppressedHashes', () => {
   // GitHub PAT classic shape: ghp_ + 36 alphanumerics
@@ -30,7 +27,7 @@ describe('runPipeline: suppressedHashes', () => {
   test('with the PAT hash in suppressedHashes, the bundled rule SKIPS that match', () => {
     const out = runPipeline({ source: 'stdout', value }, minimalConfig, {
       counted: false,
-      suppressedHashes: new Set([sha256(pat)]),
+      suppressedHashes: new Set([matchHash(pat)]),
     })
     expect(out.output).toBe(value) // unchanged
     expect(out.entries.length).toBe(0) // no entries emitted
@@ -39,7 +36,7 @@ describe('runPipeline: suppressedHashes', () => {
   test('a different hash in suppressedHashes does NOT skip an unrelated match', () => {
     const out = runPipeline({ source: 'stdout', value }, minimalConfig, {
       counted: false,
-      suppressedHashes: new Set([sha256('something-else')]),
+      suppressedHashes: new Set([matchHash('something-else')]),
     })
     expect(out.output).not.toContain(pat)
     expect(out.entries.length).toBe(1)
@@ -51,7 +48,7 @@ describe('runPipeline: suppressedHashes', () => {
     runPipeline({ source: 'stdout', value }, minimalConfig, {
       counted: true,
       counters,
-      suppressedHashes: new Set([sha256(pat)]),
+      suppressedHashes: new Set([matchHash(pat)]),
     })
     expect(counters.get('stdout:github-pat-classic')).toBe(5) // unchanged
   })


### PR DESCRIPTION
## What Changed

The runtime opt-in that lets `re-redact` (and later `review`) skip matches whose hash the user previously chose to suppress.

- `RedactOptions.suppressedHashes?: ReadonlySet<string>`: optional discriminated-union field. When provided, the pipeline computes `sha256:<hex>` of each match span and skips emission entirely (no counter bump, no entry pushed) if the hash is in the set. The recorder/canonicalize hot paths pass undefined and behave identically. Function-typed custom rules can't honor the set (no individual match spans); documented inline.
- `collectSuppressedHashes(cassette)`: pure helper that walks every recording's `suppressed[]` array and returns a `Set<string>` of `matchHash` values. Suitable to pass directly into `RedactOptions.suppressedHashes`.
- `re-redact` wiring: `reRedactOne` builds the set once via `collectSuppressedHashes` and threads it through `reRedactRecording`. Every `redact(...)` call (env, args, stdout, stderr, allLines) passes `suppressedHashes`. The recording's `suppressed` field is preserved verbatim on write; re-redact never mutates user skip decisions.
- `matchHash(value)`: extracted helper in `redact-pipeline.ts`. Producer (scan: writes hashes into findings) and consumer (pipeline: reads them back to compare) now share a single source of truth. Also replaces hand-rolled `sha256:<hex>` literals across three test files and hoists a pre-existing dynamic `node:crypto` import in `tests/cli/scan.test.ts` to a static import.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (507 passed, 1 skipped)
- [x] `npm run build` clean

New tests:

- `tests/unit/redact-suppressed.test.ts` (7 total): pipeline baseline, skip on PAT hash, no-skip on unrelated hash, counter unchanged in counted mode + skip; empty / multi-recording / dedup for the helper.
- `tests/integration/suppressed-respected.test.ts` (2): match in `_suppressed` survives re-redact verbatim; un-suppressed match alongside still gets a placeholder.