### PR TITLE
test: review preScan respects _suppressed at integration level

### DIFF
--- a/tests/helpers/paced-stdin.ts
+++ b/tests/helpers/paced-stdin.ts
@@ -1,27 +1,34 @@
 import { Readable } from 'node:stream'
 
 /**
- * Build a Readable stream that emits each line with a small delay between
- * pushes. Required because Node's `readline.question` can drop a queued
- * answer if stdin EOFs before the next `question()` call is registered.
- * A 100ms gap gives a CLI time to render its prompt and re-register before
- * the next answer lands.
+ * Build a Readable stream that emits each line with a delay between pushes.
+ * Required because Node's `readline.question` can drop a queued answer if
+ * stdin EOFs before the next `question()` call is registered. The delay
+ * gives the CLI time to render its prompt and re-register before the next
+ * answer lands.
+ *
+ * Pacing is 250ms — 100ms was sufficient on Linux but flaky on Windows CI
+ * where readline event scheduling is slower. The added latency only affects
+ * e2e tests (5 tests × 250ms × ~3 prompts each ≈ 4 seconds total), well
+ * within the e2e budget.
  *
  * Used by e2e tests that drive interactive subcommands (review today; the
  * helper is generic enough that any future interactive CLI e2e can reuse).
  */
+const PACE_MS = 250
+
 export function pacedStdin(lines: readonly string[]): Readable {
   let i = 0
   return new Readable({
     read() {
       if (i >= lines.length) {
         // Delay EOF too so the final answer has time to land before stdin closes.
-        setTimeout(() => this.push(null), 100)
+        setTimeout(() => this.push(null), PACE_MS)
         return
       }
       const line = lines[i]
       i++
-      setTimeout(() => this.push(`${line}\n`), 100)
+      setTimeout(() => this.push(`${line}\n`), PACE_MS)
     },
   })
 }

--- a/tests/integration/suppressed-respected.test.ts
+++ b/tests/integration/suppressed-respected.test.ts
@@ -1,19 +1,14 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { reRedactOne } from '../../src/cli-re-redact.js'
+import { preScan } from '../../src/cli-review.js'
 import { collectSuppressedHashes, matchHash } from '../../src/redact-pipeline.js'
 import { deserialize } from '../../src/serialize.js'
 import type { RedactConfig } from '../../src/types.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
