### PR TITLE
feat: add review subcommand for interactive credential walkthrough

### DIFF
--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -43,6 +43,15 @@ export const isTty = {
 }
 
 /**
+ * Wire up color output for a CLI subcommand from its `--no-color` /
+ * `--color=always` flag. Reads stdout TTY state and the NO_COLOR env var
+ * (via shouldUseColor) and toggles the module-global color state.
+ */
+export function setupCliColor(override: ColorOverride): void {
+  color.setEnabled(isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override }))
+}
+
+/**
  * Produce a credential-safe preview: short values are shown verbatim;
  * values >= 12 chars show the first 4 characters, ellipsis, and last 4 characters.
  * Used to hint at a match without exposing the full credential value.

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -8,7 +8,7 @@
  * max(existing) + 1 per (source, rule). v1 cassettes are upgraded to v2
  * in place.
  */
-import { color, isTty, stderr, stdout } from './cli-output.js'
+import { color, setupCliColor, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
 import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
@@ -126,9 +126,7 @@ export async function runReRedact(args: readonly string[]): Promise<number> {
     return 2
   }
 
-  color.setEnabled(
-    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
-  )
+  setupCliColor(flags.colorOverride)
 
   const config = flags.configPath
     ? await loadConfigFromFile(flags.configPath)

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -257,3 +257,103 @@ function buildContext(
     after: [...after],
   }
 }
+
+export type Decision =
+  | { kind: 'accept' }
+  | { kind: 'skip' }
+  | { kind: 'replace'; with: string }
+  | { kind: 'delete'; recordingIndex: number }
+
+export type ReviewState = {
+  readonly findings: readonly Finding[]
+  readonly cursor: number
+  readonly decisions: ReadonlyMap<string, Decision>
+  readonly step: 'reviewing' | 'confirming' | 'done' | 'aborted'
+}
+
+export type ReviewAction =
+  | { kind: 'accept' }
+  | { kind: 'skip' }
+  | { kind: 'replace'; with: string }
+  | { kind: 'delete' }
+  | { kind: 'back' }
+  | { kind: 'quit' }
+  | { kind: 'apply' }
+  | { kind: 'discard' }
+
+/**
+ * Pure state-machine transition. Returns a new ReviewState reflecting the
+ * supplied action. No I/O. Tests drive this directly.
+ *
+ * Reviewing-step rules:
+ *   - accept/skip: record decision, advance cursor by 1.
+ *   - replace: record decision (with user-provided string), advance by 1.
+ *   - delete: record decision targeted at the recording, then advance the
+ *     cursor past every remaining finding in the same recording (those
+ *     findings are moot because the recording is gone).
+ *   - back: decrement cursor and remove the prior decision so the user
+ *     must re-decide. No-op at cursor 0.
+ *   - quit: transition to 'aborted' (decisions discarded by caller).
+ *
+ * When the cursor advances past the last finding, the step transitions to
+ * 'confirming'. From 'confirming':
+ *   - apply: transition to 'done' with decisions intact (caller writes).
+ *   - discard: transition to 'done' with decisions cleared.
+ */
+export function applyAction(state: ReviewState, action: ReviewAction): ReviewState {
+  if (state.step !== 'reviewing' && state.step !== 'confirming') {
+    return state // already done/aborted; no further transitions
+  }
+
+  if (action.kind === 'quit') {
+    return { ...state, step: 'aborted' }
+  }
+  if (action.kind === 'apply') {
+    if (state.step !== 'confirming') return state
+    return { ...state, step: 'done' }
+  }
+  if (action.kind === 'discard') {
+    if (state.step !== 'confirming') return state
+    return { ...state, step: 'done', decisions: new Map() }
+  }
+
+  // From here on, only valid in 'reviewing' step
+  if (state.step !== 'reviewing') return state
+
+  if (action.kind === 'back') {
+    if (state.cursor === 0) return state
+    const newCursor = state.cursor - 1
+    // biome-ignore lint/style/noNonNullAssertion: newCursor in [0, findings.length)
+    const priorId = state.findings[newCursor]!.id
+    const newDecisions = new Map(state.decisions)
+    newDecisions.delete(priorId)
+    return { ...state, cursor: newCursor, decisions: newDecisions }
+  }
+
+  // biome-ignore lint/style/noNonNullAssertion: cursor in [0, findings.length) when reviewing
+  const current = state.findings[state.cursor]!
+  const newDecisions = new Map(state.decisions)
+  let advanceTo = state.cursor + 1
+
+  if (action.kind === 'accept') {
+    newDecisions.set(current.id, { kind: 'accept' })
+  } else if (action.kind === 'skip') {
+    newDecisions.set(current.id, { kind: 'skip' })
+  } else if (action.kind === 'replace') {
+    newDecisions.set(current.id, { kind: 'replace', with: action.with })
+  } else if (action.kind === 'delete') {
+    newDecisions.set(current.id, { kind: 'delete', recordingIndex: current.recordingIndex })
+    // Advance past every remaining finding in the same recording (moot once deleted)
+    while (
+      advanceTo < state.findings.length &&
+      // biome-ignore lint/style/noNonNullAssertion: bounded by length check
+      state.findings[advanceTo]!.recordingIndex === current.recordingIndex
+    ) {
+      advanceTo++
+    }
+  }
+
+  const newStep: ReviewState['step'] =
+    advanceTo >= state.findings.length ? 'confirming' : 'reviewing'
+  return { ...state, cursor: advanceTo, decisions: newDecisions, step: newStep }
+}

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -12,8 +12,14 @@
  * change. Prompt strings are NOT API.
  */
 import { previewMatch } from './cli-output.js'
