### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What Changed
+
+<!-- A short list of what landed in this PR. -->
+
+## Why
+
+<!-- The reason these changes are useful or necessary. -->
+
+## Related Issues
+
+<!-- Closes #N, Fixes #N, Refs #N. Delete this section if there are none. -->
+
+## Test Plan
+
+- [ ] `npm run lint` — clean
+- [ ] `npm run typecheck` — clean
+- [ ] `npm test` — N passed, N skipped
+- [ ] `npm run build` — clean
+
+## Notes
+
+<!-- Follow-ups, deferred items, or pre-existing issues touched in passing. Delete this section if there are none. -->


### PR DESCRIPTION
## What Changed

- Adds `.github/pull_request_template.md` with five sections: What Changed, Why, Related Issues, Test Plan (four quality-gate checkboxes), Notes.

## Why

GitHub auto-populates the PR body from this file, so future PRs land with a consistent skeleton instead of free-form. Splitting What from Why forces rationale onto its own heading so it survives in git history; the optional Notes section captures follow-ups and deferred items at the merge boundary.

## Test Plan

- [x] `npm run lint` clean (no source changes)
- [x] `npm run typecheck` clean (no source changes)
- [x] `npm test` unchanged from main
- [x] `npm run build` clean (no source changes)