-let tmp: string
-beforeEach(async () => {
-  tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-suppressed-'))
-})
-afterEach(async () => {
-  await rm(tmp, { recursive: true, force: true })
-})
+const tmp = useTmpDir('shell-cassette-suppressed-')
 
 const baseConfig: RedactConfig = {
   bundledPatterns: true,
@@ -24,87 +19,104 @@ const baseConfig: RedactConfig = {
   warnPathHeuristic: true,
 }
 
+// Both PATs are exactly ghp_ + 36 alphanumerics = 40 chars (the
+// github-pat-classic shape).
+const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+const OTHER_PAT = 'ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+function makeCassetteJson(opts: { stdoutLines: string[]; suppressedHashes: string[] }): string {
+  const cassette = {
+    version: 2,
+    _warning: '',
+    _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
+    recordings: [
+      {
+        call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
+        result: {
+          stdoutLines: opts.stdoutLines,
+          stderrLines: [],
+          allLines: null,
+          exitCode: 0,
+          signal: null,
+          durationMs: 0,
+          aborted: false,
+        },
+        _redactions: [],
+        _suppressed: opts.suppressedHashes.map((h) => ({
+          source: 'stdout',
+          rule: 'github-pat-classic',
+          position: '1:0',
+          matchHash: h,
+        })),
+      },
+    ],
+  }
+  return `${JSON.stringify(cassette, null, 2)}\n`
+}
+
 describe('re-redact respects _suppressed', () => {
   test('a match whose hash is in _suppressed stays unflagged after re-redact', async () => {
-    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
-    const hash = matchHash(pat)
-    const cassettePath = path.join(tmp, 'fixture.json')
-    const cassette = {
-      version: 2,
-      _warning: '',
-      _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
-      recordings: [
-        {
-          call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
-          result: {
-            stdoutLines: [pat],
-            stderrLines: [],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
-            durationMs: 0,
-            aborted: false,
-          },
-          _redactions: [],
-          _suppressed: [
-            { source: 'stdout', rule: 'github-pat-classic', position: '1:0', matchHash: hash },
-          ],
-        },
-      ],
-    }
-    await writeFile(cassettePath, `${JSON.stringify(cassette, null, 2)}\n`)
+    const cassettePath = path.join(tmp.ref(), 'fixture.json')
+    await writeFile(
+      cassettePath,
+      makeCassetteJson({ stdoutLines: [PAT], suppressedHashes: [matchHash(PAT)] }),
+    )
 
     const result = await reRedactOne(cassettePath, baseConfig, false)
     expect(result.modified).toBe(false)
     expect(result.newRedactions).toBe(0)
 
     const loaded = deserialize(await readFile(cassettePath, 'utf8'))
-    expect(loaded.recordings[0]?.result.stdoutLines[0]).toBe(pat)
+    expect(loaded.recordings[0]?.result.stdoutLines[0]).toBe(PAT)
     expect(loaded.recordings[0]?.suppressed).toHaveLength(1)
-    expect(collectSuppressedHashes(loaded).has(hash)).toBe(true)
+    expect(collectSuppressedHashes(loaded).has(matchHash(PAT))).toBe(true)
   })
 
   test('a match NOT in _suppressed still gets re-redacted normally', async () => {
-    const skippedPat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
-    const otherPat = 'ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-    const skippedHash = matchHash(skippedPat)
-    const cassettePath = path.join(tmp, 'fixture.json')
-    const cassette = {
-      version: 2,
-      _warning: '',
-      _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
-      recordings: [
-        {
-          call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
-          result: {
-            stdoutLines: [skippedPat, otherPat],
-            stderrLines: [],
-            allLines: null,
-            exitCode: 0,
-            signal: null,
-            durationMs: 0,
-            aborted: false,
-          },
-          _redactions: [],
-          _suppressed: [
-            {
-              source: 'stdout',
-              rule: 'github-pat-classic',
-              position: '1:0',
-              matchHash: skippedHash,
-            },
-          ],
-        },
-      ],
-    }
-    await writeFile(cassettePath, `${JSON.stringify(cassette, null, 2)}\n`)
+    const cassettePath = path.join(tmp.ref(), 'fixture.json')
+    await writeFile(
+      cassettePath,
+      makeCassetteJson({
+        stdoutLines: [PAT, OTHER_PAT],
+        suppressedHashes: [matchHash(PAT)],
+      }),
+    )
 
     const result = await reRedactOne(cassettePath, baseConfig, false)
     expect(result.modified).toBe(true)
     expect(result.newRedactions).toBe(1)
 
     const loaded = deserialize(await readFile(cassettePath, 'utf8'))
-    expect(loaded.recordings[0]?.result.stdoutLines[0]).toBe(skippedPat) // skip held
+    expect(loaded.recordings[0]?.result.stdoutLines[0]).toBe(PAT) // skip held
     expect(loaded.recordings[0]?.result.stdoutLines[1]).toContain('<redacted:') // other got placeholder
+  })
+})
+
+describe('review preScan respects _suppressed', () => {
+  test('a match whose hash is in _suppressed is excluded from preScan findings', async () => {
+    const cassettePath = path.join(tmp.ref(), 'fixture.json')
+    await writeFile(
+      cassettePath,
+      makeCassetteJson({ stdoutLines: [PAT], suppressedHashes: [matchHash(PAT)] }),
+    )
+
+    const loaded = deserialize(await readFile(cassettePath, 'utf8'))
+    expect(preScan(loaded, baseConfig)).toEqual([])
+  })
+
+  test('only the suppressed match is excluded; others still surface', async () => {
+    const cassettePath = path.join(tmp.ref(), 'fixture.json')
+    await writeFile(
+      cassettePath,
+      makeCassetteJson({
+        stdoutLines: [PAT, OTHER_PAT],
+        suppressedHashes: [matchHash(PAT)],
+      }),
+    )
+
+    const loaded = deserialize(await readFile(cassettePath, 'utf8'))
+    const findings = preScan(loaded, baseConfig)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.match).toBe(OTHER_PAT)
   })
 })


### PR DESCRIPTION
## What Changed

- Two new tests in `tests/integration/suppressed-respected.test.ts` exercising review's `preScan` against a real on-disk cassette: a single suppressed match returns zero findings; mixed suppressed and un-suppressed matches surface only the latter.
- Drive-by cleanup of the file: shared `makeCassetteJson` helper for the four on-disk-fixture tests (was duplicated inline twice for the existing re-redact tests). Switched to `useTmpDir` from `tests/helpers/`.

## Why

The unit-level coverage in `tests/unit/cli-review.test.ts` uses `makeRecording` to build cassettes in memory with the runtime `suppressed` field name. The on-disk format uses the wire name `_suppressed`. The integration tests catch drift between those two: if `serialize`/`deserialize` ever stops mapping the field correctly, this test fails before a user does.

A consolidated `tests/error-path/cli-errors.test.ts` was also planned but skipped: per-CLI test files (`cli-show`, `cli-review`, `cli-prune`) already cover missing-path, nonexistent-file, unknown-flag, and the prune-specific `--delete` validation paths. Adding a fourth file that re-tests the same matrix would duplicate without adding meaningful coverage.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (601 passed, 1 skipped)
- [x] `npm run build` clean