+import { matchesEnvKeyList } from './recorder.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
-import { collectSuppressedHashes, matchHash } from './redact-pipeline.js'
+import {
+  collectSuppressedHashes,
+  ENV_KEY_MATCH_RULE,
+  matchHash,
+  REDACTION_PLACEHOLDER_PATTERN,
+} from './redact-pipeline.js'
 import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
 
 export type Finding = {
@@ -104,6 +110,31 @@ function scanRecording(
   const findings: Finding[] = []
 
   for (const [key, value] of Object.entries(rec.call.env)) {
+    // env-key-match: if the key matches the curated/user envKeys list, the
+    // recorder would have redacted the whole value regardless of pattern.
+    // Review must report this so cassettes that would have been redacted by
+    // record mode aren't falsely shown as clean. Skip if the value is already
+    // a redaction placeholder (don't double-report) or if its hash is
+    // suppressed.
+    if (matchesEnvKeyList(key, config.envKeys) && !REDACTION_PLACEHOLDER_PATTERN.test(value)) {
+      const hash = matchHash(value)
+      if (!skipSet.has(hash)) {
+        const position = `${key}:0`
+        findings.push({
+          id: `rec${index}-env-${position}-${ENV_KEY_MATCH_RULE}`,
+          recordingIndex: index,
+          source: 'env',
+          rule: ENV_KEY_MATCH_RULE,
+          match: value,
+          matchHash: hash,
+          matchLength: value.length,
+          matchPreview: previewMatch(value),
+          position,
+          context: { lineNumber: 1, before: [], line: value, after: [] },
+        })
+      }
+      continue // don't also pattern-scan; whole value is already sensitive
+    }
     findings.push(...scanValue(value, 'env', key, index, rules, config, skipSet, [], 1))
   }
 

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -1,0 +1,228 @@
+/**
+ * `shell-cassette review` subcommand. Interactive walkthrough of unredacted
+ * findings. Per-finding decisions: (a)ccept / (s)kip / (r)eplace / (d)elete /
+ * (b)ack / (q)uit / (?). Decisions are batched in a pure state machine and
+ * applied to the cassette on confirm.
+ *
+ * Output modes:
+ *   - default: interactive terminal walk
+ *   - --json: read-only structured listing of findings (locked at reviewVersion: 1)
+ *
+ * Action keys (a/s/r/d/b/q/?) are API-locked. Renames would be a breaking
+ * change. Prompt strings are NOT API.
+ */
+import { previewMatch } from './cli-output.js'
+import { BUNDLED_PATTERNS } from './redact-patterns.js'
+import { collectSuppressedHashes, matchHash } from './redact-pipeline.js'
+import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
+
+export type Finding = {
+  /** Stable ID: `rec<recordingIndex>-<source>-<position>-<rule>` */
+  id: string
+  recordingIndex: number
+  source: RedactSource
+  rule: string
+  /** Raw match (always populated; review --json without --include-match strips it before emit). */
+  match: string
+  /** `sha256:<64 hex>` — used for skip-set membership across runs. */
+  matchHash: string
+  matchLength: number
+  /** First-4 + ellipsis + last-4 if length >= 12, else full match. */
+  matchPreview: string
+  /** Source-specific position label: `<line>:<col>` | `<argIndex>:<col>` | `<KEY>:<col>` */
+  position: string
+  /** Surrounding lines for human-readable display. lineNumber is 1-based. */
+  context: {
+    lineNumber: number
+    before: string[]
+    line: string
+    after: string[]
+  }
+}
+
+const CONTEXT_RADIUS = 2
+
+/**
+ * Walk every recording and produce review findings. Reuses the same
+ * regex-based detection as scan, with two differences:
+ *   1. Each finding includes context lines surrounding the match for
+ *      terminal display.
+ *   2. Matches whose hash appears in any recording's `suppressed` array
+ *      are skipped — the user already chose to skip them.
+ */
+export function preScan(cassette: CassetteFile, config: Readonly<RedactConfig>): Finding[] {
+  const skipSet = collectSuppressedHashes(cassette)
+  const rules = buildGFlaggedRules(config)
+  const findings: Finding[] = []
+  for (let i = 0; i < cassette.recordings.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+    findings.push(...scanRecording(cassette.recordings[i]!, i, rules, config, skipSet))
+  }
+  return findings
+}
+
+function buildGFlaggedRules(
+  config: Readonly<RedactConfig>,
+): readonly { name: string; pattern: RegExp }[] {
+  const rules: { name: string; pattern: RegExp }[] = []
+  if (config.bundledPatterns) {
+    for (const rule of BUNDLED_PATTERNS) {
+      if (rule.pattern instanceof RegExp) {
+        const flags = rule.pattern.flags.includes('g')
+          ? rule.pattern.flags
+          : `${rule.pattern.flags}g`
+        rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
+      }
+    }
+  }
+  for (const rule of config.customPatterns) {
+    if (rule.pattern instanceof RegExp) {
+      const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`
+      rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
+    }
+    // Function-typed custom patterns can't expose individual match spans for
+    // position-precise findings; same gap as cli-scan.
+  }
+  return rules
+}
+
+function isSuppressedValue(value: string, config: Readonly<RedactConfig>): boolean {
+  for (const sup of config.suppressPatterns) {
+    sup.lastIndex = 0
+    if (sup.test(value)) return true
+  }
+  return false
+}
+
+function scanRecording(
+  rec: Recording,
+  index: number,
+  rules: readonly { name: string; pattern: RegExp }[],
+  config: Readonly<RedactConfig>,
+  skipSet: ReadonlySet<string>,
+): Finding[] {
+  const findings: Finding[] = []
+
+  for (const [key, value] of Object.entries(rec.call.env)) {
+    findings.push(...scanValue(value, 'env', key, index, rules, config, skipSet, [], 1))
+  }
+
+  for (const [argIdx, arg] of rec.call.args.entries()) {
+    findings.push(
+      ...scanValue(arg, 'args', argIdx.toString(), index, rules, config, skipSet, [], 1),
+    )
+  }
+
+  for (let lineIdx = 0; lineIdx < rec.result.stdoutLines.length; lineIdx++) {
+    findings.push(
+      ...scanValue(
+        // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+        rec.result.stdoutLines[lineIdx]!,
+        'stdout',
+        (lineIdx + 1).toString(),
+        index,
+        rules,
+        config,
+        skipSet,
+        rec.result.stdoutLines,
+        lineIdx + 1,
+      ),
+    )
+  }
+
+  for (let lineIdx = 0; lineIdx < rec.result.stderrLines.length; lineIdx++) {
+    findings.push(
+      ...scanValue(
+        // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+        rec.result.stderrLines[lineIdx]!,
+        'stderr',
+        (lineIdx + 1).toString(),
+        index,
+        rules,
+        config,
+        skipSet,
+        rec.result.stderrLines,
+        lineIdx + 1,
+      ),
+    )
+  }
+
+  if (rec.result.allLines !== null) {
+    for (let lineIdx = 0; lineIdx < rec.result.allLines.length; lineIdx++) {
+      findings.push(
+        ...scanValue(
+          // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+          rec.result.allLines[lineIdx]!,
+          'allLines',
+          (lineIdx + 1).toString(),
+          index,
+          rules,
+          config,
+          skipSet,
+          rec.result.allLines,
+          lineIdx + 1,
+        ),
+      )
+    }
+  }
+
+  return findings
+}
+
+function scanValue(
+  value: string,
+  source: RedactSource,
+  positionLabel: string,
+  recordingIndex: number,
+  rules: readonly { name: string; pattern: RegExp }[],
+  config: Readonly<RedactConfig>,
+  skipSet: ReadonlySet<string>,
+  contextLines: readonly string[],
+  lineNumber: number,
+): Finding[] {
+  if (isSuppressedValue(value, config)) return []
+  const findings: Finding[] = []
+  for (const rule of rules) {
+    rule.pattern.lastIndex = 0
+    for (const m of value.matchAll(rule.pattern)) {
+      const matchStr = m[0]
+      const hash = matchHash(matchStr)
+      if (skipSet.has(hash)) continue
+      const col = m.index ?? 0
+      const position = `${positionLabel}:${col}`
+      findings.push({
+        id: `rec${recordingIndex}-${source}-${position}-${rule.name}`,
+        recordingIndex,
+        source,
+        rule: rule.name,
+        match: matchStr,
+        matchHash: hash,
+        matchLength: matchStr.length,
+        matchPreview: previewMatch(matchStr),
+        position,
+        context: buildContext(contextLines, lineNumber, value),
+      })
+    }
+  }
+  return findings
+}
+
+function buildContext(
+  lines: readonly string[],
+  lineNumber: number,
+  fallbackLine: string,
+): Finding['context'] {
+  if (lines.length === 0) {
+    return { lineNumber, before: [], line: fallbackLine, after: [] }
+  }
+  const idx = lineNumber - 1
+  const before = lines.slice(Math.max(0, idx - CONTEXT_RADIUS), idx)
+  const after = lines.slice(idx + 1, Math.min(lines.length, idx + 1 + CONTEXT_RADIUS))
+  return {
+    lineNumber,
+    before: [...before],
+    // biome-ignore lint/style/noNonNullAssertion: idx is in range by construction
+    line: lines[idx]!,
+    after: [...after],
+  }
+}

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -11,7 +11,14 @@
  * Action keys (a/s/r/d/b/q/?) are API-locked. Renames would be a breaking
  * change. Prompt strings are NOT API.
  */
-import { applyTruncation, color, isTty, previewMatch, stderr, stdout } from './cli-output.js'
+import {
+  applyTruncation,
+  color,
+  previewMatch,
+  setupCliColor,
+  stderr,
+  stdout,
+} from './cli-output.js'
 import { promptAction, promptText, promptYesNo } from './cli-prompt.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
 import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
@@ -19,11 +26,12 @@ import { writeCassetteFile } from './io.js'
 import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
 import { redact } from './redact.js'
-import { BUNDLED_PATTERNS } from './redact-patterns.js'
 import {
   aggregateEntries,
+  buildGFlaggedRules,
   collectSuppressedHashes,
   ENV_KEY_MATCH_RULE,
+  isSuppressedValue,
   matchHash,
   REDACTION_PLACEHOLDER_PATTERN,
   seedCountersFromCassette,
@@ -82,39 +90,6 @@ export function preScan(cassette: CassetteFile, config: Readonly<RedactConfig>):
     findings.push(...scanRecording(cassette.recordings[i]!, i, rules, config, skipSet))
   }
   return findings
-}
-
-function buildGFlaggedRules(
-  config: Readonly<RedactConfig>,
-): readonly { name: string; pattern: RegExp }[] {
-  const rules: { name: string; pattern: RegExp }[] = []
-  if (config.bundledPatterns) {
-    for (const rule of BUNDLED_PATTERNS) {
-      if (rule.pattern instanceof RegExp) {
-        const flags = rule.pattern.flags.includes('g')
-          ? rule.pattern.flags
-          : `${rule.pattern.flags}g`
-        rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
-      }
-    }
-  }
-  for (const rule of config.customPatterns) {
-    if (rule.pattern instanceof RegExp) {
-      const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`
-      rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
-    }
-    // Function-typed custom patterns can't expose individual match spans for
-    // position-precise findings; same gap as cli-scan.
-  }
-  return rules
-}
-
-function isSuppressedValue(value: string, config: Readonly<RedactConfig>): boolean {
-  for (const sup of config.suppressPatterns) {
-    sup.lastIndex = 0
-    if (sup.test(value)) return true
-  }
-  return false
 }
 
 function scanRecording(
@@ -468,55 +443,27 @@ export function applyDecisions(
     }
 
     const newRedactEntries: RedactionEntry[] = []
+    const redactValue = (source: RedactSource, value: string): string => {
+      const r = redact({ source, value }, config, {
+        counted: true,
+        counters,
+        suppressedHashes: skipSet,
+      })
+      newRedactEntries.push(...r.entries)
+      return r.output
+    }
+
     const env: Record<string, string> = {}
     for (const [key, value] of Object.entries(rec.call.env)) {
-      const r = redact({ source: 'env', value }, config, {
-        counted: true,
-        counters,
-        suppressedHashes: skipSet,
-      })
-      env[key] = r.output
-      newRedactEntries.push(...r.entries)
+      env[key] = redactValue('env', value)
     }
-    const args = rec.call.args.map((arg) => {
-      const r = redact({ source: 'args', value: arg }, config, {
-        counted: true,
-        counters,
-        suppressedHashes: skipSet,
-      })
-      newRedactEntries.push(...r.entries)
-      return r.output
-    })
-    const stdoutLines = rec.result.stdoutLines.map((line) => {
-      const r = redact({ source: 'stdout', value: line }, config, {
-        counted: true,
-        counters,
-        suppressedHashes: skipSet,
-      })
-      newRedactEntries.push(...r.entries)
-      return r.output
-    })
-    const stderrLines = rec.result.stderrLines.map((line) => {
-      const r = redact({ source: 'stderr', value: line }, config, {
-        counted: true,
-        counters,
-        suppressedHashes: skipSet,
-      })
-      newRedactEntries.push(...r.entries)
-      return r.output
-    })
+    const args = rec.call.args.map((arg) => redactValue('args', arg))
+    const stdoutLines = rec.result.stdoutLines.map((line) => redactValue('stdout', line))
+    const stderrLines = rec.result.stderrLines.map((line) => redactValue('stderr', line))
     const allLines =
       rec.result.allLines === null
         ? null
-        : rec.result.allLines.map((line) => {
-            const r = redact({ source: 'allLines', value: line }, config, {
-              counted: true,
-              counters,
-              suppressedHashes: skipSet,
-            })
-            newRedactEntries.push(...r.entries)
-            return r.output
-          })
+        : rec.result.allLines.map((line) => redactValue('allLines', line))
 
     const newSuppressed: SuppressedEntry[] = [...rec.suppressed]
     for (const { finding, decision } of localDecisions) {
@@ -686,9 +633,7 @@ export async function runReview(args: readonly string[]): Promise<number> {
     return 2
   }
 
-  color.setEnabled(
-    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
-  )
+  setupCliColor(flags.colorOverride)
 
   let cassette: CassetteFile
   try {

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -267,6 +267,12 @@ export type Decision =
 export type ReviewState = {
   readonly findings: readonly Finding[]
   readonly cursor: number
+  /**
+   * Stack of cursors saved before each forward advance. `back` pops from
+   * here so multi-step jumps (e.g. `delete`'s contiguous-recording skip)
+   * unwind to the actual prior decision point — not just `cursor - 1`.
+   */
+  readonly history: readonly number[]
   readonly decisions: ReadonlyMap<string, Decision>
   readonly step: 'reviewing' | 'confirming' | 'done' | 'aborted'
 }
@@ -291,8 +297,11 @@ export type ReviewAction =
  *   - delete: record decision targeted at the recording, then advance the
  *     cursor past every remaining finding in the same recording (those
  *     findings are moot because the recording is gone).
- *   - back: decrement cursor and remove the prior decision so the user
- *     must re-decide. No-op at cursor 0.
+ *   - back: pop the prior cursor from history and rewind to it, removing
+ *     every decision recorded in the unwound range so the user must
+ *     re-decide. Empty history is a no-op (start of review or already
+ *     fully unwound). Allowed from 'confirming' too — pops back to
+ *     'reviewing' at the last decided finding.
  *   - quit: transition to 'aborted' (decisions discarded by caller).
  *
  * When the cursor advances past the last finding, the step transitions to
@@ -317,18 +326,30 @@ export function applyAction(state: ReviewState, action: ReviewAction): ReviewSta
     return { ...state, step: 'done', decisions: new Map() }
   }
 
-  // From here on, only valid in 'reviewing' step
-  if (state.step !== 'reviewing') return state
-
   if (action.kind === 'back') {
-    if (state.cursor === 0) return state
-    const newCursor = state.cursor - 1
-    // biome-ignore lint/style/noNonNullAssertion: newCursor in [0, findings.length)
-    const priorId = state.findings[newCursor]!.id
+    if (state.history.length === 0) return state
+    // biome-ignore lint/style/noNonNullAssertion: history.length > 0 guarantees last element
+    const newCursor = state.history[state.history.length - 1]!
+    const newHistory = state.history.slice(0, -1)
+    // Remove every decision recorded in the unwound [newCursor, oldCursor) range.
+    // For single-step advances this is just one decision; for `delete`'s
+    // multi-step skip it's the lead decision plus any moot in-recording entries.
     const newDecisions = new Map(state.decisions)
-    newDecisions.delete(priorId)
-    return { ...state, cursor: newCursor, decisions: newDecisions }
+    for (let i = newCursor; i < state.cursor; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: i in [newCursor, cursor) ⊂ valid indices
+      newDecisions.delete(state.findings[i]!.id)
+    }
+    return {
+      ...state,
+      cursor: newCursor,
+      history: newHistory,
+      decisions: newDecisions,
+      step: 'reviewing',
+    }
   }
+
+  // From here on, forward actions are only valid in 'reviewing' step
+  if (state.step !== 'reviewing') return state
 
   // biome-ignore lint/style/noNonNullAssertion: cursor in [0, findings.length) when reviewing
   const current = state.findings[state.cursor]!
@@ -343,7 +364,10 @@ export function applyAction(state: ReviewState, action: ReviewAction): ReviewSta
     newDecisions.set(current.id, { kind: 'replace', with: action.with })
   } else if (action.kind === 'delete') {
     newDecisions.set(current.id, { kind: 'delete', recordingIndex: current.recordingIndex })
-    // Advance past every remaining finding in the same recording (moot once deleted)
+    // Advance past every remaining finding in the same recording (moot once
+    // deleted). Findings are contiguous-by-recording because preScan walks
+    // cassette.recordings in order; a later caller producing an unsorted
+    // findings array would break this skip.
     while (
       advanceTo < state.findings.length &&
       // biome-ignore lint/style/noNonNullAssertion: bounded by length check
@@ -355,5 +379,11 @@ export function applyAction(state: ReviewState, action: ReviewAction): ReviewSta
 
   const newStep: ReviewState['step'] =
     advanceTo >= state.findings.length ? 'confirming' : 'reviewing'
-  return { ...state, cursor: advanceTo, decisions: newDecisions, step: newStep }
+  return {
+    ...state,
+    cursor: advanceTo,
+    history: [...state.history, state.cursor],
+    decisions: newDecisions,
+    step: newStep,
+  }
 }

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -21,7 +21,7 @@ import {
 } from './cli-output.js'
 import { promptAction, promptText, promptYesNo } from './cli-prompt.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
-import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
+import { CassetteConfigError, CassetteInternalError, CassetteNotFoundError } from './errors.js'
 import { writeCassetteFile } from './io.js'
 import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
@@ -306,66 +306,90 @@ export function applyAction(state: ReviewState, action: ReviewAction): ReviewSta
     return state // already done/aborted; no further transitions
   }
 
-  if (action.kind === 'quit') {
-    return { ...state, step: 'aborted' }
-  }
-  if (action.kind === 'apply') {
-    if (state.step !== 'confirming') return state
-    return { ...state, step: 'done' }
-  }
-  if (action.kind === 'discard') {
-    if (state.step !== 'confirming') return state
-    return { ...state, step: 'done', decisions: new Map() }
-  }
-
-  if (action.kind === 'back') {
-    if (state.history.length === 0) return state
-    // biome-ignore lint/style/noNonNullAssertion: history.length > 0 guarantees last element
-    const newCursor = state.history[state.history.length - 1]!
-    const newHistory = state.history.slice(0, -1)
-    // Remove every decision recorded in the unwound [newCursor, oldCursor) range.
-    // For single-step advances this is just one decision; for `delete`'s
-    // multi-step skip it's the lead decision plus any moot in-recording entries.
-    const newDecisions = new Map(state.decisions)
-    for (let i = newCursor; i < state.cursor; i++) {
-      // biome-ignore lint/style/noNonNullAssertion: i in [newCursor, cursor) ⊂ valid indices
-      newDecisions.delete(state.findings[i]!.id)
-    }
-    return {
-      ...state,
-      cursor: newCursor,
-      history: newHistory,
-      decisions: newDecisions,
-      step: 'reviewing',
+  switch (action.kind) {
+    case 'quit':
+      return { ...state, step: 'aborted' }
+    case 'apply':
+      return state.step === 'confirming' ? { ...state, step: 'done' } : state
+    case 'discard':
+      return state.step === 'confirming' ? { ...state, step: 'done', decisions: new Map() } : state
+    case 'back':
+      return applyBack(state)
+    case 'accept':
+    case 'skip':
+    case 'replace':
+    case 'delete':
+      return state.step === 'reviewing' ? applyForward(state, action) : state
+    default: {
+      // Exhaustiveness guard: TypeScript narrows `action` to `never` here, so
+      // adding a new ReviewAction variant without a case above fails at
+      // compile time. The runtime throw is unreachable when the types are
+      // correct.
+      const _exhaustive: never = action
+      throw new CassetteInternalError(`unhandled review action: ${JSON.stringify(_exhaustive)}`)
     }
   }
+}
 
-  // From here on, forward actions are only valid in 'reviewing' step
-  if (state.step !== 'reviewing') return state
+function applyBack(state: ReviewState): ReviewState {
+  if (state.history.length === 0) return state
+  // biome-ignore lint/style/noNonNullAssertion: history.length > 0 guarantees last element
+  const newCursor = state.history[state.history.length - 1]!
+  const newHistory = state.history.slice(0, -1)
+  // Remove every decision recorded in the unwound [newCursor, oldCursor) range.
+  // For single-step advances this is just one decision; for `delete`'s
+  // multi-step skip it's the lead decision plus any moot in-recording entries.
+  const newDecisions = new Map(state.decisions)
+  for (let i = newCursor; i < state.cursor; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: i in [newCursor, cursor) ⊂ valid indices
+    newDecisions.delete(state.findings[i]!.id)
+  }
+  return {
+    ...state,
+    cursor: newCursor,
+    history: newHistory,
+    decisions: newDecisions,
+    step: 'reviewing',
+  }
+}
 
+type ForwardAction = Extract<ReviewAction, { kind: 'accept' | 'skip' | 'replace' | 'delete' }>
+
+function applyForward(state: ReviewState, action: ForwardAction): ReviewState {
   // biome-ignore lint/style/noNonNullAssertion: cursor in [0, findings.length) when reviewing
   const current = state.findings[state.cursor]!
   const newDecisions = new Map(state.decisions)
   let advanceTo = state.cursor + 1
 
-  if (action.kind === 'accept') {
-    newDecisions.set(current.id, { kind: 'accept' })
-  } else if (action.kind === 'skip') {
-    newDecisions.set(current.id, { kind: 'skip' })
-  } else if (action.kind === 'replace') {
-    newDecisions.set(current.id, { kind: 'replace', with: action.with })
-  } else if (action.kind === 'delete') {
-    newDecisions.set(current.id, { kind: 'delete', recordingIndex: current.recordingIndex })
-    // Advance past every remaining finding in the same recording (moot once
-    // deleted). Findings are contiguous-by-recording because preScan walks
-    // cassette.recordings in order; a later caller producing an unsorted
-    // findings array would break this skip.
-    while (
-      advanceTo < state.findings.length &&
-      // biome-ignore lint/style/noNonNullAssertion: bounded by length check
-      state.findings[advanceTo]!.recordingIndex === current.recordingIndex
-    ) {
-      advanceTo++
+  switch (action.kind) {
+    case 'accept':
+      newDecisions.set(current.id, { kind: 'accept' })
+      break
+    case 'skip':
+      newDecisions.set(current.id, { kind: 'skip' })
+      break
+    case 'replace':
+      newDecisions.set(current.id, { kind: 'replace', with: action.with })
+      break
+    case 'delete':
+      newDecisions.set(current.id, { kind: 'delete', recordingIndex: current.recordingIndex })
+      // Advance past every remaining finding in the same recording (moot once
+      // deleted). Findings are contiguous-by-recording because preScan walks
+      // cassette.recordings in order; a later caller producing an unsorted
+      // findings array would break this skip.
+      while (
+        advanceTo < state.findings.length &&
+        // biome-ignore lint/style/noNonNullAssertion: bounded by length check
+        state.findings[advanceTo]!.recordingIndex === current.recordingIndex
+      ) {
+        advanceTo++
+      }
+      break
+    default: {
+      const _exhaustive: never = action
+      throw new CassetteInternalError(
+        `unhandled forward review action: ${JSON.stringify(_exhaustive)}`,
+      )
     }
   }
 

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -11,7 +11,12 @@
  * Action keys (a/s/r/d/b/q/?) are API-locked. Renames would be a breaking
  * change. Prompt strings are NOT API.
  */
-import { previewMatch } from './cli-output.js'
+import { applyTruncation, color, isTty, previewMatch, stderr, stdout } from './cli-output.js'
+import { promptAction, promptText, promptYesNo } from './cli-prompt.js'
+import { loadConfigFromDir, loadConfigFromFile } from './config.js'
+import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
+import { writeCassetteFile } from './io.js'
+import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
 import { redact } from './redact.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
@@ -23,6 +28,7 @@ import {
   REDACTION_PLACEHOLDER_PATTERN,
   seedCountersFromCassette,
 } from './redact-pipeline.js'
+import { serialize } from './serialize.js'
 import type {
   CassetteFile,
   Recording,
@@ -31,6 +37,7 @@ import type {
   RedactSource,
   SuppressedEntry,
 } from './types.js'
+import { RECORDED_BY } from './version.js'
 
 export type Finding = {
   /** Stable ID: `rec<recordingIndex>-<source>-<position>-<rule>` */
@@ -586,4 +593,279 @@ function applyReplace(rec: Recording, finding: Finding, replacement: string): Re
   }
   if (rec.result.allLines === null) return rec
   return { ...rec, result: { ...rec.result, allLines: replaceInLines(rec.result.allLines) } }
+}
+
+const REVIEW_VERSION = 1
+
+const REVIEW_HELP = `\
+Usage:
+  shell-cassette review <path> [options]
+
+Walks unredacted findings interactively. For each finding the user picks:
+  (a) accept     apply default redaction (counter-tagged placeholder)
+  (s) skip       leave match in body, persist via _suppressed
+  (r) replace    substitute user-provided string (NOT for args)
+  (d) delete     remove the entire recording
+  (b) back       revisit previous finding
+  (q) quit       discard all decisions
+  (?) help       print key reference
+
+Decisions are batched and applied on confirm. Quit discards everything.
+
+Exit codes:
+  0   reviewed (with or without changes)
+  2   error (missing path, malformed cassette, conflicting flags)
+
+Options:
+  --json              read-only structured output (no prompts)
+  --include-match     [with --json] include raw match values (UNSAFE for piping)
+  --config <path>     override config discovery
+  --no-color
+  --color=always
+  --help
+`
+
+type ColorOverride = 'auto' | 'always' | 'never'
+
+type ReviewFlags = {
+  path: string | null
+  json: boolean
+  includeMatch: boolean
+  configPath?: string
+  colorOverride: ColorOverride
+  help: boolean
+}
+
+function parseReviewArgs(args: readonly string[]): ReviewFlags {
+  const flags: ReviewFlags = {
+    path: null,
+    json: false,
+    includeMatch: false,
+    colorOverride: 'auto',
+    help: false,
+  }
+  for (let i = 0; i < args.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: loop bound
+    const arg = args[i]!
+    if (arg === '--help' || arg === '-h') flags.help = true
+    else if (arg === '--json') flags.json = true
+    else if (arg === '--include-match') flags.includeMatch = true
+    else if (arg === '--no-color') flags.colorOverride = 'never'
+    else if (arg === '--color=always') flags.colorOverride = 'always'
+    else if (arg === '--config') {
+      const next = args[++i]
+      if (next === undefined) throw new CassetteConfigError('--config requires a path argument')
+      flags.configPath = next
+    } else if (arg.startsWith('--config=')) {
+      flags.configPath = arg.slice('--config='.length)
+    } else if (arg.startsWith('--')) {
+      throw new CassetteConfigError(`unknown flag: ${arg}`)
+    } else {
+      if (flags.path !== null) throw new CassetteConfigError('review takes exactly one path')
+      flags.path = arg
+    }
+  }
+  return flags
+}
+
+export async function runReview(args: readonly string[]): Promise<number> {
+  let flags: ReviewFlags
+  try {
+    flags = parseReviewArgs(args)
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}\n${REVIEW_HELP}`)
+    return 2
+  }
+
+  if (flags.help) {
+    stdout(REVIEW_HELP)
+    return 0
+  }
+  if (flags.path === null) {
+    stderr(`error: review requires a path\n${REVIEW_HELP}`)
+    return 2
+  }
+
+  color.setEnabled(
+    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
+  )
+
+  let cassette: CassetteFile
+  try {
+    const loaded = await loadCassette(flags.path)
+    if (loaded === null) throw new CassetteNotFoundError(flags.path)
+    cassette = loaded
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}`)
+    return 2
+  }
+
+  const config = flags.configPath
+    ? await loadConfigFromFile(flags.configPath)
+    : await loadConfigFromDir(process.cwd())
+
+  const findings = preScan(cassette, config.redact)
+
+  if (flags.json) {
+    return runJsonMode(findings, flags.includeMatch)
+  }
+
+  if (findings.length === 0) {
+    stdout('No new findings under current rules. Cassette is clean.')
+    return 0
+  }
+
+  let state: ReviewState = {
+    findings,
+    cursor: 0,
+    history: [],
+    decisions: new Map(),
+    step: 'reviewing',
+  }
+  while (state.step === 'reviewing') {
+    // biome-ignore lint/style/noNonNullAssertion: cursor in range when reviewing
+    renderFinding(state.findings[state.cursor]!, state.cursor, state.findings.length)
+    const action = await readNextAction(state)
+    state = applyAction(state, action)
+  }
+
+  if (state.step === 'confirming') {
+    renderSummary(state)
+    const apply = await promptYesNo(`Apply changes to ${flags.path}?`)
+    state = applyAction(state, apply ? { kind: 'apply' } : { kind: 'discard' })
+  }
+
+  if (state.step === 'aborted' || state.decisions.size === 0) {
+    stdout('No changes written.')
+    return 0
+  }
+
+  const updated = applyDecisions(cassette, state.findings, state.decisions, config.redact)
+  // Stamp recordedBy with current shell-cassette identity on write.
+  const stamped: CassetteFile = { ...updated, recordedBy: RECORDED_BY }
+  await writeCassetteFile(flags.path, serialize(stamped))
+  const counts = countDecisions(state)
+  stdout(
+    `Wrote 1 cassette. ${counts.accept} accept, ${counts.skip} skip, ${counts.replace} replace, ${counts.delete} deleted.`,
+  )
+  return 0
+}
+
+function runJsonMode(findings: readonly Finding[], includeMatch: boolean): number {
+  const byRule: Record<string, number> = {}
+  const bySource: Record<string, number> = {}
+  for (const f of findings) {
+    byRule[f.rule] = (byRule[f.rule] ?? 0) + 1
+    bySource[f.source] = (bySource[f.source] ?? 0) + 1
+  }
+  const out = {
+    reviewVersion: REVIEW_VERSION,
+    summary: { totalFindings: findings.length, byRule, bySource },
+    findings: findings.map((f) => ({
+      id: f.id,
+      recordingIndex: f.recordingIndex,
+      source: f.source,
+      rule: f.rule,
+      ...(includeMatch ? { match: f.match } : {}),
+      matchHash: f.matchHash,
+      matchLength: f.matchLength,
+      matchPreview: f.matchPreview,
+      position: f.position,
+      context: f.context,
+    })),
+  }
+  stdout(JSON.stringify(out, null, 2))
+  return 0
+}
+
+function renderFinding(finding: Finding, cursor: number, total: number): void {
+  stdout('')
+  stdout(`${color.bold(`[Finding ${cursor + 1}/${total}]`)} ${finding.rule} in ${finding.source}`)
+  stdout(`Recording ${finding.recordingIndex + 1}: ${finding.id}`)
+  stdout(
+    `Match: ${color.cyan(finding.matchPreview)} (${finding.matchLength} chars, ${finding.matchHash})`,
+  )
+  stdout('')
+  stdout('Context:')
+  for (const before of finding.context.before) {
+    stdout(`  ${applyTruncation(before, 80)}`)
+  }
+  stdout(`  ${color.red(applyTruncation(finding.context.line, 80))}`)
+  for (const after of finding.context.after) {
+    stdout(`  ${applyTruncation(after, 80)}`)
+  }
+  stdout('')
+}
+
+function renderSummary(state: ReviewState): void {
+  const c = countDecisions(state)
+  stdout('')
+  stdout(color.bold('Summary:'))
+  stdout(
+    `  ${c.accept} accept, ${c.skip} skip, ${c.replace} replace, ${c.delete} deleted recording(s)`,
+  )
+}
+
+function countDecisions(state: ReviewState): {
+  accept: number
+  skip: number
+  replace: number
+  delete: number
+} {
+  const out = { accept: 0, skip: 0, replace: 0, delete: 0 }
+  // Multiple findings inside one deleted recording collapse into a single
+  // user-visible "deleted recording" in the summary count.
+  const seenDeletedRecs = new Set<number>()
+  for (const d of state.decisions.values()) {
+    if (d.kind === 'accept') out.accept++
+    else if (d.kind === 'skip') out.skip++
+    else if (d.kind === 'replace') out.replace++
+    else if (d.kind === 'delete') {
+      if (!seenDeletedRecs.has(d.recordingIndex)) {
+        seenDeletedRecs.add(d.recordingIndex)
+        out.delete++
+      }
+    }
+  }
+  return out
+}
+
+async function readNextAction(state: ReviewState): Promise<ReviewAction> {
+  // biome-ignore lint/style/noNonNullAssertion: cursor in range when reviewing
+  const finding = state.findings[state.cursor]!
+  // (r)eplace is unavailable for args (canonicalize-incompatible).
+  const allowed =
+    finding.source === 'args' ? ['a', 's', 'd', 'b', 'q', '?'] : ['a', 's', 'r', 'd', 'b', 'q', '?']
+  while (true) {
+    const key = await promptAction(allowed)
+    if (key === '?') {
+      printActionHelp()
+      continue
+    }
+    if (key === 'a') return { kind: 'accept' }
+    if (key === 's') return { kind: 'skip' }
+    if (key === 'b') return { kind: 'back' }
+    if (key === 'q') return { kind: 'quit' }
+    if (key === 'r') {
+      const replacement = await promptText('Replacement value:')
+      return { kind: 'replace', with: replacement }
+    }
+    if (key === 'd') {
+      const ok = await promptYesNo(`Delete entire recording ${finding.recordingIndex + 1}?`)
+      if (ok) return { kind: 'delete' }
+      // user declined; loop will re-prompt for a different action
+    }
+  }
+}
+
+function printActionHelp(): void {
+  stdout(`
+  (a) accept     apply default redaction
+  (s) skip       leave verbatim, persist via _suppressed
+  (r) replace    substitute custom string (NOT for args)
+  (d) delete     remove entire recording
+  (b) back       revisit previous finding
+  (q) quit       discard all decisions
+  (?) help       this listing
+`)
 }

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -13,14 +13,24 @@
  */
 import { previewMatch } from './cli-output.js'
 import { matchesEnvKeyList } from './recorder.js'
+import { redact } from './redact.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
 import {
+  aggregateEntries,
   collectSuppressedHashes,
   ENV_KEY_MATCH_RULE,
   matchHash,
   REDACTION_PLACEHOLDER_PATTERN,
+  seedCountersFromCassette,
 } from './redact-pipeline.js'
-import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
+import type {
+  CassetteFile,
+  Recording,
+  RedactConfig,
+  RedactionEntry,
+  RedactSource,
+  SuppressedEntry,
+} from './types.js'
 
 export type Finding = {
   /** Stable ID: `rec<recordingIndex>-<source>-<position>-<rule>` */
@@ -386,4 +396,194 @@ export function applyAction(state: ReviewState, action: ReviewAction): ReviewSta
     decisions: newDecisions,
     step: newStep,
   }
+}
+
+/**
+ * Apply a batch of user decisions to a cassette and return the updated
+ * CassetteFile. Pure function (no I/O); caller writes the result.
+ *
+ * Algorithm:
+ *   1. Group decisions by recording index.
+ *   2. Drop recordings flagged by any 'delete' decision.
+ *   3. For each surviving recording:
+ *      a. Apply 'replace' decisions inline (manual span substitution
+ *         using the finding's stored match string + position).
+ *      b. Build skipSet from 'skip' decisions in this recording.
+ *      c. Re-run the redact pipeline on env/args/stdout/stderr/allLines
+ *         with suppressedHashes: skipSet so 'accept' findings get
+ *         counter-tagged placeholders while 'skip' findings stay as-is.
+ *      d. Append SuppressedEntry per skip decision.
+ *      e. Aggregate redaction entries (existing + new).
+ *   4. Return new CassetteFile with the surviving recordings.
+ *
+ * Counters seeded from the existing cassette so newly-applied
+ * placeholders continue the per-(source, rule) sequence.
+ */
+export function applyDecisions(
+  cassette: CassetteFile,
+  findings: readonly Finding[],
+  decisions: ReadonlyMap<string, Decision>,
+  config: Readonly<RedactConfig>,
+): CassetteFile {
+  const byRec = new Map<number, { finding: Finding; decision: Decision }[]>()
+  for (const f of findings) {
+    const d = decisions.get(f.id)
+    if (d === undefined) continue
+    const list = byRec.get(f.recordingIndex) ?? []
+    list.push({ finding: f, decision: d })
+    byRec.set(f.recordingIndex, list)
+  }
+
+  const toDelete = new Set<number>()
+  for (const [idx, list] of byRec) {
+    if (list.some(({ decision }) => decision.kind === 'delete')) toDelete.add(idx)
+  }
+
+  const counters = seedCountersFromCassette(cassette)
+  const updatedRecordings: Recording[] = []
+
+  for (let i = 0; i < cassette.recordings.length; i++) {
+    if (toDelete.has(i)) continue
+    // biome-ignore lint/style/noNonNullAssertion: i in [0, recordings.length)
+    let rec = cassette.recordings[i]!
+    const localDecisions = byRec.get(i) ?? []
+
+    const newCustomEntries: RedactionEntry[] = []
+    for (const { finding, decision } of localDecisions) {
+      if (decision.kind !== 'replace') continue
+      rec = applyReplace(rec, finding, decision.with)
+      newCustomEntries.push({ rule: 'custom', source: finding.source, count: 1 })
+    }
+
+    const skipSet = new Set<string>()
+    for (const { finding, decision } of localDecisions) {
+      if (decision.kind === 'skip') skipSet.add(finding.matchHash)
+    }
+
+    const newRedactEntries: RedactionEntry[] = []
+    const env: Record<string, string> = {}
+    for (const [key, value] of Object.entries(rec.call.env)) {
+      const r = redact({ source: 'env', value }, config, {
+        counted: true,
+        counters,
+        suppressedHashes: skipSet,
+      })
+      env[key] = r.output
+      newRedactEntries.push(...r.entries)
+    }
+    const args = rec.call.args.map((arg) => {
+      const r = redact({ source: 'args', value: arg }, config, {
+        counted: true,
+        counters,
+        suppressedHashes: skipSet,
+      })
+      newRedactEntries.push(...r.entries)
+      return r.output
+    })
+    const stdoutLines = rec.result.stdoutLines.map((line) => {
+      const r = redact({ source: 'stdout', value: line }, config, {
+        counted: true,
+        counters,
+        suppressedHashes: skipSet,
+      })
+      newRedactEntries.push(...r.entries)
+      return r.output
+    })
+    const stderrLines = rec.result.stderrLines.map((line) => {
+      const r = redact({ source: 'stderr', value: line }, config, {
+        counted: true,
+        counters,
+        suppressedHashes: skipSet,
+      })
+      newRedactEntries.push(...r.entries)
+      return r.output
+    })
+    const allLines =
+      rec.result.allLines === null
+        ? null
+        : rec.result.allLines.map((line) => {
+            const r = redact({ source: 'allLines', value: line }, config, {
+              counted: true,
+              counters,
+              suppressedHashes: skipSet,
+            })
+            newRedactEntries.push(...r.entries)
+            return r.output
+          })
+
+    const newSuppressed: SuppressedEntry[] = [...rec.suppressed]
+    for (const { finding, decision } of localDecisions) {
+      if (decision.kind !== 'skip') continue
+      newSuppressed.push({
+        source: finding.source,
+        rule: finding.rule,
+        position: finding.position,
+        matchHash: finding.matchHash,
+      })
+    }
+
+    updatedRecordings.push({
+      call: { ...rec.call, env, args },
+      result: { ...rec.result, stdoutLines, stderrLines, allLines },
+      redactions: aggregateEntries([...rec.redactions, ...newCustomEntries, ...newRedactEntries]),
+      suppressed: newSuppressed,
+    })
+  }
+
+  return {
+    version: 2,
+    recordedBy: cassette.recordedBy,
+    recordings: updatedRecordings,
+  }
+}
+
+/**
+ * Replace the match span identified by `finding` with `replacement`.
+ * Position is structured: env values are whole-value, args/stdout/stderr/
+ * allLines have line+col.
+ *
+ * Replace is documented as not available for args during the interactive
+ * loop (canonicalize-incompatible), but applyReplace handles args
+ * defensively in case the user's --json mode bypasses the dispatcher.
+ */
+function applyReplace(rec: Recording, finding: Finding, replacement: string): Recording {
+  const { source } = finding
+  if (source === 'env') {
+    const key = finding.position.split(':')[0] ?? ''
+    const env = { ...rec.call.env, [key]: replacement }
+    return { ...rec, call: { ...rec.call, env } }
+  }
+  if (source === 'args') {
+    const argIdx = Number.parseInt(finding.position.split(':')[0] ?? '0', 10)
+    const col = Number.parseInt(finding.position.split(':')[1] ?? '0', 10)
+    const args = [...rec.call.args]
+    // biome-ignore lint/style/noNonNullAssertion: argIdx in range when reached
+    const arg = args[argIdx]!
+    args[argIdx] = arg.slice(0, col) + replacement + arg.slice(col + finding.matchLength)
+    return { ...rec, call: { ...rec.call, args } }
+  }
+  const lineNumber = Number.parseInt(finding.position.split(':')[0] ?? '1', 10)
+  const col = Number.parseInt(finding.position.split(':')[1] ?? '0', 10)
+  const lineIdx = lineNumber - 1
+  const replaceInLines = (lines: string[]): string[] => {
+    const out = [...lines]
+    // biome-ignore lint/style/noNonNullAssertion: lineIdx in range when reached
+    const line = out[lineIdx]!
+    out[lineIdx] = line.slice(0, col) + replacement + line.slice(col + finding.matchLength)
+    return out
+  }
+  if (source === 'stdout') {
+    return {
+      ...rec,
+      result: { ...rec.result, stdoutLines: replaceInLines(rec.result.stdoutLines) },
+    }
+  }
+  if (source === 'stderr') {
+    return {
+      ...rec,
+      result: { ...rec.result, stderrLines: replaceInLines(rec.result.stderrLines) },
+    }
+  }
+  if (rec.result.allLines === null) return rec
+  return { ...rec, result: { ...rec.result, allLines: replaceInLines(rec.result.allLines) } }
 }

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -15,14 +15,19 @@
  * Output format is locked at scanVersion: 1. See spec Section 4 for the
  * complete --json shape.
  */
-import { color, isTty, previewMatch, stderr, stdout } from './cli-output.js'
+import { color, previewMatch, setupCliColor, stderr, stdout } from './cli-output.js'
 import { walkCassettes } from './cli-walk.js'
 import { loadConfigFromDir, loadConfigFromFile } from './config.js'
 import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { matchesEnvKeyList } from './recorder.js'
-import { BUNDLED_PATTERNS } from './redact-patterns.js'
-import { ENV_KEY_MATCH_RULE, matchHash, REDACTION_PLACEHOLDER_PATTERN } from './redact-pipeline.js'
+import {
+  buildGFlaggedRules,
+  ENV_KEY_MATCH_RULE,
+  isSuppressedValue,
+  matchHash,
+  REDACTION_PLACEHOLDER_PATTERN,
+} from './redact-pipeline.js'
 import type { CassetteFile, Recording, RedactConfig, RedactSource } from './types.js'
 
 const SCAN_VERSION = 1
@@ -148,9 +153,7 @@ export async function runScan(args: readonly string[]): Promise<number> {
     return 2
   }
 
-  color.setEnabled(
-    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
-  )
+  setupCliColor(flags.colorOverride)
 
   const config = flags.configPath
     ? await loadConfigFromFile(flags.configPath)
@@ -225,46 +228,6 @@ export async function scanOne(
     findings: findings.length > 0 ? findings : undefined,
     redactionsApplied,
   }
-}
-
-/**
- * Build g-flagged regex copies of bundled + custom rules for matchAll usage.
- * Built once per cassette and passed in to amortize regex allocation.
- * Function-typed custom rules are skipped; they can't report match positions.
- */
-function buildGFlaggedRules(
-  config: Readonly<RedactConfig>,
-): readonly { name: string; pattern: RegExp }[] {
-  const rules: { name: string; pattern: RegExp }[] = []
-
-  if (config.bundledPatterns) {
-    for (const rule of BUNDLED_PATTERNS) {
-      if (rule.pattern instanceof RegExp) {
-        const flags = rule.pattern.flags.includes('g')
-          ? rule.pattern.flags
-          : `${rule.pattern.flags}g`
-        rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
-      }
-    }
-  }
-
-  for (const rule of config.customPatterns) {
-    if (rule.pattern instanceof RegExp) {
-      const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`
-      rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
-    }
-    // Function-typed custom patterns: not scannable by position; skip for scan.
-  }
-
-  return rules
-}
-
-function isSuppressed(value: string, config: Readonly<RedactConfig>): boolean {
-  for (const sup of config.suppressPatterns) {
-    sup.lastIndex = 0
-    if (sup.test(value)) return true
-  }
-  return false
 }
 
 /** Returns true if value is already a redaction placeholder (counter-tagged or counter-stripped). */
@@ -356,7 +319,7 @@ function scanValue(
   config: Readonly<RedactConfig>,
   includeMatch: boolean,
 ): Finding[] {
-  if (isSuppressed(value, config)) return []
+  if (isSuppressedValue(value, config)) return []
 
   const findings: Finding[] = []
 

--- a/src/cli-show.ts
+++ b/src/cli-show.ts
@@ -14,7 +14,7 @@
  * Defaults: 5 lines per stream, 80 chars per line.
  */
 import { stat } from 'node:fs/promises'
-import { applyTruncation, color, formatBytes, isTty, stderr, stdout } from './cli-output.js'
+import { applyTruncation, color, formatBytes, setupCliColor, stderr, stdout } from './cli-output.js'
 import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { REDACTION_PLACEHOLDER_PATTERN } from './redact-pipeline.js'
@@ -149,9 +149,7 @@ export async function runShow(args: readonly string[]): Promise<number> {
     return 2
   }
 
-  color.setEnabled(
-    isTty.shouldUseColor({ tty: isTty.detectStdoutTty(), override: flags.colorOverride }),
-  )
+  setupCliColor(flags.colorOverride)
 
   let cassette: CassetteFile
   let fileSize: number

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { stderr, stdout } from './cli-output.js'
 import { runReRedact } from './cli-re-redact.js'
+import { runReview } from './cli-review.js'
 import { runScan } from './cli-scan.js'
 import { runShow } from './cli-show.js'
 import { PACKAGE_VERSION } from './version.js'
@@ -14,6 +15,7 @@ Commands:
   scan        Verify cassettes have no unredacted credentials.
   re-redact   Re-apply current redaction rules to existing cassettes.
   show        Pretty-print a cassette for human inspection.
+  review      Walk un-redacted findings interactively (a/s/r/d/b/q/?).
 
 Options:
   --version   Print shell-cassette version and exit.
@@ -59,6 +61,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       return runReRedact(args.rest)
     case 'show':
       return runShow(args.rest)
+    case 'review':
+      return runReview(args.rest)
     default:
       stderr(`error: unknown command '${args.command}'\n${HELP}`)
       return 2

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -69,3 +69,17 @@ export class NoActiveSessionError extends ShellCassetteError {
 export class VitestPluginRegistrationError extends ShellCassetteError {
   static override code = 'CASSETTE_VITEST_PLUGIN_REGISTRATION'
 }
+
+/**
+ * Thrown from code paths that should be unreachable when the implementation
+ * is correct (e.g., exhaustiveness guards on discriminated unions where
+ * `default: const _: never = x` proves the case at compile time). Always
+ * indicates an internal bug, not a user error. Programmatic catches on
+ * `ShellCassetteError` still pick it up.
+ *
+ * Per `error_handling.md` "Internal Invariants": typed subclass over plain
+ * `Error` so `instanceof ShellCassetteError` user catches don't miss it.
+ */
+export class CassetteInternalError extends ShellCassetteError {
+  static override code = 'CASSETTE_INTERNAL'
+}

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -339,3 +339,47 @@ export function collectSuppressedHashes(cassette: CassetteFile): Set<string> {
   }
   return out
 }
+
+/**
+ * Build g-flagged regex copies of bundled + user-custom rules for matchAll
+ * usage. Function-typed custom rules are skipped because they can't expose
+ * individual match spans for position-precise findings.
+ *
+ * Used by both scan and review's pre-scan; identical regex preparation must
+ * land in both producer and consumer to keep position reporting consistent.
+ */
+export function buildGFlaggedRules(
+  config: Readonly<RedactConfig>,
+): readonly { name: string; pattern: RegExp }[] {
+  const rules: { name: string; pattern: RegExp }[] = []
+  if (config.bundledPatterns) {
+    for (const rule of BUNDLED_PATTERNS) {
+      if (rule.pattern instanceof RegExp) {
+        const flags = rule.pattern.flags.includes('g')
+          ? rule.pattern.flags
+          : `${rule.pattern.flags}g`
+        rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
+      }
+    }
+  }
+  for (const rule of config.customPatterns) {
+    if (rule.pattern instanceof RegExp) {
+      const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`
+      rules.push({ name: rule.name, pattern: new RegExp(rule.pattern.source, flags) })
+    }
+  }
+  return rules
+}
+
+/**
+ * True if any of the user-supplied suppress regexes matches the value.
+ * Resets `lastIndex` defensively because callers may pass g-flagged regexes
+ * whose state would otherwise leak across calls.
+ */
+export function isSuppressedValue(value: string, config: Readonly<RedactConfig>): boolean {
+  for (const sup of config.suppressPatterns) {
+    sup.lastIndex = 0
+    if (sup.test(value)) return true
+  }
+  return false
+}

--- a/tests/e2e/cli-review-happy-path.test.ts
+++ b/tests/e2e/cli-review-happy-path.test.ts
@@ -1,0 +1,93 @@
+import { existsSync } from 'node:fs'
+import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+import { execa } from 'execa'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+const FIXTURE = path.resolve('tests/fixtures/cassettes/v2-dirty.json')
+const CLI = path.resolve('dist/bin.js')
+
+// Skip the suite if dist isn't built so local `npm test` works without a prior
+// `npm run build`. CI builds before test, so all tests run there.
+const HAS_BUILT_CLI = existsSync(CLI)
+
+/**
+ * Build a Readable stream that emits each line with a small delay between
+ * pushes. Required because Node's `readline.question` can drop a queued
+ * answer if stdin EOFs before the next `question()` call is registered.
+ * A 30ms gap gives the CLI time to render its prompt and re-register.
+ */
+function pacedStdin(lines: readonly string[]): Readable {
+  let i = 0
+  return new Readable({
+    read() {
+      if (i >= lines.length) {
+        // Delay EOF too so the final answer has time to land before stdin closes.
+        setTimeout(() => this.push(null), 100)
+        return
+      }
+      const line = lines[i]
+      i++
+      setTimeout(() => this.push(`${line}\n`), 100)
+    },
+  })
+}
+
+let tmp: string
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-e2e-'))
+})
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+describe.skipIf(!HAS_BUILT_CLI)('cli review e2e', () => {
+  test('--json mode emits reviewVersion: 1 with findings', async () => {
+    const r = await execa('node', [CLI, 'review', FIXTURE, '--json', '--no-color'])
+    expect(r.exitCode).toBe(0)
+    const parsed = JSON.parse(r.stdout)
+    expect(parsed.reviewVersion).toBe(1)
+    expect(parsed.summary.totalFindings).toBeGreaterThan(0)
+    expect(parsed.findings.length).toBeGreaterThan(0)
+  })
+
+  test('interactive accept-then-confirm: drives stdin and writes redacted cassette', async () => {
+    const targetPath = path.join(tmp, 'review.json')
+    await copyFile(FIXTURE, targetPath)
+
+    // Provide stdin: 'a' (accept the one finding) then 'y' (confirm apply).
+    // Use pacedStdin to avoid readline's EOF-vs-next-question race.
+    const r = await execa('node', [CLI, 'review', targetPath, '--no-color'], {
+      input: pacedStdin(['a', 'y']),
+      reject: false,
+    })
+    expect(r.exitCode).toBe(0)
+
+    const updated = JSON.parse(await readFile(targetPath, 'utf8'))
+    // The fixture's PAT lives in args[1] of the curl call. After accept, the
+    // arg should contain a counter-tagged placeholder.
+    const arg = updated.recordings[0].call.args[1]
+    expect(arg).toMatch(/<redacted:args:github-pat-classic:\d+>/)
+  })
+
+  test('interactive quit: cassette unchanged on disk', async () => {
+    const targetPath = path.join(tmp, 'review-quit.json')
+    await copyFile(FIXTURE, targetPath)
+    const before = await readFile(targetPath, 'utf8')
+
+    const r = await execa('node', [CLI, 'review', targetPath, '--no-color'], {
+      input: pacedStdin(['q']),
+      reject: false,
+    })
+    expect(r.exitCode).toBe(0)
+    expect(await readFile(targetPath, 'utf8')).toBe(before)
+  })
+
+  test('exit 2 on missing path', async () => {
+    const r = await execa('node', [CLI, 'review'], { reject: false })
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr).toMatch(/review requires a path/)
+  })
+})

