### PR TITLE
feat(cli): add cli-prompt helpers (promptAction, promptText, promptYesNo)

### DIFF
--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -1,0 +1,82 @@
+/**
+ * Interactive prompt helpers used by `shell-cassette review`. Wraps Node's
+ * built-in `node:readline/promises` (stdlib; no npm dependency).
+ *
+ * The reader is a settable module-level singleton so unit tests can inject
+ * a fake without spawning a subprocess. Production code calls `getReader()`
+ * which lazily constructs a real readline interface bound to process.stdin
+ * and process.stdout.
+ *
+ * Prompt strings are explicitly NOT API. Bots should use `--json` modes for
+ * automation; do not parse interactive prompt text. Action keys (which are
+ * read from user input) ARE API and locked.
+ */
+import * as readline from 'node:readline/promises'
+import { stderr } from './cli-output.js'
+
+export type Reader = {
+  question(prompt: string): Promise<string>
+  close(): void
+}
+
+let _reader: Reader | null = null
+
+function getReader(): Reader {
+  if (_reader !== null) return _reader
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  _reader = {
+    question: (q) => rl.question(q),
+    close: () => rl.close(),
+  }
+  return _reader
+}
+
+/**
+ * Override the prompt reader. Tests inject a fake `Reader` to avoid
+ * subprocess spawning. Pass `null` to reset (closing the previous reader
+ * if it owned a real readline interface).
+ */
+export function setReader(reader: Reader | null): void {
+  if (_reader !== null && reader === null) {
+    _reader.close()
+  }
+  _reader = reader
+}
+
+/**
+ * Prompt for an action key from the `allowed` list (e.g. `['a', 's', 'q', '?']`).
+ * Case-insensitive; leading/trailing whitespace ignored. Re-prompts on
+ * unknown input. Returns the lowercased key.
+ */
+export async function promptAction(allowed: readonly string[]): Promise<string> {
+  const allowedSet = new Set(allowed.map((s) => s.toLowerCase()))
+  const prompt = `Action? (${allowed.join('/')})\n> `
+  const reader = getReader()
+  while (true) {
+    const line = await reader.question(prompt)
+    const trimmed = line.trim().toLowerCase()
+    if (allowedSet.has(trimmed)) return trimmed
+    stderr(`(unknown action: '${trimmed}'; expected one of ${allowed.join(', ')})`)
+  }
+}
+
+/** Prompt for free-text input. Returns the trimmed string. */
+export async function promptText(label: string): Promise<string> {
+  const reader = getReader()
+  const line = await reader.question(`${label}\n> `)
+  return line.trim()
+}
+
+/**
+ * Prompt for yes/no. Default is no (empty input returns false). Accepts
+ * `y`/`yes`/`n`/`no` case-insensitively; re-prompts on anything else.
+ */
+export async function promptYesNo(label: string): Promise<boolean> {
+  const reader = getReader()
+  while (true) {
+    const ans = (await reader.question(`${label} (y/N)\n> `)).trim().toLowerCase()
+    if (ans === '' || ans === 'n' || ans === 'no') return false
+    if (ans === 'y' || ans === 'yes') return true
+    stderr('(expected y or n)')
+  }
+}

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -6,10 +6,6 @@
  * a fake without spawning a subprocess. Production code calls `getReader()`
  * which lazily constructs a real readline interface bound to process.stdin
  * and process.stdout.
- *
- * Prompt strings are explicitly NOT API. Bots should use `--json` modes for
- * automation; do not parse interactive prompt text. Action keys (which are
- * read from user input) ARE API and locked.
  */
 import * as readline from 'node:readline/promises'
 import { stderr } from './cli-output.js'
