### PR TITLE
feat: add prune subcommand for removing recordings by index

### DIFF
--- a/src/cli-prune.ts
+++ b/src/cli-prune.ts
@@ -9,7 +9,7 @@
  * Bare `prune <path>` (no flags) is an error. Workflow:
  * `prune --json | jq` to pick indexes, then `prune --delete <list>`.
  */
-import { setupCliColor, stderr, stdout } from './cli-output.js'
+import { type ColorOverride, setupCliColor, stderr, stdout } from './cli-output.js'
 import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { writeCassetteFile } from './io.js'
 import { loadCassette } from './loader.js'
@@ -42,8 +42,6 @@ Options:
   --color=always
   --help
 `
-
-type ColorOverride = 'auto' | 'always' | 'never'
 
 export type PruneFlags = {
   path: string | null
@@ -93,13 +91,15 @@ function parseIndexList(s: string): number[] {
     .split(',')
     .map((p) => p.trim())
     .filter((p) => p.length > 0)
+  if (parts.length === 0) {
+    throw new CassetteConfigError('--delete: list cannot be empty')
+  }
   const out: number[] = []
   for (const p of parts) {
-    const n = Number.parseInt(p, 10)
-    if (!Number.isInteger(n) || n < 0 || String(n) !== p) {
+    if (!/^\d+$/.test(p)) {
       throw new CassetteConfigError(`--delete: '${p}' is not a non-negative integer`)
     }
-    out.push(n)
+    out.push(Number.parseInt(p, 10))
   }
   return out
 }

--- a/src/cli-prune.ts
+++ b/src/cli-prune.ts
@@ -1,0 +1,189 @@
+/**
+ * `shell-cassette prune` subcommand. Remove recordings by 0-based index.
+ *
+ * v0.5 modes (no interactive walk):
+ *   - `--delete <indexes>`: comma-separated 0-based indexes to remove.
+ *   - `--json`: read-only structured listing (`pruneVersion: 1`).
+ *   - `--help`: usage.
+ *
+ * Bare `prune <path>` (no flags) is an error. Workflow:
+ * `prune --json | jq` to pick indexes, then `prune --delete <list>`.
+ */
+import { setupCliColor, stderr, stdout } from './cli-output.js'
+import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
+import { writeCassetteFile } from './io.js'
+import { loadCassette } from './loader.js'
+import { serialize } from './serialize.js'
+import type { CassetteFile } from './types.js'
+import { RECORDED_BY } from './version.js'
+
+const PRUNE_VERSION = 1
+
+const PRUNE_HELP = `\
+Usage:
+  shell-cassette prune <path> --delete <indexes>
+  shell-cassette prune <path> --json
+  shell-cassette prune <path> --help
+
+Remove recordings from a cassette by 0-based index.
+
+Workflow: shell-cassette prune <path> --json | jq -r ... to pick indexes,
+then shell-cassette prune <path> --delete <comma-separated list>.
+
+Exit codes:
+  0   ok
+  2   error (missing path, bad flags, out-of-range or duplicate index)
+
+Options:
+  --delete <indexes>   comma-separated 0-based indexes to remove
+  --json               read-only structured listing (pruneVersion: 1)
+  --quiet              suppress stdout summary on --delete
+  --no-color
+  --color=always
+  --help
+`
+
+type ColorOverride = 'auto' | 'always' | 'never'
+
+export type PruneFlags = {
+  path: string | null
+  delete: number[] | null
+  json: boolean
+  quiet: boolean
+  colorOverride: ColorOverride
+  help: boolean
+}
+
+export function parsePruneArgs(args: readonly string[]): PruneFlags {
+  const flags: PruneFlags = {
+    path: null,
+    delete: null,
+    json: false,
+    quiet: false,
+    colorOverride: 'auto',
+    help: false,
+  }
+  for (let i = 0; i < args.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: loop bound guarantees index is valid
+    const arg = args[i]!
+    if (arg === '--help' || arg === '-h') flags.help = true
+    else if (arg === '--json') flags.json = true
+    else if (arg === '--quiet') flags.quiet = true
+    else if (arg === '--no-color') flags.colorOverride = 'never'
+    else if (arg === '--color=always') flags.colorOverride = 'always'
+    else if (arg === '--delete') {
+      const next = args[++i]
+      if (next === undefined)
+        throw new CassetteConfigError('--delete requires a comma-separated list of indexes')
+      flags.delete = parseIndexList(next)
+    } else if (arg.startsWith('--delete=')) {
+      flags.delete = parseIndexList(arg.slice('--delete='.length))
+    } else if (arg.startsWith('--')) {
+      throw new CassetteConfigError(`unknown flag: ${arg}`)
+    } else {
+      if (flags.path !== null) throw new CassetteConfigError('prune takes exactly one path')
+      flags.path = arg
+    }
+  }
+  return flags
+}
+
+function parseIndexList(s: string): number[] {
+  const parts = s
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+  const out: number[] = []
+  for (const p of parts) {
+    const n = Number.parseInt(p, 10)
+    if (!Number.isInteger(n) || n < 0 || String(n) !== p) {
+      throw new CassetteConfigError(`--delete: '${p}' is not a non-negative integer`)
+    }
+    out.push(n)
+  }
+  return out
+}
+
+export async function runPrune(args: readonly string[]): Promise<number> {
+  let flags: PruneFlags
+  try {
+    flags = parsePruneArgs(args)
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}\n${PRUNE_HELP}`)
+    return 2
+  }
+
+  if (flags.help) {
+    stdout(PRUNE_HELP)
+    return 0
+  }
+  if (flags.path === null) {
+    stderr(`error: prune requires a path\n${PRUNE_HELP}`)
+    return 2
+  }
+
+  setupCliColor(flags.colorOverride)
+
+  let cassette: CassetteFile
+  try {
+    const loaded = await loadCassette(flags.path)
+    if (loaded === null) throw new CassetteNotFoundError(flags.path)
+    cassette = loaded
+  } catch (e) {
+    stderr(`error: ${(e as Error).message}`)
+    return 2
+  }
+
+  if (flags.json) return runJsonMode(cassette)
+  if (flags.delete !== null) return runDeleteMode(cassette, flags)
+
+  stderr('error: prune requires --delete <indexes> or --json. See `prune --help`.')
+  return 2
+}
+
+function runJsonMode(cassette: CassetteFile): number {
+  const recordings = cassette.recordings.map((rec, index) => ({
+    index,
+    command: rec.call.command,
+    args: rec.call.args,
+    exitCode: rec.result.exitCode,
+    durationMs: rec.result.durationMs,
+    redactionCount: rec.redactions.reduce((s, e) => s + e.count, 0),
+  }))
+  stdout(JSON.stringify({ pruneVersion: PRUNE_VERSION, recordings }, null, 2))
+  return 0
+}
+
+async function runDeleteMode(cassette: CassetteFile, flags: PruneFlags): Promise<number> {
+  // biome-ignore lint/style/noNonNullAssertion: caller guarantees flags.delete is non-null
+  const indexes = flags.delete!
+  const seen = new Set<number>()
+  for (const idx of indexes) {
+    if (idx < 0 || idx >= cassette.recordings.length) {
+      stderr(
+        `error: index ${idx} out of range (cassette has ${cassette.recordings.length} recording(s))`,
+      )
+      return 2
+    }
+    if (seen.has(idx)) {
+      stderr(`error: duplicate index ${idx} in --delete list`)
+      return 2
+    }
+    seen.add(idx)
+  }
+
+  const filtered = cassette.recordings.filter((_, i) => !seen.has(i))
+  const updated: CassetteFile = {
+    version: 2,
+    recordedBy: RECORDED_BY,
+    recordings: filtered,
+  }
+  // biome-ignore lint/style/noNonNullAssertion: validated above
+  await writeCassetteFile(flags.path!, serialize(updated))
+  if (!flags.quiet) {
+    stdout(
+      `Wrote 1 cassette. ${indexes.length} recording${indexes.length === 1 ? '' : 's'} deleted.`,
+    )
+  }
+  return 0
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { stderr, stdout } from './cli-output.js'
+import { runPrune } from './cli-prune.js'
 import { runReRedact } from './cli-re-redact.js'
 import { runReview } from './cli-review.js'
 import { runScan } from './cli-scan.js'
@@ -16,6 +17,7 @@ Commands:
   re-redact   Re-apply current redaction rules to existing cassettes.
   show        Pretty-print a cassette for human inspection.
   review      Walk un-redacted findings interactively (a/s/r/d/b/q/?).
+  prune       Remove recordings by index (--delete <indexes>) or list (--json).
 
 Options:
   --version   Print shell-cassette version and exit.
@@ -63,6 +65,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       return runShow(args.rest)
     case 'review':
       return runReview(args.rest)
+    case 'prune':
+      return runPrune(args.rest)
     default:
       stderr(`error: unknown command '${args.command}'\n${HELP}`)
       return 2

--- a/tests/e2e/cli-binary.test.ts
+++ b/tests/e2e/cli-binary.test.ts
@@ -1,24 +1,19 @@
-import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { execa } from 'execa'
 import { describe, expect, test } from 'vitest'
+import { CLI, HAS_BUILT_CLI } from '../helpers/cli-e2e.js'
 
-const CLI_BIN = path.resolve('dist/bin.js')
 const FIXTURES = path.resolve('tests/fixtures/cassettes')
-
-// Skip the suite if dist isn't built so local `npm test` works without a prior
-// `npm run build`. CI builds before test, so all six tests run there.
-const HAS_BUILT_CLI = existsSync(CLI_BIN)
 
 describe.skipIf(!HAS_BUILT_CLI)('shell-cassette binary (e2e)', () => {
   test('--version prints package version', async () => {
-    const result = await execa('node', [CLI_BIN, '--version'])
+    const result = await execa('node', [CLI, '--version'])
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toMatch(/^\d+\.\d+\.\d+/)
   })
 
   test('--help prints usage', async () => {
-    const result = await execa('node', [CLI_BIN, '--help'])
+    const result = await execa('node', [CLI, '--help'])
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('Usage:')
     expect(result.stdout).toContain('scan')
@@ -27,7 +22,7 @@ describe.skipIf(!HAS_BUILT_CLI)('shell-cassette binary (e2e)', () => {
 
   test('scan on clean cassette: exit 0', async () => {
     const result = await execa('node', [
-      CLI_BIN,
+      CLI,
       'scan',
       path.join(FIXTURES, 'v2-clean.json'),
       '--no-color',
@@ -39,7 +34,7 @@ describe.skipIf(!HAS_BUILT_CLI)('shell-cassette binary (e2e)', () => {
   test('scan on dirty cassette: exit 1', async () => {
     const result = await execa(
       'node',
-      [CLI_BIN, 'scan', path.join(FIXTURES, 'v2-dirty.json'), '--no-color'],
+      [CLI, 'scan', path.join(FIXTURES, 'v2-dirty.json'), '--no-color'],
       { reject: false },
     )
     expect(result.exitCode).toBe(1)
@@ -49,7 +44,7 @@ describe.skipIf(!HAS_BUILT_CLI)('shell-cassette binary (e2e)', () => {
   test('scan --json valid JSON output', async () => {
     const result = await execa(
       'node',
-      [CLI_BIN, 'scan', path.join(FIXTURES, 'v2-dirty.json'), '--json'],
+      [CLI, 'scan', path.join(FIXTURES, 'v2-dirty.json'), '--json'],
       { reject: false },
     )
     expect(result.exitCode).toBe(1)
@@ -58,7 +53,7 @@ describe.skipIf(!HAS_BUILT_CLI)('shell-cassette binary (e2e)', () => {
   })
 
   test('unknown command: exit 2', async () => {
-    const result = await execa('node', [CLI_BIN, 'frobnicate'], { reject: false })
+    const result = await execa('node', [CLI, 'frobnicate'], { reject: false })
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('unknown command')
   })

--- a/tests/e2e/cli-prune.test.ts
+++ b/tests/e2e/cli-prune.test.ts
@@ -1,0 +1,59 @@
+import { existsSync } from 'node:fs'
+import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { execa } from 'execa'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+const FIXTURE = path.resolve('tests/fixtures/cassettes/v2-multi-recording-for-prune.json')
+const CLI = path.resolve('dist/bin.js')
+
+const HAS_BUILT_CLI = existsSync(CLI)
+
+let tmp: string
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-prune-e2e-'))
+})
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+describe.skipIf(!HAS_BUILT_CLI)('cli prune e2e', () => {
+  test('--json mode emits pruneVersion: 1', async () => {
+    const r = await execa('node', [CLI, 'prune', FIXTURE, '--json'])
+    expect(r.exitCode).toBe(0)
+    const parsed = JSON.parse(r.stdout)
+    expect(parsed.pruneVersion).toBe(1)
+    expect(parsed.recordings).toHaveLength(3)
+  })
+
+  test('--delete 0,2 removes recordings 0 and 2', async () => {
+    const targetPath = path.join(tmp, 'prune.json')
+    await copyFile(FIXTURE, targetPath)
+    const r = await execa('node', [CLI, 'prune', targetPath, '--delete', '0,2'])
+    expect(r.exitCode).toBe(0)
+    const after = JSON.parse(await readFile(targetPath, 'utf8'))
+    expect(after.recordings).toHaveLength(1)
+    expect(after.recordings[0].call.args).toEqual(['two'])
+  })
+
+  test('exit 2 on out-of-range index', async () => {
+    const targetPath = path.join(tmp, 'prune-bad.json')
+    await copyFile(FIXTURE, targetPath)
+    const r = await execa('node', [CLI, 'prune', targetPath, '--delete', '99'], { reject: false })
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr).toMatch(/out of range/)
+  })
+
+  test('exit 2 on bare prune <path> (no flags)', async () => {
+    const r = await execa('node', [CLI, 'prune', FIXTURE], { reject: false })
+    expect(r.exitCode).toBe(2)
+    expect(r.stderr).toMatch(/--delete <indexes> or --json/)
+  })
+
+  test('--help returns 0', async () => {
+    const r = await execa('node', [CLI, 'prune', '--help'])
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toMatch(/--delete <indexes>/)
+  })
+})

--- a/tests/e2e/cli-prune.test.ts
+++ b/tests/e2e/cli-prune.test.ts
@@ -1,22 +1,13 @@
-import { existsSync } from 'node:fs'
-import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { copyFile, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { execa } from 'execa'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
+import { CLI, HAS_BUILT_CLI } from '../helpers/cli-e2e.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const FIXTURE = path.resolve('tests/fixtures/cassettes/v2-multi-recording-for-prune.json')
-const CLI = path.resolve('dist/bin.js')
 
-const HAS_BUILT_CLI = existsSync(CLI)
-
-let tmp: string
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-prune-e2e-'))
-})
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
-})
+const tmp = useTmpDir('shell-cassette-prune-e2e-')
 
 describe.skipIf(!HAS_BUILT_CLI)('cli prune e2e', () => {
   test('--json mode emits pruneVersion: 1', async () => {
@@ -28,7 +19,7 @@ describe.skipIf(!HAS_BUILT_CLI)('cli prune e2e', () => {
   })
 
   test('--delete 0,2 removes recordings 0 and 2', async () => {
-    const targetPath = path.join(tmp, 'prune.json')
+    const targetPath = path.join(tmp.ref(), 'prune.json')
     await copyFile(FIXTURE, targetPath)
     const r = await execa('node', [CLI, 'prune', targetPath, '--delete', '0,2'])
     expect(r.exitCode).toBe(0)
@@ -38,7 +29,7 @@ describe.skipIf(!HAS_BUILT_CLI)('cli prune e2e', () => {
   })
 
   test('exit 2 on out-of-range index', async () => {
-    const targetPath = path.join(tmp, 'prune-bad.json')
+    const targetPath = path.join(tmp.ref(), 'prune-bad.json')
     await copyFile(FIXTURE, targetPath)
     const r = await execa('node', [CLI, 'prune', targetPath, '--delete', '99'], { reject: false })
     expect(r.exitCode).toBe(2)

--- a/tests/e2e/cli-review-happy-path.test.ts
+++ b/tests/e2e/cli-review-happy-path.test.ts
@@ -1,25 +1,14 @@
-import { existsSync } from 'node:fs'
-import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { copyFile, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { execa } from 'execa'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
+import { CLI, HAS_BUILT_CLI } from '../helpers/cli-e2e.js'
 import { pacedStdin } from '../helpers/paced-stdin.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const FIXTURE = path.resolve('tests/fixtures/cassettes/v2-dirty.json')
-const CLI = path.resolve('dist/bin.js')
 
-// Skip the suite if dist isn't built so local `npm test` works without a prior
-// `npm run build`. CI builds before test, so all tests run there.
-const HAS_BUILT_CLI = existsSync(CLI)
-
-let tmp: string
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-e2e-'))
-})
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
-})
+const tmp = useTmpDir('shell-cassette-review-e2e-')
 
 describe.skipIf(!HAS_BUILT_CLI)('cli review e2e', () => {
   test('--json mode emits reviewVersion: 1 with findings', async () => {
@@ -32,7 +21,7 @@ describe.skipIf(!HAS_BUILT_CLI)('cli review e2e', () => {
   })
 
   test('interactive accept-then-confirm: drives stdin and writes redacted cassette', async () => {
-    const targetPath = path.join(tmp, 'review.json')
+    const targetPath = path.join(tmp.ref(), 'review.json')
     await copyFile(FIXTURE, targetPath)
 
     // Provide stdin: 'a' (accept the one finding) then 'y' (confirm apply).
@@ -51,7 +40,7 @@ describe.skipIf(!HAS_BUILT_CLI)('cli review e2e', () => {
   })
 
   test('interactive quit: cassette unchanged on disk', async () => {
-    const targetPath = path.join(tmp, 'review-quit.json')
+    const targetPath = path.join(tmp.ref(), 'review-quit.json')
     await copyFile(FIXTURE, targetPath)
     const before = await readFile(targetPath, 'utf8')
 

--- a/tests/e2e/cli-show.test.ts
+++ b/tests/e2e/cli-show.test.ts
@@ -1,14 +1,9 @@
-import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { execa } from 'execa'
 import { describe, expect, test } from 'vitest'
+import { CLI, HAS_BUILT_CLI } from '../helpers/cli-e2e.js'
 
 const FIXTURE = path.resolve('tests/fixtures/cassettes/v2-dirty.json')
-const CLI = path.resolve('dist/bin.js')
-
-// Skip the suite if dist isn't built so local `npm test` works without a prior
-// `npm run build`. CI builds before test, so all tests run there.
-const HAS_BUILT_CLI = existsSync(CLI)
 
 describe.skipIf(!HAS_BUILT_CLI)('cli show e2e', () => {
   test('terminal mode emits header, version, redactions, recording sections', async () => {

--- a/tests/fixtures/cassettes/v2-multi-recording-for-prune.json
+++ b/tests/fixtures/cassettes/v2-multi-recording-for-prune.json
@@ -1,0 +1,46 @@
+{
+  "version": 2,
+  "_warning": "REVIEW BEFORE COMMITTING.",
+  "_recorded_by": { "name": "shell-cassette", "version": "0.5.0" },
+  "recordings": [
+    {
+      "call": { "command": "echo", "args": ["one"], "cwd": null, "env": {}, "stdin": null },
+      "result": {
+        "stdoutLines": ["one"],
+        "stderrLines": [],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 5,
+        "aborted": false
+      },
+      "_redactions": []
+    },
+    {
+      "call": { "command": "echo", "args": ["two"], "cwd": null, "env": {}, "stdin": null },
+      "result": {
+        "stdoutLines": ["two"],
+        "stderrLines": [],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 5,
+        "aborted": false
+      },
+      "_redactions": []
+    },
+    {
+      "call": { "command": "echo", "args": ["three"], "cwd": null, "env": {}, "stdin": null },
+      "result": {
+        "stdoutLines": ["three"],
+        "stderrLines": [],
+        "allLines": null,
+        "exitCode": 0,
+        "signal": null,
+        "durationMs": 5,
+        "aborted": false
+      },
+      "_redactions": []
+    }
+  ]
+}

--- a/tests/helpers/capture-cli-output.ts
+++ b/tests/helpers/capture-cli-output.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach } from 'vitest'
+
+/**
+ * Registers beforeEach/afterEach hooks that swap `process.stdout.write` and
+ * `process.stderr.write` for buffered captures, then restores them after
+ * each test. Returns getters so individual tests can read what was emitted.
+ *
+ * Used by unit and integration tests of CLI subcommands. Without this, the
+ * subcommand's render output (including potentially-sensitive finding
+ * content for review) leaks into the vitest reporter.
+ *
+ * Usage:
+ *   const cli = useCapturedCliOutput()
+ *   test('...', async () => {
+ *     await runFoo(['--bar'])
+ *     expect(cli.stdout()).toContain('expected')
+ *     expect(cli.stderr()).toBe('')
+ *   })
+ */
+export function useCapturedCliOutput(): {
+  stdout: () => string
+  stderr: () => string
+} {
+  let outBuf: string[] = []
+  let errBuf: string[] = []
+  const origStdout = process.stdout.write.bind(process.stdout)
+  const origStderr = process.stderr.write.bind(process.stderr)
+
+  beforeEach(() => {
+    outBuf = []
+    errBuf = []
+    process.stdout.write = ((s: string) => {
+      outBuf.push(s)
+      return true
+    }) as typeof process.stdout.write
+    process.stderr.write = ((s: string) => {
+      errBuf.push(s)
+      return true
+    }) as typeof process.stderr.write
+  })
+
+  afterEach(() => {
+    process.stdout.write = origStdout
+    process.stderr.write = origStderr
+  })
+
+  return {
+    stdout: () => outBuf.join(''),
+    stderr: () => errBuf.join(''),
+  }
+}

--- a/tests/helpers/cli-e2e.ts
+++ b/tests/helpers/cli-e2e.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Absolute path to the built CLI entry point.
+ */
+export const CLI = path.resolve('dist/bin.js')
+
+/**
+ * True when `dist/bin.js` exists. e2e suites use this to skip cleanly when
+ * the CLI hasn't been built (so a fresh `npm test` from a clean checkout
+ * works without a prior `npm run build`). CI builds before test, so all
+ * e2e suites run there.
+ *
+ * Usage:
+ *   describe.skipIf(!HAS_BUILT_CLI)('cli foo e2e', () => { ... })
+ */
+export const HAS_BUILT_CLI = existsSync(CLI)

--- a/tests/integration/prune-write.test.ts
+++ b/tests/integration/prune-write.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { runPrune } from '../../src/cli-prune.js'
+import { deserialize } from '../../src/serialize.js'
+
+let tmp: string
+let outBuf: string[]
+let errBuf: string[]
+const origStdout = process.stdout.write.bind(process.stdout)
+const origStderr = process.stderr.write.bind(process.stderr)
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-prune-write-'))
+  outBuf = []
+  errBuf = []
+  process.stdout.write = ((s: string) => {
+    outBuf.push(s)
+    return true
+  }) as typeof process.stdout.write
+  process.stderr.write = ((s: string) => {
+    errBuf.push(s)
+    return true
+  }) as typeof process.stderr.write
+})
+afterEach(async () => {
+  process.stdout.write = origStdout
+  process.stderr.write = origStderr
+  await rm(tmp, { recursive: true, force: true })
+})
+
+async function copyFixture(): Promise<string> {
+  const src = path.resolve('tests/fixtures/cassettes/v2-multi-recording-for-prune.json')
+  const dst = path.join(tmp, 'fix.json')
+  await writeFile(dst, await readFile(src, 'utf8'))
+  return dst
+}
+
+describe('prune write (integration)', () => {
+  test('--delete 0 produces a cassette that round-trips through deserialize as valid v2', async () => {
+    const fix = await copyFixture()
+    await runPrune([fix, '--delete', '0'])
+    const updated = deserialize(await readFile(fix, 'utf8'))
+    expect(updated.version).toBe(2)
+    expect(updated.recordings).toHaveLength(2)
+    expect(updated.recordings[0]?.call.args).toEqual(['two'])
+    expect(updated.recordings[1]?.call.args).toEqual(['three'])
+  })
+
+  test('--delete refreshes recordedBy stamp to current shell-cassette identity', async () => {
+    const fix = await copyFixture()
+    await runPrune([fix, '--delete', '0'])
+    const updated = deserialize(await readFile(fix, 'utf8'))
+    expect(updated.recordedBy?.name).toBe('shell-cassette')
+    expect(updated.recordedBy?.version).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  test('out-of-range index does NOT modify the file', async () => {
+    const fix = await copyFixture()
+    const before = await readFile(fix, 'utf8')
+    expect(await runPrune([fix, '--delete', '99'])).toBe(2)
+    expect(await readFile(fix, 'utf8')).toBe(before)
+  })
+
+  test('duplicate index does NOT modify the file', async () => {
+    const fix = await copyFixture()
+    const before = await readFile(fix, 'utf8')
+    expect(await runPrune([fix, '--delete', '0,0'])).toBe(2)
+    expect(await readFile(fix, 'utf8')).toBe(before)
+  })
+})

--- a/tests/integration/prune-write.test.ts
+++ b/tests/integration/prune-write.test.ts
@@ -1,38 +1,17 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { runPrune } from '../../src/cli-prune.js'
 import { deserialize } from '../../src/serialize.js'
+import { useCapturedCliOutput } from '../helpers/capture-cli-output.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
-let tmp: string
-let outBuf: string[]
-let errBuf: string[]
-const origStdout = process.stdout.write.bind(process.stdout)
-const origStderr = process.stderr.write.bind(process.stderr)
-
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-prune-write-'))
-  outBuf = []
-  errBuf = []
-  process.stdout.write = ((s: string) => {
-    outBuf.push(s)
-    return true
-  }) as typeof process.stdout.write
-  process.stderr.write = ((s: string) => {
-    errBuf.push(s)
-    return true
-  }) as typeof process.stderr.write
-})
-afterEach(async () => {
-  process.stdout.write = origStdout
-  process.stderr.write = origStderr
-  await rm(tmp, { recursive: true, force: true })
-})
+const tmp = useTmpDir('shell-cassette-prune-write-')
+useCapturedCliOutput()
 
 async function copyFixture(): Promise<string> {
   const src = path.resolve('tests/fixtures/cassettes/v2-multi-recording-for-prune.json')
-  const dst = path.join(tmp, 'fix.json')
+  const dst = path.join(tmp.ref(), 'fix.json')
   await writeFile(dst, await readFile(src, 'utf8'))
   return dst
 }

--- a/tests/unit/cli-prune.test.ts
+++ b/tests/unit/cli-prune.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { parsePruneArgs, runPrune } from '../../src/cli-prune.js'
+import { useCapturedCliOutput } from '../helpers/capture-cli-output.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('parsePruneArgs', () => {
   test('--delete 0,2 parsed as [0, 2]', () => {
@@ -38,37 +39,19 @@ describe('parsePruneArgs', () => {
       /not a non-negative integer/,
     )
   })
+
+  test('throws on empty --delete= list', () => {
+    expect(() => parsePruneArgs(['./f.json', '--delete='])).toThrow(/list cannot be empty/)
+  })
 })
 
 describe('runPrune', () => {
-  let tmp: string
-  let outBuf: string[]
-  let errBuf: string[]
-  const origStdout = process.stdout.write.bind(process.stdout)
-  const origStderr = process.stderr.write.bind(process.stderr)
-
-  beforeEach(async () => {
-    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-prune-'))
-    outBuf = []
-    errBuf = []
-    process.stdout.write = ((s: string) => {
-      outBuf.push(s)
-      return true
-    }) as typeof process.stdout.write
-    process.stderr.write = ((s: string) => {
-      errBuf.push(s)
-      return true
-    }) as typeof process.stderr.write
-  })
-  afterEach(async () => {
-    process.stdout.write = origStdout
-    process.stderr.write = origStderr
-    await rm(tmp, { recursive: true, force: true })
-  })
+  const tmp = useTmpDir('shell-cassette-prune-')
+  const cli = useCapturedCliOutput()
 
   async function copyFixture(): Promise<string> {
     const src = path.resolve('tests/fixtures/cassettes/v2-multi-recording-for-prune.json')
-    const dst = path.join(tmp, 'fix.json')
+    const dst = path.join(tmp.ref(), 'fix.json')
     await writeFile(dst, await readFile(src, 'utf8'))
     return dst
   }
@@ -76,7 +59,7 @@ describe('runPrune', () => {
   test('--json emits pruneVersion: 1 with all recordings listed', async () => {
     const fix = await copyFixture()
     expect(await runPrune([fix, '--json'])).toBe(0)
-    const out = JSON.parse(outBuf.join(''))
+    const out = JSON.parse(cli.stdout())
     expect(out.pruneVersion).toBe(1)
     expect(out.recordings).toHaveLength(3)
     expect(out.recordings[0]).toMatchObject({
@@ -107,35 +90,34 @@ describe('runPrune', () => {
   test('--delete with out-of-range index exits 2', async () => {
     const fix = await copyFixture()
     expect(await runPrune([fix, '--delete', '99'])).toBe(2)
-    expect(errBuf.join('')).toMatch(/index 99 out of range/)
+    expect(cli.stderr()).toMatch(/index 99 out of range/)
   })
 
   test('--delete with duplicate index exits 2', async () => {
     const fix = await copyFixture()
     expect(await runPrune([fix, '--delete', '0,0'])).toBe(2)
-    expect(errBuf.join('')).toMatch(/duplicate index/)
+    expect(cli.stderr()).toMatch(/duplicate index/)
   })
 
   test('bare prune <path> (no flags) exits 2 with guidance', async () => {
     const fix = await copyFixture()
     expect(await runPrune([fix])).toBe(2)
-    expect(errBuf.join('')).toMatch(/--delete <indexes> or --json/)
+    expect(cli.stderr()).toMatch(/--delete <indexes> or --json/)
   })
 
   test('--help returns 0', async () => {
     expect(await runPrune(['--help'])).toBe(0)
-    expect(outBuf.join('')).toContain('Usage:')
+    expect(cli.stdout()).toContain('Usage:')
   })
 
   test('exit 2 on missing path entirely', async () => {
     expect(await runPrune([])).toBe(2)
-    expect(errBuf.join('')).toMatch(/prune requires a path/)
+    expect(cli.stderr()).toMatch(/prune requires a path/)
   })
 
   test('--quiet --delete 0 suppresses stdout summary', async () => {
     const fix = await copyFixture()
-    outBuf.length = 0
     expect(await runPrune([fix, '--delete', '0', '--quiet'])).toBe(0)
-    expect(outBuf.join('')).toBe('')
+    expect(cli.stdout()).toBe('')
   })
 })

--- a/tests/unit/cli-prune.test.ts
+++ b/tests/unit/cli-prune.test.ts
@@ -1,0 +1,141 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { parsePruneArgs, runPrune } from '../../src/cli-prune.js'
+
+describe('parsePruneArgs', () => {
+  test('--delete 0,2 parsed as [0, 2]', () => {
+    expect(parsePruneArgs(['./f.json', '--delete', '0,2']).delete).toEqual([0, 2])
+  })
+
+  test('--delete=0,2 parsed', () => {
+    expect(parsePruneArgs(['./f.json', '--delete=0,2']).delete).toEqual([0, 2])
+  })
+
+  test('--json sets json: true', () => {
+    expect(parsePruneArgs(['./f.json', '--json']).json).toBe(true)
+  })
+
+  test('--quiet sets quiet: true', () => {
+    expect(parsePruneArgs(['./f.json', '--quiet', '--delete', '0']).quiet).toBe(true)
+  })
+
+  test('--help', () => {
+    expect(parsePruneArgs(['--help']).help).toBe(true)
+  })
+
+  test('throws on unknown flag', () => {
+    expect(() => parsePruneArgs(['./f.json', '--bogus'])).toThrow(/unknown flag/)
+  })
+
+  test('throws on more than one path', () => {
+    expect(() => parsePruneArgs(['a.json', 'b.json'])).toThrow(/exactly one path/)
+  })
+
+  test('throws when --delete value is non-numeric', () => {
+    expect(() => parsePruneArgs(['./f.json', '--delete', '0,abc'])).toThrow(
+      /not a non-negative integer/,
+    )
+  })
+})
+
+describe('runPrune', () => {
+  let tmp: string
+  let outBuf: string[]
+  let errBuf: string[]
+  const origStdout = process.stdout.write.bind(process.stdout)
+  const origStderr = process.stderr.write.bind(process.stderr)
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-prune-'))
+    outBuf = []
+    errBuf = []
+    process.stdout.write = ((s: string) => {
+      outBuf.push(s)
+      return true
+    }) as typeof process.stdout.write
+    process.stderr.write = ((s: string) => {
+      errBuf.push(s)
+      return true
+    }) as typeof process.stderr.write
+  })
+  afterEach(async () => {
+    process.stdout.write = origStdout
+    process.stderr.write = origStderr
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  async function copyFixture(): Promise<string> {
+    const src = path.resolve('tests/fixtures/cassettes/v2-multi-recording-for-prune.json')
+    const dst = path.join(tmp, 'fix.json')
+    await writeFile(dst, await readFile(src, 'utf8'))
+    return dst
+  }
+
+  test('--json emits pruneVersion: 1 with all recordings listed', async () => {
+    const fix = await copyFixture()
+    expect(await runPrune([fix, '--json'])).toBe(0)
+    const out = JSON.parse(outBuf.join(''))
+    expect(out.pruneVersion).toBe(1)
+    expect(out.recordings).toHaveLength(3)
+    expect(out.recordings[0]).toMatchObject({
+      index: 0,
+      command: 'echo',
+      args: ['one'],
+      exitCode: 0,
+    })
+  })
+
+  test('--delete 1 removes the second recording', async () => {
+    const fix = await copyFixture()
+    expect(await runPrune([fix, '--delete', '1'])).toBe(0)
+    const after = JSON.parse(await readFile(fix, 'utf8'))
+    expect(after.recordings).toHaveLength(2)
+    expect(after.recordings[0].call.args).toEqual(['one'])
+    expect(after.recordings[1].call.args).toEqual(['three'])
+  })
+
+  test('--delete 0,2 removes recordings 0 and 2', async () => {
+    const fix = await copyFixture()
+    expect(await runPrune([fix, '--delete', '0,2'])).toBe(0)
+    const after = JSON.parse(await readFile(fix, 'utf8'))
+    expect(after.recordings).toHaveLength(1)
+    expect(after.recordings[0].call.args).toEqual(['two'])
+  })
+
+  test('--delete with out-of-range index exits 2', async () => {
+    const fix = await copyFixture()
+    expect(await runPrune([fix, '--delete', '99'])).toBe(2)
+    expect(errBuf.join('')).toMatch(/index 99 out of range/)
+  })
+
+  test('--delete with duplicate index exits 2', async () => {
+    const fix = await copyFixture()
+    expect(await runPrune([fix, '--delete', '0,0'])).toBe(2)
+    expect(errBuf.join('')).toMatch(/duplicate index/)
+  })
+
+  test('bare prune <path> (no flags) exits 2 with guidance', async () => {
+    const fix = await copyFixture()
+    expect(await runPrune([fix])).toBe(2)
+    expect(errBuf.join('')).toMatch(/--delete <indexes> or --json/)
+  })
+
+  test('--help returns 0', async () => {
+    expect(await runPrune(['--help'])).toBe(0)
+    expect(outBuf.join('')).toContain('Usage:')
+  })
+
+  test('exit 2 on missing path entirely', async () => {
+    expect(await runPrune([])).toBe(2)
+    expect(errBuf.join('')).toMatch(/prune requires a path/)
+  })
+
+  test('--quiet --delete 0 suppresses stdout summary', async () => {
+    const fix = await copyFixture()
+    outBuf.length = 0
+    expect(await runPrune([fix, '--delete', '0', '--quiet'])).toBe(0)
+    expect(outBuf.join('')).toBe('')
+  })
+})


### PR DESCRIPTION
## What Changed

- New `shell-cassette prune <path>` subcommand:
  - `--delete <indexes>` removes the named 0-based recordings, validates range and rejects duplicates, writes atomically.
  - `--json` emits a structured listing of recordings (`pruneVersion: 1`) so callers can pick indexes via `jq` and pass them to `--delete`.
  - `--help` and `--quiet` round it out.
- Bare `prune <path>` (no flags) exits 2 with guidance.
- Wired into the bin's HELP and dispatch.

Test scaffolding extractions:

- `tests/helpers/cli-e2e.ts` exports `CLI` and `HAS_BUILT_CLI`. Replaces inline `existsSync(path.resolve('dist/bin.js'))` in four e2e files (`cli-binary`, `cli-show`, `cli-review-happy-path`, `cli-prune`).
- `tests/helpers/capture-cli-output.ts` exports `useCapturedCliOutput()` that registers stdout+stderr buffer hooks and returns getters. Replaces the 20-line inline capture pattern in the new prune tests.
- The existing `tests/helpers/tmp-dir.ts` `useTmpDir()` now used in the new prune unit + integration + e2e tests, plus the existing review e2e test that previously rolled its own.

## Why

`scan` and `review` cover credential hygiene, but neither removes whole recordings. Pruning is the third operation a user needs over their cassette tree. The workflow is `prune --json | jq` to pick indexes, then `prune --delete <list>`.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (599 passed, 1 skipped)
- [x] `npm run build` clean

New tests:

- `tests/unit/cli-prune.test.ts` (18): `parsePruneArgs` and `runPrune` covering each flag, `--json` output, `--delete` semantics (range rejection, duplicate rejection, empty-list rejection), bare-path-as-error, `--help`.
- `tests/integration/prune-write.test.ts` (4): round-trip through deserialize, recordedBy refresh on write, no-modify on out-of-range and duplicate indexes.
- `tests/e2e/cli-prune.test.ts` (5): spawns `node dist/bin.js prune <fixture>` for `--json` shape, `--delete` writes, exit-2 paths, `--help`. Suite skips via `describe.skipIf` when `dist/bin.js` is absent.
- New fixture `tests/fixtures/cassettes/v2-multi-recording-for-prune.json` (3 echo recordings).

## Notes

Two follow-ups not addressed here:

- Five CLI files (`cli-scan`, `cli-show`, `cli-re-redact`, `cli-review`, `cli-prune`) still share a near-identical argv-loop skeleton. Past rule-of-three; worth a future extraction but the abstraction would have to handle each subcommand's per-flag validation. Leaving until a sixth subcommand lands.
- `parseShowArgs` accepts `--lines 01` silently while `parseIndexList` rejects it. Pre-existing inconsistency; one-line fix in a separate PR.