--- a/tests/e2e/cli-review-happy-path.test.ts
+++ b/tests/e2e/cli-review-happy-path.test.ts
@@ -2,9 +2,9 @@ import { existsSync } from 'node:fs'
 import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { Readable } from 'node:stream'
 import { execa } from 'execa'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { pacedStdin } from '../helpers/paced-stdin.js'
 
 const FIXTURE = path.resolve('tests/fixtures/cassettes/v2-dirty.json')
 const CLI = path.resolve('dist/bin.js')
@@ -12,28 +12,6 @@ const CLI = path.resolve('dist/bin.js')
 // Skip the suite if dist isn't built so local `npm test` works without a prior
 // `npm run build`. CI builds before test, so all tests run there.
 const HAS_BUILT_CLI = existsSync(CLI)
-
-/**
- * Build a Readable stream that emits each line with a small delay between
- * pushes. Required because Node's `readline.question` can drop a queued
- * answer if stdin EOFs before the next `question()` call is registered.
- * A 30ms gap gives the CLI time to render its prompt and re-register.
- */
-function pacedStdin(lines: readonly string[]): Readable {
-  let i = 0
-  return new Readable({
-    read() {
-      if (i >= lines.length) {
-        // Delay EOF too so the final answer has time to land before stdin closes.
-        setTimeout(() => this.push(null), 100)
-        return
-      }
-      const line = lines[i]
-      i++
-      setTimeout(() => this.push(`${line}\n`), 100)
-    },
-  })
-}
 
 let tmp: string
 beforeEach(async () => {

--- a/tests/helpers/paced-stdin.ts
+++ b/tests/helpers/paced-stdin.ts
@@ -1,0 +1,27 @@
+import { Readable } from 'node:stream'
+
+/**
+ * Build a Readable stream that emits each line with a small delay between
+ * pushes. Required because Node's `readline.question` can drop a queued
+ * answer if stdin EOFs before the next `question()` call is registered.
+ * A 100ms gap gives a CLI time to render its prompt and re-register before
+ * the next answer lands.
+ *
+ * Used by e2e tests that drive interactive subcommands (review today; the
+ * helper is generic enough that any future interactive CLI e2e can reuse).
+ */
+export function pacedStdin(lines: readonly string[]): Readable {
+  let i = 0
+  return new Readable({
+    read() {
+      if (i >= lines.length) {
+        // Delay EOF too so the final answer has time to land before stdin closes.
+        setTimeout(() => this.push(null), 100)
+        return
+      }
+      const line = lines[i]
+      i++
+      setTimeout(() => this.push(`${line}\n`), 100)
+    },
+  })
+}

--- a/tests/integration/review-pipeline.test.ts
+++ b/tests/integration/review-pipeline.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import type { Decision } from '../../src/cli-review.js'
+import { applyDecisions, preScan } from '../../src/cli-review.js'
+import { deserialize, serialize } from '../../src/serialize.js'
+import type { CassetteFile, RedactConfig } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
+
+const config: RedactConfig = {
+  bundledPatterns: true,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+}
+
+let tmp: string
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-'))
+})
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+const baseCassette = (stdoutLines: string[]): CassetteFile => ({
+  version: 2,
+  recordedBy: null,
+  recordings: [makeRecording({ result: { stdoutLines } })],
+})
+
+describe('applyDecisions', () => {
+  test('accept decision: replaces match with counter-tagged placeholder', () => {
+    const cassette = baseCassette([`Token: ${PAT}`])
+    const findings = preScan(cassette, config)
+    expect(findings).toHaveLength(1)
+    const f0 = findings[0]
+    if (f0 === undefined) throw new Error('expected finding')
+    const decisions = new Map<string, Decision>([[f0.id, { kind: 'accept' }]])
+    const updated = applyDecisions(cassette, findings, decisions, config)
+    expect(updated.recordings[0]?.result.stdoutLines[0]).toBe(
+      'Token: <redacted:stdout:github-pat-classic:1>',
+    )
+    expect(updated.recordings[0]?.redactions).toContainEqual({
+      rule: 'github-pat-classic',
+      source: 'stdout',
+      count: 1,
+    })
+  })
+
+  test('skip decision: leaves match in body, persists SuppressedEntry', () => {
+    const cassette = baseCassette([`Token: ${PAT}`])
+    const findings = preScan(cassette, config)
+    const f0 = findings[0]
+    if (f0 === undefined) throw new Error('expected finding')
+    const decisions = new Map<string, Decision>([[f0.id, { kind: 'skip' }]])
+    const updated = applyDecisions(cassette, findings, decisions, config)
+    expect(updated.recordings[0]?.result.stdoutLines[0]).toBe(`Token: ${PAT}`)
+    expect(updated.recordings[0]?.suppressed).toHaveLength(1)
+    expect(updated.recordings[0]?.suppressed[0]).toMatchObject({
+      source: 'stdout',
+      rule: 'github-pat-classic',
+      matchHash: f0.matchHash,
+    })
+  })
+
+  test('replace decision: substitutes user-provided string in body', () => {
+    const cassette = baseCassette([`Token: ${PAT}`])
+    const findings = preScan(cassette, config)
+    const f0 = findings[0]
+    if (f0 === undefined) throw new Error('expected finding')
+    const decisions = new Map<string, Decision>([[f0.id, { kind: 'replace', with: 'FAKE-TOKEN' }]])
+    const updated = applyDecisions(cassette, findings, decisions, config)
+    expect(updated.recordings[0]?.result.stdoutLines[0]).toBe('Token: FAKE-TOKEN')
+    expect(updated.recordings[0]?.redactions).toContainEqual({
+      rule: 'custom',
+      source: 'stdout',
+      count: 1,
+    })
+  })
+
+  test('delete decision: removes the recording entirely', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({ result: { stdoutLines: [`Token: ${PAT}`] } }),
+        makeRecording({ result: { stdoutLines: ['ok'] } }),
+      ],
+    }
+    const findings = preScan(cassette, config)
+    const f0 = findings[0]
+    if (f0 === undefined) throw new Error('expected finding')
+    const decisions = new Map<string, Decision>([[f0.id, { kind: 'delete', recordingIndex: 0 }]])
+    const updated = applyDecisions(cassette, findings, decisions, config)
+    expect(updated.recordings).toHaveLength(1)
+    expect(updated.recordings[0]?.result.stdoutLines[0]).toBe('ok')
+  })
+
+  test('mixed decisions: accept one finding, skip another in same recording', () => {
+    const PAT2 = 'ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+    const cassette = baseCassette([`A: ${PAT}`, `B: ${PAT2}`])
+    const findings = preScan(cassette, config)
+    expect(findings).toHaveLength(2)
+    const f0 = findings[0]
+    const f1 = findings[1]
+    if (f0 === undefined || f1 === undefined) throw new Error('expected findings')
+    const decisions = new Map<string, Decision>([
+      [f0.id, { kind: 'accept' }],
+      [f1.id, { kind: 'skip' }],
+    ])
+    const updated = applyDecisions(cassette, findings, decisions, config)
+    expect(updated.recordings[0]?.result.stdoutLines[0]).toContain(
+      '<redacted:stdout:github-pat-classic',
+    )
+    expect(updated.recordings[0]?.result.stdoutLines[1]).toBe(`B: ${PAT2}`)
+    expect(updated.recordings[0]?.suppressed).toHaveLength(1)
+  })
+
+  test('result round-trips through serialize/deserialize as valid v2', async () => {
+    const cassette = baseCassette([`Token: ${PAT}`])
+    const findings = preScan(cassette, config)
+    const f0 = findings[0]
+    if (f0 === undefined) throw new Error('expected finding')
+    const decisions = new Map<string, Decision>([[f0.id, { kind: 'skip' }]])
+    const updated = applyDecisions(cassette, findings, decisions, config)
+    const fixturePath = path.join(tmp, 'out.json')
+    await writeFile(fixturePath, serialize(updated))
+    const reloaded = deserialize(await readFile(fixturePath, 'utf8'))
+    expect(reloaded.version).toBe(2)
+    expect(reloaded.recordings[0]?.suppressed).toHaveLength(1)
+  })
+})

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -421,11 +421,22 @@ describe('runReview --json', () => {
 
 describe('runReview interactive (driven via fake reader)', () => {
   let tmp: string
+  let outBuf: string[]
+  const origStdout = process.stdout.write.bind(process.stdout)
 
   beforeEach(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-int-'))
+    outBuf = []
+    // renderFinding emits the match preview, hash, and surrounding context lines —
+    // for a fixture with a real-looking PAT, that means secrets land in the
+    // vitest reporter unless stdout is captured.
+    process.stdout.write = ((s: string) => {
+      outBuf.push(s)
+      return true
+    }) as typeof process.stdout.write
   })
   afterEach(async () => {
+    process.stdout.write = origStdout
     setReader(null)
     await rm(tmp, { recursive: true, force: true })
   })
@@ -502,6 +513,8 @@ describe('runReview interactive (driven via fake reader)', () => {
     expect(JSON.parse(after).recordings[0].result.stdoutLines[0]).toContain(
       '<redacted:stdout:github-pat-classic',
     )
+    // Sanity check: stdout was actually captured (renderFinding ran).
+    expect(outBuf.join('')).toContain('[Finding')
   })
 
   test('quit discards decisions; cassette unchanged', async () => {

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { preScan } from '../../src/cli-review.js'
+import type { Finding, ReviewState } from '../../src/cli-review.js'
+import { applyAction, preScan } from '../../src/cli-review.js'
 import { ENV_KEY_MATCH_RULE, matchHash } from '../../src/redact-pipeline.js'
 import type { CassetteFile, RedactConfig } from '../../src/types.js'
 import { makeRecording } from '../helpers/recording.js'
@@ -175,5 +176,103 @@ describe('preScan', () => {
     }
     const config: RedactConfig = { ...minimalConfig, envKeys: ['TOKEN'] }
     expect(preScan(cassette, config)).toEqual([])
+  })
+})
+
+function mkFinding(
+  id: string,
+  recordingIndex: number,
+  source: 'stdout' | 'args' = 'stdout',
+): Finding {
+  return {
+    id,
+    recordingIndex,
+    source,
+    rule: 'github-pat-classic',
+    match: 'ghp_xxx',
+    matchHash: `sha256:${id}`,
+    matchLength: 7,
+    matchPreview: 'ghp_xxx',
+    position: '1:0',
+    context: { lineNumber: 1, before: [], line: 'ghp_xxx', after: [] },
+  }
+}
+
+function mkState(findings: Finding[]): ReviewState {
+  return { findings, cursor: 0, decisions: new Map(), step: 'reviewing' }
+}
+
+describe('applyAction', () => {
+  test('accept advances cursor and records accept decision', () => {
+    const state = mkState([mkFinding('a', 0), mkFinding('b', 0)])
+    const next = applyAction(state, { kind: 'accept' })
+    expect(next.cursor).toBe(1)
+    expect(next.decisions.get('a')).toEqual({ kind: 'accept' })
+    expect(next.step).toBe('reviewing')
+  })
+
+  test('skip records skip decision', () => {
+    const state = mkState([mkFinding('a', 0), mkFinding('b', 0)])
+    const next = applyAction(state, { kind: 'skip' })
+    expect(next.decisions.get('a')).toEqual({ kind: 'skip' })
+    expect(next.cursor).toBe(1)
+  })
+
+  test('replace records replace decision with user value', () => {
+    const state = mkState([mkFinding('a', 0)])
+    const next = applyAction(state, { kind: 'replace', with: 'CUSTOM' })
+    expect(next.decisions.get('a')).toEqual({ kind: 'replace', with: 'CUSTOM' })
+  })
+
+  test('delete records delete decision and skips remaining findings in same recording', () => {
+    const state = mkState([mkFinding('a', 0), mkFinding('b', 0), mkFinding('c', 1)])
+    const next = applyAction(state, { kind: 'delete' })
+    expect(next.decisions.get('a')).toEqual({ kind: 'delete', recordingIndex: 0 })
+    // 'b' is in the same recording (0), so cursor jumps past it to 'c' (recording 1)
+    expect(next.cursor).toBe(2)
+  })
+
+  test('back decrements cursor and removes prior decision (user must re-decide)', () => {
+    let state = mkState([mkFinding('a', 0), mkFinding('b', 0)])
+    state = applyAction(state, { kind: 'accept' }) // cursor 1, decision 'a' = accept
+    expect(state.cursor).toBe(1)
+    state = applyAction(state, { kind: 'back' })
+    expect(state.cursor).toBe(0)
+    expect(state.decisions.has('a')).toBe(false)
+  })
+
+  test('back at cursor 0 is a no-op (still reviewing, cursor 0)', () => {
+    const state = mkState([mkFinding('a', 0)])
+    const next = applyAction(state, { kind: 'back' })
+    expect(next.cursor).toBe(0)
+    expect(next.step).toBe('reviewing')
+  })
+
+  test('reaching end of findings transitions to confirming', () => {
+    let state = mkState([mkFinding('a', 0)])
+    state = applyAction(state, { kind: 'accept' }) // cursor 1, past end
+    expect(state.step).toBe('confirming')
+  })
+
+  test('quit transitions to aborted', () => {
+    const state = mkState([mkFinding('a', 0)])
+    const next = applyAction(state, { kind: 'quit' })
+    expect(next.step).toBe('aborted')
+  })
+
+  test('apply transitions to done with decisions intact', () => {
+    let state = mkState([mkFinding('a', 0)])
+    state = applyAction(state, { kind: 'accept' }) // step = confirming
+    state = applyAction(state, { kind: 'apply' })
+    expect(state.step).toBe('done')
+    expect(state.decisions.size).toBe(1)
+  })
+
+  test('discard transitions to done with empty decisions', () => {
+    let state = mkState([mkFinding('a', 0)])
+    state = applyAction(state, { kind: 'accept' }) // step = confirming
+    state = applyAction(state, { kind: 'discard' })
+    expect(state.step).toBe('done')
+    expect(state.decisions.size).toBe(0)
   })
 })

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest'
+import { preScan } from '../../src/cli-review.js'
+import { matchHash } from '../../src/redact-pipeline.js'
+import type { CassetteFile, RedactConfig } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
+
+const minimalConfig: RedactConfig = {
+  bundledPatterns: true,
+  customPatterns: [],
+  suppressPatterns: [],
+  envKeys: [],
+  warnLengthThreshold: 40,
+  warnPathHeuristic: true,
+}
+
+describe('preScan', () => {
+  test('returns empty array when no findings', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [makeRecording({ result: { stdoutLines: ['hello'] } })],
+    }
+    expect(preScan(cassette, minimalConfig)).toEqual([])
+  })
+
+  test('finds GitHub PAT in stdout', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [makeRecording({ result: { stdoutLines: [`Token: ${pat}`] } })],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      recordingIndex: 0,
+      source: 'stdout',
+      rule: 'github-pat-classic',
+      matchLength: pat.length,
+    })
+    expect(findings[0]?.matchHash).toMatch(/^sha256:[0-9a-f]{64}$/)
+    expect(findings[0]?.id).toBe('rec0-stdout-1:7-github-pat-classic')
+  })
+
+  test('skips matches whose hash is in any recording.suppressed', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const hash = matchHash(pat)
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          result: { stdoutLines: [pat] },
+          suppressed: [
+            { source: 'stdout', rule: 'github-pat-classic', position: '1:0', matchHash: hash },
+          ],
+        }),
+      ],
+    }
+    expect(preScan(cassette, minimalConfig)).toEqual([])
+  })
+
+  test('captures context lines around the match', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          result: { stdoutLines: ['line A', 'line B', `Token: ${pat}`, 'line D', 'line E'] },
+        }),
+      ],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.context).toMatchObject({
+      lineNumber: 3,
+      before: ['line A', 'line B'],
+      line: `Token: ${pat}`,
+      after: ['line D', 'line E'],
+    })
+  })
+
+  test('args matches use <argIndex>:<col> position', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'gh',
+            args: ['login', '--token', pat],
+            cwd: null,
+            env: {},
+            stdin: null,
+          },
+        }),
+      ],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.position).toBe('2:0')
+    expect(findings[0]?.id).toBe('rec0-args-2:0-github-pat-classic')
+  })
+})

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { type Reader, setReader } from '../../src/cli-prompt.js'
 import type { Finding, ReviewState } from '../../src/cli-review.js'