@@ -33,11 +29,11 @@ function getReader(): Reader {
 
 /**
  * Override the prompt reader. Tests inject a fake `Reader` to avoid
- * subprocess spawning. Pass `null` to reset (closing the previous reader
- * if it owned a real readline interface).
+ * subprocess spawning. Pass `null` to reset. Closes the active reader
+ * before replacing or clearing it.
  */
 export function setReader(reader: Reader | null): void {
-  if (_reader !== null && reader === null) {
+  if (_reader !== null && _reader !== reader) {
     _reader.close()
   }
   _reader = reader
@@ -56,7 +52,7 @@ export async function promptAction(allowed: readonly string[]): Promise<string> 
     const line = await reader.question(prompt)
     const trimmed = line.trim().toLowerCase()
     if (allowedSet.has(trimmed)) return trimmed
-    stderr(`(unknown action: '${trimmed}'; expected one of ${allowed.join(', ')})`)
+    stderr(`(unknown action: '${trimmed}'; expected one of ${allowed.join('/')})`)
   }
 }
 

--- a/tests/unit/cli-prompt.test.ts
+++ b/tests/unit/cli-prompt.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  promptAction,
+  promptText,
+  promptYesNo,
+  type Reader,
+  setReader,
+} from '../../src/cli-prompt.js'
+
+function makeReader(answers: string[]): Reader {
+  const queue = [...answers]
+  return {
+    question: vi.fn(async () => {
+      const next = queue.shift()
+      if (next === undefined) throw new Error('reader: no more answers queued')
+      return next
+    }),
+    close: vi.fn(),
+  }
+}
+
+afterEach(() => {
+  setReader(null)
+})
+
+describe('promptAction', () => {
+  test('returns the lowercased trimmed key when valid', async () => {
+    setReader(makeReader([' A ']))
+    expect(await promptAction(['a', 's', 'q'])).toBe('a')
+  })
+
+  test('re-prompts on invalid key', async () => {
+    setReader(makeReader(['x', 'q']))
+    expect(await promptAction(['a', 's', 'q'])).toBe('q')
+  })
+
+  test('accepts the special help key `?`', async () => {
+    setReader(makeReader(['?']))
+    expect(await promptAction(['a', 's', 'q', '?'])).toBe('?')
+  })
+})
+
+describe('promptText', () => {
+  test('returns trimmed input', async () => {
+    setReader(makeReader(['  hello world  ']))
+    expect(await promptText('Replacement:')).toBe('hello world')
+  })
+
+  test('returns empty string when user just hits enter', async () => {
+    setReader(makeReader(['']))
+    expect(await promptText('Replacement:')).toBe('')
+  })
+})
+
+describe('promptYesNo', () => {
+  test('y returns true', async () => {
+    setReader(makeReader(['y']))
+    expect(await promptYesNo('OK?')).toBe(true)
+  })
+
+  test('yes returns true', async () => {
+    setReader(makeReader(['YES']))
+    expect(await promptYesNo('OK?')).toBe(true)
+  })
+
+  test('empty input returns false (default-no)', async () => {
+    setReader(makeReader(['']))
+    expect(await promptYesNo('OK?')).toBe(false)
+  })
+
+  test('n returns false', async () => {
+    setReader(makeReader(['n']))
+    expect(await promptYesNo('OK?')).toBe(false)
+  })
+
+  test('re-prompts on garbage input', async () => {
+    setReader(makeReader(['lol', 'maybe', 'y']))
+    expect(await promptYesNo('OK?')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What Changed

Interactive prompt helpers wrapping `node:readline/promises` (stdlib; no npm deps). Used by the upcoming `review` subcommand for action keys (a/s/r/d/b/q/?), free-text input (replace), and yes/no confirms.

- `promptAction(allowed)`: case-insensitive trimmed key match against the allowed list; re-prompts on unknown input with feedback to stderr; returns the lowercased key.
- `promptText(label)`: single-shot read; returns the trimmed line.
- `promptYesNo(label)`: accepts `y`/`yes`/`n`/`no` case-insensitively; empty input is default-no; re-prompts on garbage.
- `Reader` type + `setReader()`: settable singleton so unit tests inject a fake `Reader` (`vi.fn`-backed) without spawning subprocesses. Matches the project's existing `let _state: T | null = null` pattern from `src/state.ts`. Production code never calls `setReader`; the lazy `getReader()` constructs a real readline interface bound to process.stdin/stdout on first use.

The module ships standalone; no consumers yet. The `review` subcommand will import these helpers in a follow-up PR.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (508 passed, 1 skipped; 498 baseline + 10 new)
- [x] `npm run build` clean

10 new tests in `tests/unit/cli-prompt.test.ts` cover: action key trim/lowercase, action re-prompt on invalid, action accepts `?`, text trim, text empty, yes-no for `y`/`yes`/`empty`/`n`, yes-no re-prompts on garbage. The `makeReader(answers)` factory queues responses and throws on exhaustion so test failures are crisp.