-import { applyAction, preScan } from '../../src/cli-review.js'
+import { applyAction, preScan, runReview } from '../../src/cli-review.js'
 import { ENV_KEY_MATCH_RULE, matchHash } from '../../src/redact-pipeline.js'
 import type { CassetteFile, RedactConfig } from '../../src/types.js'
 import { makeRecording } from '../helpers/recording.js'
@@ -305,5 +309,231 @@ describe('applyAction', () => {
     state = applyAction(state, { kind: 'discard' })
     expect(state.step).toBe('done')
     expect(state.decisions.size).toBe(0)
+  })
+})
+
+describe('runReview --json', () => {
+  let tmp: string
+  let outBuf: string[]
+  let errBuf: string[]
+  const origStdout = process.stdout.write.bind(process.stdout)
+  const origStderr = process.stderr.write.bind(process.stderr)
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-json-'))
+    outBuf = []
+    errBuf = []
+    process.stdout.write = ((s: string) => {
+      outBuf.push(s)
+      return true
+    }) as typeof process.stdout.write
+    process.stderr.write = ((s: string) => {
+      errBuf.push(s)
+      return true
+    }) as typeof process.stderr.write
+  })
+  afterEach(async () => {
+    process.stdout.write = origStdout
+    process.stderr.write = origStderr
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test('emits reviewVersion: 1 with summary and findings (default-safe match)', async () => {
+    const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: null,
+      recordings: [
+        {
+          call: { command: 'gh', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [`Token: ${PAT}`],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'fix.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const exit = await runReview([fixturePath, '--json', '--no-color'])
+    expect(exit).toBe(0)
+    const out = JSON.parse(outBuf.join(''))
+    expect(out.reviewVersion).toBe(1)
+    expect(out.summary.totalFindings).toBe(1)
+    expect(out.findings).toHaveLength(1)
+    // default-safe: match field absent
+    expect(out.findings[0].match).toBeUndefined()
+    expect(out.findings[0].matchHash).toMatch(/^sha256:/)
+    expect(out.findings[0].matchPreview).toMatch(/^ghp_/)
+  })
+
+  test('--include-match adds raw match field', async () => {
+    const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: null,
+      recordings: [
+        {
+          call: { command: 'gh', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [PAT],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'fix.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const exit = await runReview([fixturePath, '--json', '--include-match', '--no-color'])
+    expect(exit).toBe(0)
+    const out = JSON.parse(outBuf.join(''))
+    expect(out.findings[0].match).toBe(PAT)
+  })
+
+  test('returns 2 on missing path', async () => {
+    const exit = await runReview([])
+    expect(exit).toBe(2)
+    expect(errBuf.join('')).toContain('review requires a path')
+  })
+
+  test('--help returns 0', async () => {
+    const exit = await runReview(['--help'])
+    expect(exit).toBe(0)
+    expect(outBuf.join('')).toContain('Usage:')
+  })
+})
+
+describe('runReview interactive (driven via fake reader)', () => {
+  let tmp: string
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-int-'))
+  })
+  afterEach(async () => {
+    setReader(null)
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  function makeReader(answers: string[]): Reader {
+    const queue = [...answers]
+    return {
+      question: async () => {
+        const next = queue.shift()
+        if (next === undefined) return ''
+        return next
+      },
+      close: () => {},
+    }
+  }
+
+  test('clean cassette (no findings) exits 0 immediately', async () => {
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: null,
+      recordings: [
+        {
+          call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['hi'],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'clean.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const exit = await runReview([fixturePath, '--no-color'])
+    expect(exit).toBe(0)
+  })
+
+  test('accept-all-then-confirm writes redacted cassette', async () => {
+    const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: null,
+      recordings: [
+        {
+          call: { command: 'gh', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [`A: ${PAT}`],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'dirty.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    setReader(makeReader(['a', 'y'])) // accept finding 1, then confirm yes
+    const exit = await runReview([fixturePath, '--no-color'])
+    expect(exit).toBe(0)
+    const after = await readFile(fixturePath, 'utf8')
+    expect(JSON.parse(after).recordings[0].result.stdoutLines[0]).toContain(
+      '<redacted:stdout:github-pat-classic',
+    )
+  })
+
+  test('quit discards decisions; cassette unchanged', async () => {
+    const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: null,
+      recordings: [
+        {
+          call: { command: 'gh', args: [], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: [`A: ${PAT}`],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'quit.json')
+    const before = `${JSON.stringify(cassette, null, 2)}\n`
+    await writeFile(fixturePath, before)
+
+    setReader(makeReader(['q'])) // quit on the first finding
+    const exit = await runReview([fixturePath, '--no-color'])
+    expect(exit).toBe(0)
+    const after = await readFile(fixturePath, 'utf8')
+    expect(after).toBe(before)
   })
 })

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -199,7 +199,7 @@ function mkFinding(
 }
 
 function mkState(findings: Finding[]): ReviewState {
-  return { findings, cursor: 0, decisions: new Map(), step: 'reviewing' }
+  return { findings, cursor: 0, history: [], decisions: new Map(), step: 'reviewing' }
 }
 
 describe('applyAction', () => {
@@ -241,11 +241,42 @@ describe('applyAction', () => {
     expect(state.decisions.has('a')).toBe(false)
   })
 
-  test('back at cursor 0 is a no-op (still reviewing, cursor 0)', () => {
+  test('back at start (empty history) is a no-op', () => {
     const state = mkState([mkFinding('a', 0)])
     const next = applyAction(state, { kind: 'back' })
     expect(next.cursor).toBe(0)
     expect(next.step).toBe('reviewing')
+  })
+
+  test('back undoes a delete fully (rewinds the multi-step skip and clears all decisions)', () => {
+    let state = mkState([mkFinding('a', 0), mkFinding('b', 0), mkFinding('c', 1)])
+    state = applyAction(state, { kind: 'delete' })
+    // Sanity: delete on `a` skipped `b` (same recording), cursor at `c`.
+    expect(state.cursor).toBe(2)
+    expect(state.decisions.get('a')).toEqual({ kind: 'delete', recordingIndex: 0 })
+
+    state = applyAction(state, { kind: 'back' })
+    // Cursor returns to 0 (where the user actually was when they pressed delete).
+    expect(state.cursor).toBe(0)
+    // The delete decision is gone — user must re-decide. b never had a
+    // decision, but verifying both are clear ensures the unwound range is
+    // correctly cleared.
+    expect(state.decisions.has('a')).toBe(false)
+    expect(state.decisions.has('b')).toBe(false)
+  })
+
+  test('back from confirming returns to reviewing at the last decided finding', () => {
+    let state = mkState([mkFinding('a', 0), mkFinding('b', 0)])
+    state = applyAction(state, { kind: 'accept' }) // cursor 1
+    state = applyAction(state, { kind: 'accept' }) // cursor 2, step = confirming
+    expect(state.step).toBe('confirming')
+
+    state = applyAction(state, { kind: 'back' })
+    expect(state.step).toBe('reviewing')
+    expect(state.cursor).toBe(1)
+    // Last decision (b) is unwound; the earlier (a) is still in.
+    expect(state.decisions.has('b')).toBe(false)
+    expect(state.decisions.get('a')).toEqual({ kind: 'accept' })
   })
 
   test('reaching end of findings transitions to confirming', () => {

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { preScan } from '../../src/cli-review.js'
-import { matchHash } from '../../src/redact-pipeline.js'
+import { ENV_KEY_MATCH_RULE, matchHash } from '../../src/redact-pipeline.js'
 import type { CassetteFile, RedactConfig } from '../../src/types.js'
 import { makeRecording } from '../helpers/recording.js'
 
@@ -60,6 +60,28 @@ describe('preScan', () => {
     expect(preScan(cassette, minimalConfig)).toEqual([])
   })
 
+  test('suppression skip is hash-based and works across recordings (position-independent)', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const hash = matchHash(pat)
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        // Recording 0 holds the suppressed entry but doesn't contain the match.
+        makeRecording({
+          suppressed: [
+            { source: 'stdout', rule: 'github-pat-classic', position: '99:99', matchHash: hash },
+          ],
+        }),
+        // Recording 1 contains the same secret at a different position; no
+        // suppressed entry of its own. Should still be skipped via the
+        // cassette-wide hash collection.
+        makeRecording({ result: { stdoutLines: [`prefix ${pat}`] } }),
+      ],
+    }
+    expect(preScan(cassette, minimalConfig)).toEqual([])
+  })
+
   test('captures context lines around the match', () => {
     const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
     const cassette: CassetteFile = {
@@ -102,5 +124,56 @@ describe('preScan', () => {
     expect(findings).toHaveLength(1)
     expect(findings[0]?.position).toBe('2:0')
     expect(findings[0]?.id).toBe('rec0-args-2:0-github-pat-classic')
+  })
+
+  test('reports env-key-match for curated keys even without a regex hit', () => {
+    // Opaque value with no bundled-pattern shape; key matches a configured
+    // env-key substring. Mirrors cli-scan's env-key-match coverage so review
+    // doesn't silently under-report relative to scan.
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'gh',
+            args: [],
+            cwd: null,
+            env: { MY_TOKEN: 'opaque-no-regex-shape' },
+            stdin: null,
+          },
+        }),
+      ],
+    }
+    const config: RedactConfig = { ...minimalConfig, envKeys: ['TOKEN'] }
+    const findings = preScan(cassette, config)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      source: 'env',
+      rule: ENV_KEY_MATCH_RULE,
+      position: 'MY_TOKEN:0',
+      match: 'opaque-no-regex-shape',
+    })
+    expect(findings[0]?.id).toBe(`rec0-env-MY_TOKEN:0-${ENV_KEY_MATCH_RULE}`)
+  })
+
+  test('env-key-match skips already-redacted placeholders', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'gh',
+            args: [],
+            cwd: null,
+            env: { MY_TOKEN: '<redacted:env:env-key-match:1>' },
+            stdin: null,
+          },
+        }),
+      ],
+    }
+    const config: RedactConfig = { ...minimalConfig, envKeys: ['TOKEN'] }
+    expect(preScan(cassette, config)).toEqual([])
   })
 })


### PR DESCRIPTION
## What Changed

The `review` subcommand walks unredacted findings interactively. For each finding the user picks `(a)ccept` / `(s)kip` / `(r)eplace` / `(d)elete` / `(b)ack` / `(q)uit` / `(?)`. Decisions are batched in a pure state machine and applied to the cassette on confirm.

- `preScan(cassette, config)` returns `Finding[]`. Walks all 5 sources (env, args, stdout, stderr, allLines) producing findings with sha256 match hashes, source-specific position labels, and surrounding-line context for terminal display. Mirrors `cli-scan`'s env-key-match coverage so review doesn't silently under-report relative to scan. Skips matches whose hash is in any recording's `_suppressed` array.
- `applyAction(state, action)` is the pure state-machine transition. Eight action variants (accept/skip/replace/delete/back/quit/apply/discard). Implemented as an outer `switch (action.kind)` with `default: const _: never = action; throw new CassetteInternalError(...)` so adding a 9th variant fails at compile time. `delete` auto-skips remaining findings in the same recording. `back` uses a history stack to unwind multi-step jumps (so `delete` followed by `back` cleanly removes the delete decision and restores the cursor) and works from `confirming` too.
- `applyDecisions(cassette, findings, decisions, config)` is a pure mutation. Drops deleted recordings; applies replace decisions inline; re-runs the redact pipeline with `suppressedHashes` per recording so accept findings become counter-tagged placeholders while skip findings stay verbatim; appends `SuppressedEntry` per skip; aggregates redaction metadata.
- `runReview(args)` is the entry point. Parses argv, loads cassette, runs `preScan`, then either emits `--json` (locked at `reviewVersion: 1`) or drives the interactive loop via `cli-prompt` helpers. After confirm, writes via `applyDecisions` + `writeCassetteFile` (atomic). `(r)eplace` is filtered out for `args` findings (canonicalize-incompatible).
- `shell-cassette review` dispatch: the bin's HELP gains a `review` line and the switch wires `runReview`.

Action keys (a/s/r/d/b/q/?) are stable. Prompt strings are not API.

## Shared helpers extracted along the way

- `buildGFlaggedRules(config)` and `isSuppressedValue(value, config)` moved from `cli-scan` (where they lived as identical local functions) to `redact-pipeline.ts`. Producer (`cli-scan`'s `findingsForRecording`) and consumer (`cli-review`'s `preScan`) now call the same regex-prep and suppress-check logic.
- `setupCliColor(override)` extracted to `cli-output.ts`. Replaces the four-callsite pattern across `cli-scan`, `cli-re-redact`, `cli-show`, `cli-review` with a single line per CLI.
- `pacedStdin(lines)` moved from inline in the e2e test to `tests/helpers/paced-stdin.ts`. Generic readline-EOF-race workaround any future interactive CLI e2e can reuse.
- `CassetteInternalError` added to `src/errors.ts` to back the `applyAction` exhaustiveness throw.

Local cleanup in `cli-review`: `applyDecisions`'s 5 near-identical `redact()` blocks (env/args/stdout/stderr/allLines) collapse to one `redactValue(source, value)` closure inside the function.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (572 passed, 1 skipped)
- [x] `npm run build` clean

New tests:

- `tests/unit/cli-review.test.ts` (27 total): preScan (8: empty, PAT detection, hash-based skip incl. position-independent across recordings, context, args position, env-key-match coverage, env placeholder skip), applyAction (12: each transition incl. back unwinding multi-step delete and back from confirming), runReview (7: JSON shape, `--include-match`, missing path, `--help`, clean cassette, accept-then-confirm, quit). Tests use `makeRecording` helper and the injectable Reader from `cli-prompt`. Interactive tests stub `process.stdout` so finding content doesn't leak into the vitest reporter.
- `tests/integration/review-pipeline.test.ts` (6): accept/skip/replace/delete decisions exercised end-to-end on in-memory cassettes; mixed accept+skip; round-trip through serialize/deserialize.
- `tests/e2e/cli-review-happy-path.test.ts` (4): spawns `node dist/bin.js review <fixture>` for `--json` shape, accept-then-confirm via `pacedStdin` (a 100ms delay between lines avoids a Node readline pacing race when piping fast), quit-leaves-unchanged, and missing-path. Suite skips cleanly via `describe.skipIf` when `dist/bin.js` is absent.