### PR TITLE
docs: CLI reference, CHANGELOG entry, README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ No public API changes from the main `shell-cassette` entry. The cassette schema 
 ### Added
 
 - **`shell-cassette show <path>` subcommand.** Pretty-prints a cassette for human inspection. Default terminal output is sectioned (header + per-recording with cwd, redacted env keys, exit + duration, line-count truncation). `--json` emits structured output locked at `showVersion: 1`. TTY-aware color, `--no-color` and `--color=always` overrides, `--full` to disable truncation, `--lines <N>` to set lines per stream (default 5).
-- **`shell-cassette review <path>` subcommand.** Interactive walkthrough of unredacted findings. Action keys (API-locked at v0.5): `(a)` accept (apply default redaction), `(s)` skip (persist via `_suppressed`), `(r)` replace (substitute custom string; not for args), `(d)` delete (remove the recording), `(b)` back (revisit previous finding), `(q)` quit (discard all decisions), `(?)` help. Decisions are batched and applied atomically on confirm. `--json` emits a read-only finding listing locked at `reviewVersion: 1` with default-safe match output (hash + preview); `--include-match` opts into raw match values (UNSAFE for piping to logs / CI artifacts).
+- **`shell-cassette review <path>` subcommand.** Interactive walkthrough of unredacted findings. Action keys: `(a)` accept (apply default redaction), `(s)` skip (persist via `_suppressed`), `(r)` replace (substitute custom string; not for args), `(d)` delete (remove the recording), `(b)` back (revisit previous finding), `(q)` quit (discard all decisions), `(?)` help. Decisions are batched and applied atomically on confirm. `--json` emits a read-only finding listing locked at `reviewVersion: 1` with default-safe match output (hash + preview); `--include-match` opts into raw match values (UNSAFE for piping to logs / CI artifacts).
 - **`shell-cassette prune <path>` subcommand.** Remove recordings by 0-based index. `--delete <indexes>` takes a comma-separated list, validates range and rejects duplicates, writes atomically. `--json` emits a read-only listing locked at `pruneVersion: 1` for `jq` composition. `--quiet` suppresses the stdout summary on `--delete`. Bare `prune <path>` (no flags) is an error; the workflow is `prune --json | jq` to pick indexes, then `prune --delete <list>`.
 - **Cassette schema additive: `_suppressed: [{source, rule, position, matchHash}]` per recording.** Written by `review`'s `(s)kip` action; consulted by `re-redact` and `review`'s pre-scan to avoid re-flagging matches the user previously chose to skip. Skip semantics key off `matchHash` (sha256 hex), so the same secret in different positions across recordings is suppressed uniformly.
 - **`CassetteInternalError`** typed `ShellCassetteError` subclass for exhaustiveness throws (`default: const _: never = action; throw new CassetteInternalError(...)`). Programmatic catches on `ShellCassetteError` still pick it up.
@@ -24,7 +24,6 @@ No public API changes from the main `shell-cassette` entry. The cassette schema 
 
 ### Notes
 
-- **Action keys in `review` are API.** Renames would be a breaking change.
 - **Prompt strings are NOT API.** Bots should use `--json` modes plus `re-redact` for automation, not parse interactive prompt text.
 - **Match values in `--json` output default to hash + preview format.** Use `--include-match` for raw values; treat the resulting JSON as sensitive.
 - **`prune --interactive` was cut from v0.5.** `prune --json | jq` plus `prune --delete <list>` covers the workflow without a state machine. Revisit if users ask.
@@ -45,7 +44,7 @@ No public API changes from the main `shell-cassette` entry. The cassette schema 
 
 ### Added
 
-- **25 bundled credential pattern rules** (see `docs/redact-patterns.md`). Default ON. Applies to env values, args, stdout lines, stderr lines, and `allLines`. Covers GitHub (6 token shapes), AWS access key IDs, Stripe (4), OpenAI, Anthropic, Google, Slack (token + webhook URL), GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI, Discord, Square. Rule names are API-stable: locked at v0.4 and never renamed.
+- **25 bundled credential pattern rules** (see `docs/redact-patterns.md`). Default ON. Applies to env values, args, stdout lines, stderr lines, and `allLines`. Covers GitHub (6 token shapes), AWS access key IDs, Stripe (4), OpenAI, Anthropic, Google, Slack (token + webhook URL), GitLab, npm, DigitalOcean, SendGrid, Mailgun, Hugging Face, PyPI, Discord, Square.
 - **User-supplied custom rules** via `Config.redact.customPatterns: RedactRule[]`. Each rule has a kebab-case `name`, a `pattern` (regex or `(s) => string` function), and an optional `description`. Same five-source coverage as the bundle.
 - **Suppress list** via `Config.redact.suppressPatterns: RegExp[]`. Checked first, before bundle and custom rules. A suppressed value is exempt from all rules and from the long-value warning.
 - **Per-cassette redaction override**: `useCassette(name, { redact: false }, fn)`. Coarse-grained; per-stream toggling not supported.
@@ -69,8 +68,7 @@ No public API changes from the main `shell-cassette` entry. The cassette schema 
 
 ### Notes
 
-- **Documented residual gaps** in the redaction surface: AWS Secret Access Keys (caught only by length warning), JWTs (default-off; opt-in via custom rule), encoded credentials (`Authorization: Basic ...`, base64 YAML/JSON), binary output (`BinaryOutputError`), `cwd` values, subprocess `stdin` (until v0.5). See README's "Not redacted (residual risks)" section and `docs/troubleshooting.md` "Residual risks and gaps in v0.4 redaction".
-- **v0.5 will add `show`, `review`, `prune` CLIs** to the same binary, plus the `_suppressed` schema field for `review`'s persistent skip semantics.
+- **Documented residual gaps** in the redaction surface: AWS Secret Access Keys (caught only by length warning), JWTs (default-off; opt-in via custom rule), encoded credentials (`Authorization: Basic ...`, base64 YAML/JSON), binary output (`BinaryOutputError`), `cwd` values, subprocess `stdin`. See README's "Not redacted (residual risks)" section and `docs/troubleshooting.md` "Residual risks and gaps in redaction".
 - **Cassettes recorded by v0.4 are NOT loadable by v0.3.** v0.3's deserializer rejects the schema version. v0.4 still loads v0.3 cassettes; mixed-version teams should pin to v0.4 across the team.
 
 ## [0.3.0] - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-XX-XX
+
+No public API changes from the main `shell-cassette` entry. The cassette schema stays at version 2 (additive `_suppressed` field, no v3 bump). v0.4 cassettes load and replay correctly under v0.5; v0.4 readers ignore the new field.
+
+### Added
+
+- **`shell-cassette show <path>` subcommand.** Pretty-prints a cassette for human inspection. Default terminal output is sectioned (header + per-recording with cwd, redacted env keys, exit + duration, line-count truncation). `--json` emits structured output locked at `showVersion: 1`. TTY-aware color, `--no-color` and `--color=always` overrides, `--full` to disable truncation, `--lines <N>` to set lines per stream (default 5).
+- **`shell-cassette review <path>` subcommand.** Interactive walkthrough of unredacted findings. Action keys (API-locked at v0.5): `(a)` accept (apply default redaction), `(s)` skip (persist via `_suppressed`), `(r)` replace (substitute custom string; not for args), `(d)` delete (remove the recording), `(b)` back (revisit previous finding), `(q)` quit (discard all decisions), `(?)` help. Decisions are batched and applied atomically on confirm. `--json` emits a read-only finding listing locked at `reviewVersion: 1` with default-safe match output (hash + preview); `--include-match` opts into raw match values (UNSAFE for piping to logs / CI artifacts).
+- **`shell-cassette prune <path>` subcommand.** Remove recordings by 0-based index. `--delete <indexes>` takes a comma-separated list, validates range and rejects duplicates, writes atomically. `--json` emits a read-only listing locked at `pruneVersion: 1` for `jq` composition. `--quiet` suppresses the stdout summary on `--delete`. Bare `prune <path>` (no flags) is an error; the workflow is `prune --json | jq` to pick indexes, then `prune --delete <list>`.
+- **Cassette schema additive: `_suppressed: [{source, rule, position, matchHash}]` per recording.** Written by `review`'s `(s)kip` action; consulted by `re-redact` and `review`'s pre-scan to avoid re-flagging matches the user previously chose to skip. Skip semantics key off `matchHash` (sha256 hex), so the same secret in different positions across recordings is suppressed uniformly.
+- **`CassetteInternalError`** typed `ShellCassetteError` subclass for exhaustiveness throws (`default: const _: never = action; throw new CassetteInternalError(...)`). Programmatic catches on `ShellCassetteError` still pick it up.
+
+### Changed
+
+- The bin's `--help` text now lists 5 subcommands (`scan`, `re-redact`, `show`, `review`, `prune`).
+- `re-redact` and `review`'s pre-scan both consult cassette `_suppressed` entries. Matches whose hash is in any recording's suppressed list are not re-flagged on subsequent runs.
+- `RedactOptions` (internal pipeline shape) gains optional `suppressedHashes: ReadonlySet<string>`. v0.4 callers (recorder, canonicalize) pass undefined and behave identically; v0.5's `re-redact` and `review` pass populated sets built from `_suppressed` entries.
+
+### Notes
+
+- **Action keys in `review` are API.** Renames would be a breaking change.
+- **Prompt strings are NOT API.** Bots should use `--json` modes plus `re-redact` for automation, not parse interactive prompt text.
+- **Match values in `--json` output default to hash + preview format.** Use `--include-match` for raw values; treat the resulting JSON as sensitive.
+- **`prune --interactive` was cut from v0.5.** `prune --json | jq` plus `prune --delete <list>` covers the workflow without a state machine. Revisit if users ask.
+- **`(r)eplace` in `review` is unavailable for args** (canonicalize-incompatible). Documented limitation; users can `(d)elete` the recording instead, or hand-edit the cassette JSON.
+
 ## [0.4.0] - 2026-04-28
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 > Polly.js for shell commands. Record subprocess output once, replay deterministically forever. Credential redaction on by default, with `shell-cassette scan` as a pre-commit safety check.
 
-> **Migrating from v0.3?** v0.4 ships breaking changes. See the [migration callout](#migrating-from-v03) below or [CHANGELOG](CHANGELOG.md#040---2026-xx-xx).
-
 ## Why
 
 Tests that shell out are flaky in subtle ways. `git log` returns different output every commit. CI hits a registry that occasionally times out. `gh` and `aws` calls don't work on a plane. The CLI you're wrapping isn't installed on the CI image.
@@ -531,26 +529,6 @@ The default canonicalize is conservative. These patterns are NOT normalized. Wri
 | Relative tmp paths via `path.relative(cwd, tmpPath)` | Custom canonicalize that resolves to absolute first |
 | Custom `$TMPDIR` outside the standard set (e.g., `/scratch/...`) | Compose your own pattern alongside `defaultCanonicalize` |
 | `process.cwd()` substrings inside args | Custom canonicalize that replaces `call.cwd ?? ''` with a token |
-
-## Migrating from v0.3
-
-v0.4 ships breaking changes around redaction and the cassette schema. The full list lives in the [CHANGELOG](CHANGELOG.md#040---2026-xx-xx); the practical migration steps are:
-
-1. **Update your config.** `Config.redactEnvKeys` moved under the new composed `Config.redact` shape:
-   ```diff
-   - export default { redactEnvKeys: ['STRIPE_API_KEY'] }
-   + export default { redact: { envKeys: ['STRIPE_API_KEY'] } }
-   ```
-2. **Remove any direct calls to `redactEnv()`.** The function is removed. The recorder applies redaction transparently at record time; if you need ad-hoc redaction in your code, use the exported `redact()` instead.
-3. **Upgrade existing cassettes.** v0.4 bumps the cassette schema from version 1 to version 2. v0.4 reads both; v0.3 readers reject v2. If you've already recorded under v0.3 and want v0.4's redaction applied to them in place:
-   ```bash
-   npx shell-cassette re-redact tests/__cassettes__/
-   ```
-   Idempotent; running twice yields identical output.
-4. **Add the pre-commit hook.** v0.4 ships the `shell-cassette scan` CLI; wire it as a pre-commit hook (see [Pre-commit hook](#pre-commit-hook) above).
-5. **Review residual gaps.** v0.4's bundle covers 25 credential shapes but does not cover AWS Secret Access Keys, JWTs, or encoded credentials. Check the [Not redacted (residual risks)](#not-redacted-residual-risks) section and [docs/troubleshooting.md](docs/troubleshooting.md#residual-risks-and-gaps-in-v04-redaction); add custom rules for project-specific shapes if needed.
-
-Mixed-version teams should pin to v0.4 across the team. Cassettes recorded by v0.4 are not loadable by v0.3.
 
 ## Common gotchas
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ shell-cassette fits tests that **assert on subprocess output** (stdout, stderr, 
 
 It is NOT for:
 
-- Tests asserting on **which command was called** (`expect(execMock).toHaveBeenCalledWith(...)`). That's mock-for-assertion. Use `vi.mock` instead; that's a different problem and `vi.mock` is the right tool for it.
+- Tests asserting on **which command was called** (`expect(execMock).toHaveBeenCalledWith(...)`). That's mock-for-assertion. Use `vi.mock` instead.
 - Tests where the subprocess **mutates state** (creates a commit, installs packages, writes files) that non-mocked downstream code then reads. Replay returns recorded output but doesn't perform the mutation; downstream sees an unset-up state.
 
 See [What this doesn't do](#what-this-doesnt-do) for the full incompatibility list.
@@ -108,11 +108,11 @@ CI:
 npm test  # CI=true forces replay-strict
 ```
 
-Cassettes land at `__cassettes__/<test-file>/<test-name>.json`. Commit them.
+Cassettes are written to `__cassettes__/<test-file>/<test-name>.json`. Commit them.
 
 ## Adapters
 
-shell-cassette ships drop-in replacements for two subprocess libraries:
+shell-cassette provides drop-in replacements for two subprocess libraries:
 
 - **[execa](docs/execa.md)** (`shell-cassette/execa`)
 - **[tinyexec](docs/tinyexec.md)** (`shell-cassette/tinyexec`)
@@ -155,11 +155,11 @@ Set via `SHELL_CASSETTE_MODE=record|replay|passthrough|auto`. `CI=true` forces `
 
 ## Security: redaction
 
-shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`. The ack gate forces a conscious "I know what gets redacted and what doesn't" decision before any cassette lands on disk. Recording is the only mode that requires it; replay needs nothing.
+shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`. The ack gate forces a conscious "I know what gets redacted and what doesn't" decision before any cassette is written to disk. Recording is the only mode that requires it; replay needs nothing.
 
 ### Redacted by default
 
-shell-cassette ships **25 bundled credential patterns**, applied to env values, args, stdout lines, stderr lines, and `allLines`. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format:
+shell-cassette provides **25 bundled credential patterns**, applied to env values, args, stdout lines, stderr lines, and `allLines`. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format:
 
 - **GitHub** (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `github_pat_`)
 - **AWS access key IDs** (`AKIA`, `ASIA`, `AROA`, `AIDA`, `AGPA`, `ANPA`, `ANVA`, `APKA`, `ABIA`, `ACCA`)
@@ -178,7 +178,7 @@ shell-cassette ships **25 bundled credential patterns**, applied to env values, 
 - **Discord** (three-segment base64 bot tokens)
 - **Square** (`EAAA`)
 
-Full reference table with provider docs in [docs/redact-patterns.md](docs/redact-patterns.md). Rule names are API-stable: locked at v0.4 and never renamed.
+Full reference table with provider docs in [docs/redact-patterns.md](docs/redact-patterns.md).
 
 Each redaction replaces the credential with a counter-tagged placeholder: `<redacted:source:rule-name:N>`. The counter is per-cassette per (source, rule). Diff-friendly: re-recording a cassette with the same secrets produces identical placeholders.
 
@@ -211,9 +211,9 @@ shell-cassette redacts what it can detect with 100% reliability and warns on sus
 - **Encoded credentials.** `Authorization: Basic <base64>` headers, base64-encoded YAML/JSON secrets. shell-cassette doesn't decode. Add a custom rule if relevant.
 - **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8.
 - **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
-- **Subprocess `stdin`.** Not captured in v0.4. v0.5 will capture stdin and apply the same pipeline.
+- **Subprocess `stdin`.** Not captured.
 
-Workarounds for each gap are in [docs/troubleshooting.md](docs/troubleshooting.md#residual-risks-and-gaps-in-v04-redaction).
+Workarounds for each gap are in [docs/troubleshooting.md](docs/troubleshooting.md#residual-risks-and-gaps-in-redaction).
 
 ### Long-value warnings
 
@@ -231,7 +231,7 @@ Each cassette JSON also contains a top-level `_warning` field reminding reviewer
 
 ## Pre-commit hook
 
-The `shell-cassette scan` CLI walks cassette files (or directories) and reports any unredacted findings. Run it as a pre-commit hook to block credentials from ever landing in a commit.
+The `shell-cassette scan` CLI walks cassette files (or directories) and reports any unredacted findings. Run it as a pre-commit hook to block credentials from ever ending up in a commit.
 
 **husky:**
 
@@ -260,7 +260,7 @@ When the hook blocks: review the listed findings, run `npx shell-cassette re-red
 
 ## CLI usage
 
-shell-cassette ships a `shell-cassette` binary with five subcommands. Two write to cassettes (`re-redact`, `prune`), one walks them interactively (`review`), two are read-only (`scan`, `show`).
+shell-cassette includes a `shell-cassette` binary with five subcommands. Two write to cassettes (`re-redact`, `prune`), one walks them interactively (`review`), two are read-only (`scan`, `show`).
 
 ### `scan`
 
@@ -345,7 +345,7 @@ npx shell-cassette review tests/__cassettes__/foo.json --json   # read-only find
 
 `--json` emits a finding listing locked at `reviewVersion: 1` with default-safe match output (sha256 hash + preview). Use `--include-match` to include raw match values; treat the resulting JSON as sensitive.
 
-Action keys (`a/s/r/d/b/q/?`) are API-locked at v0.5. Renames would be a breaking change. See [`docs/cli.md`](./docs/cli.md#shell-cassette-review-path) for the full reference.
+See [`docs/cli.md`](./docs/cli.md#shell-cassette-review-path) for the full reference.
 
 Exit `0` reviewed (with or without changes), `2` error.
 
@@ -358,7 +358,7 @@ npx shell-cassette prune tests/__cassettes__/foo.json --json   # list recordings
 npx shell-cassette prune tests/__cassettes__/foo.json --delete 0,2
 ```
 
-There is no interactive walk in v0.5. Pipe `prune --json | jq` to pick indexes by command, args, or exit code, then pass the comma-separated list to `--delete`. Bare `prune <path>` (no flags) is an error. See [`docs/cli.md`](./docs/cli.md#shell-cassette-prune-path) for the full reference.
+There is no interactive walk. Pipe `prune --json | jq` to pick indexes by command, args, or exit code, then pass the comma-separated list to `--delete`. Bare `prune <path>` (no flags) is an error. See [`docs/cli.md`](./docs/cli.md#shell-cassette-prune-path) for the full reference.
 
 Exit `0` ok, `2` error.
 
@@ -408,10 +408,10 @@ Run `shell-cassette --help` for the full subcommand list, or `shell-cassette <co
 
 ## Adapter quirks
 
-A few v0.4 specifics worth knowing:
+A few v0.4 specifics:
 
 - **`shell-cassette/tinyexec` exports `exec` as an alias for `x`.** Mirrors tinyexec's own dual export so `import { exec } from 'tinyexec'` redirects to `import { exec } from 'shell-cassette/tinyexec'` without renaming.
-- **`shell-cassette/tinyexec.xSync` throws.** Sync subprocess wrapping requires synchronous lazy-load support, planned for v0.5. Use async `x` (recommended), or import `xSync` directly from `tinyexec` (those calls bypass shell-cassette).
+- **`shell-cassette/tinyexec.xSync` throws.** Sync subprocess wrapping is not supported. Use async `x` (recommended), or import `xSync` directly from `tinyexec` (those calls bypass shell-cassette).
 - **`result.process` on tinyexec replay throws** a clear `ShellCassetteError`. Tests reading `result.process.stdout` / `.stderr` / `.stdin` should switch to the buffered `result.stdout` / `result.stderr` fields, or run with `SHELL_CASSETTE_MODE=passthrough`.
 
 See [docs/tinyexec.md](docs/tinyexec.md) for the full set of replay limits.
@@ -549,7 +549,7 @@ If you hit one of these, see [docs/troubleshooting.md](docs/troubleshooting.md):
 
 Two patterns shell-cassette is not a fit for. 
 
-**Mock-for-assertion patterns.** shell-cassette captures and replays subprocess **output**, not subprocess invocations. Tests that assert on **which command was called** (`expect(execMock).toHaveBeenCalledWith('git', ['commit', ...])`) are testing the wrong abstraction layer. Use `vi.mock` for that pattern; it's a different concern. Examples in the wild: `prettier/pretty-quick`, `antfu/ni`, `jinghaihan/pncat`.
+**Mock-for-assertion patterns.** shell-cassette captures and replays subprocess **output**, not subprocess invocations. Tests that assert on **which command was called** (`expect(execMock).toHaveBeenCalledWith('git', ['commit', ...])`) are testing the wrong abstraction layer. Use `vi.mock` for that pattern. Examples in the wild: `prettier/pretty-quick`, `antfu/ni`, `jinghaihan/pncat`.
 
 **Subprocess as state mutator.** shell-cassette mocks subprocess **outputs** on replay; it does NOT actually re-execute the subprocess. Tests that use a subprocess to mutate state (`git commit` to make a real commit, `mkdir`/`touch` to create files, `npm install` to populate node_modules), then have downstream code that depends on that mutation, will fail in replay mode: setup is mocked, no real mutation happens, downstream sees an unset-up state. Two patterns to watch for:
 
@@ -571,7 +571,7 @@ shell-cassette is for **output-assertion** tests: spawn a subprocess, capture st
 
 ### Speedup measurements
 
-Three projects measured on Windows + Node 23.11 against v0.4. Point measurements, not benchmarks: directional only.
+Three projects measured on Windows + Node 23.11. Point measurements, not benchmarks.
 
 | Project | Tests / cassettes | Test-phase speedup | Wall speedup | Notes |
 |---|---:|---:|---:|---|
@@ -583,7 +583,7 @@ Wall-time speedup is bounded by vitest startup (~300-400ms regardless of mode). 
 
 **What "speedup" means here.** Record runs the real subprocess once, replay reads the cassette. The multiplier is record test-phase divided by replay test-phase. Wall-time speedup includes vitest startup and is the smaller number. Both numbers vary with machine state, Node version, and background load.
 
-**What "tests / cassettes" means here.** Not every test in a project's suite cleanly cassettes: tests that assert on subprocess side effects (filesystem state, network calls outside subprocess) can't replay because the side effect didn't happen. Tests reading `result.process.stdout` synchronously hit the same limit. The test count is the suite's full execution count under SC; the cassette count is what records cleanly. Tests outside the cassettable surface either fall to passthrough or fail in replay with actionable errors. See [docs/troubleshooting.md](docs/troubleshooting.md) for patterns and workarounds.
+**What "tests / cassettes" means here.** Not every test in a project's suite records to a cassette: tests that assert on subprocess side effects (filesystem state, network calls outside subprocess) can't replay because the side effect didn't happen. Tests reading `result.process.stdout` synchronously hit the same limit. The test count is the suite's full execution count under SC; the cassette count is what records without errors. Tests outside the cassettable surface either fall to passthrough or fail in replay with actionable errors. See [docs/troubleshooting.md](docs/troubleshooting.md) for patterns and workarounds.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -582,10 +582,6 @@ shell-cassette is for **output-assertion** tests: spawn a subprocess, capture st
 
 ## Real-world results
 
-### Each claim, what proves it
-
-Every claim in [What this unlocks](#why) is backed by a concrete demonstration. The table below maps claim to evidence.
-
 | Claim | What was demonstrated |
 |---|---|
 | Reproducible CI failures | One subprocess call recorded, then replayed 10 times in sequence. All 10 replays produce byte-identical stdout, stderr, and exitCode. If any external variance leaked through, at least one of the ten would diverge. |
@@ -594,8 +590,6 @@ Every claim in [What this unlocks](#why) is backed by a concrete demonstration. 
 | Failure-path testing | Successful subprocess (`exitCode: 0`) recorded. Cassette JSON read, mutated to `exitCode: 137`, written back. Replay throws an ExecaError-shaped object with `exitCode === 137`, `failed === true`. The user's `try/catch` runs. With `reject: false`, replay returns the same shape without throwing. |
 | Speed | Per-call: ~75ms record vs ~1.2ms replay on a trivial node-eval workload (60x). Full suite: unjs/nypm 211.72s record vs 0.263s replay (805x). See speedup table below. |
 | Credentials stay out | All 25 bundled patterns plus 5 curated env-key substrings exercised end-to-end. 30 cassettes recorded, scanned with `shell-cassette scan`, 0 dirty. The host's `LM_STUDIO_API_KEY` was caught by `API_KEY` substring match on every recording. Pattern reference: [docs/redact-patterns.md](docs/redact-patterns.md). |
-
-Demonstrations live in the validation harness alongside the project. The first four are new in v0.4 (`determinism`, `offline`, `failure-path`); credentials and full-suite speed have been validated since v0.3 (M9-M10) and v0.4 M14 respectively.
 
 ### Speedup measurements
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ When the hook blocks: review the listed findings, run `npx shell-cassette re-red
 
 ## CLI usage
 
-shell-cassette ships a `shell-cassette` binary with two subcommands.
+shell-cassette ships a `shell-cassette` binary with five subcommands. Two write to cassettes (`re-redact`, `prune`), one walks them interactively (`review`), two are read-only (`scan`, `show`).
 
 ### `scan`
 
@@ -322,6 +322,72 @@ Common flags:
 
 Exit `0` no new redactions, `1` at least one cassette modified (or would be in dry-run), `2` error.
 
+### `show`
+
+Read-only. Pretty-prints a single cassette for human inspection.
+
+```bash
+npx shell-cassette show tests/__cassettes__/login.json
+npx shell-cassette show tests/__cassettes__/login.json --json | jq '.summary'
+npx shell-cassette show tests/__cassettes__/login.json --full   # disable truncation
+```
+
+Default output is sectioned (header + per-recording listing). `--json` emits structured output locked at `showVersion: 1`. See [`docs/cli.md`](./docs/cli.md#shell-cassette-show-path) for the full reference.
+
+Exit `0` ok, `2` error.
+
+### `review`
+
+Walk un-redacted findings interactively. For each finding, pick `(a)` accept, `(s)` skip, `(r)` replace, `(d)` delete, `(b)` back, or `(q)` quit. Decisions are batched and applied atomically on confirm. The skip action persists via the cassette's `_suppressed` field so `re-redact` and subsequent `review` runs do not re-flag the same match.
+
+```bash
+npx shell-cassette review tests/__cassettes__/foo.json
+npx shell-cassette review tests/__cassettes__/foo.json --json   # read-only finding listing
+```
+
+`--json` emits a finding listing locked at `reviewVersion: 1` with default-safe match output (sha256 hash + preview). Use `--include-match` to include raw match values; treat the resulting JSON as sensitive.
+
+Action keys (`a/s/r/d/b/q/?`) are API-locked at v0.5. Renames would be a breaking change. See [`docs/cli.md`](./docs/cli.md#shell-cassette-review-path) for the full reference.
+
+Exit `0` reviewed (with or without changes), `2` error.
+
+### `prune`
+
+Remove recordings by 0-based index. Atomic write.
+
+```bash
+npx shell-cassette prune tests/__cassettes__/foo.json --json   # list recordings
+npx shell-cassette prune tests/__cassettes__/foo.json --delete 0,2
+```
+
+There is no interactive walk in v0.5. Pipe `prune --json | jq` to pick indexes by command, args, or exit code, then pass the comma-separated list to `--delete`. Bare `prune <path>` (no flags) is an error. See [`docs/cli.md`](./docs/cli.md#shell-cassette-prune-path) for the full reference.
+
+Exit `0` ok, `2` error.
+
+### Cassette inspection workflow
+
+A typical flow when a freshly-recorded cassette has findings:
+
+```bash
+# 1. Record (the ack gate runs at record time)
+SHELL_CASSETTE_ACK_REDACTION=true npm test
+
+# 2. Verify nothing leaked
+npx shell-cassette scan tests/__cassettes__
+
+# 3. If scan is dirty, walk findings and decide per-match
+npx shell-cassette review tests/__cassettes__/the-dirty-one.json
+
+# 4. Optionally remove unwanted recordings
+npx shell-cassette prune tests/__cassettes__/the-dirty-one.json --json | jq ...
+npx shell-cassette prune tests/__cassettes__/the-dirty-one.json --delete 0,5
+
+# 5. Final verification before commit
+npx shell-cassette scan tests/__cassettes__
+git add tests/__cassettes__
+git commit
+```
+
 ### Ack-gate workflow
 
 Recording requires `SHELL_CASSETTE_ACK_REDACTION=true`. Replay does not. Typical flow:
@@ -340,7 +406,7 @@ npm test
 npm test  # CI=true is set by your CI provider
 ```
 
-Run `shell-cassette --help`, `shell-cassette scan --help`, and `shell-cassette re-redact --help` for the full flag list.
+Run `shell-cassette --help` for the full subcommand list, or `shell-cassette <command> --help` for per-subcommand flags.
 
 ## Adapter quirks
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # shell-cassette CLI reference
 
-The `shell-cassette` binary ships five subcommands as of v0.5:
+The `shell-cassette` binary includes five subcommands:
 
 | Subcommand   | Purpose                                                  | Read/Write          |
 | ------------ | -------------------------------------------------------- | ------------------- |
@@ -218,10 +218,10 @@ shell-cassette prune <path> --help
 
 Two modes (one is required when a path is provided):
 
-- `--delete <indexes>` — comma-separated 0-based indexes. The named recordings are removed; the remaining recordings keep their relative order. Atomic write via the temp-file + rename pipeline.
-- `--json` — structured listing of recordings (`pruneVersion: 1`). Read-only.
+- `--delete <indexes>` takes a comma-separated list of 0-based indexes. The named recordings are removed; the remaining recordings keep their relative order. Atomic write via the temp-file + rename pipeline.
+- `--json` emits a structured listing of recordings (`pruneVersion: 1`). Read-only.
 
-There is no interactive walk in v0.5. The typical workflow is `prune --json | jq` to choose indexes by command, args, or exit code, then `prune --delete <list>`.
+There is no interactive walk. The typical workflow is `prune --json | jq` to choose indexes by command, args, or exit code, then `prune --delete <list>`.
 
 ### Flags
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,280 @@
+# shell-cassette CLI reference
+
+The `shell-cassette` binary ships five subcommands as of v0.5:
+
+| Subcommand   | Purpose                                                  | Read/Write          |
+| ------------ | -------------------------------------------------------- | ------------------- |
+| `scan`       | Verify cassettes have no unredacted credentials.         | Read-only           |
+| `re-redact`  | Re-apply current redaction rules to existing cassettes.  | Writes (idempotent) |
+| `show`       | Pretty-print a cassette for human inspection.            | Read-only           |
+| `review`     | Walk un-redacted findings interactively.                 | Writes on confirm   |
+| `prune`      | Remove recordings by 0-based index.                      | Writes              |
+
+All subcommands share the same color and TTY conventions (TTY auto-detect, `NO_COLOR` env var honored, `--no-color` and `--color=always` overrides) and the same exit-code semantics: 0 on success, 2 on error. `scan` additionally returns 1 when at least one cassette is dirty; `re-redact` returns 1 when at least one cassette was modified.
+
+`scan` and `re-redact` are documented in the [README](../README.md). The rest of this file covers `show`, `review`, and `prune`.
+
+---
+
+## `shell-cassette show <path>`
+
+Pretty-print a cassette. Read-only.
+
+### Synopsis
+
+```
+shell-cassette show <path> [--json] [--full] [--lines <N>] [--no-color] [--color=always] [--help]
+```
+
+### Description
+
+Renders a cassette file in one of two formats:
+
+- **Terminal mode (default).** Sectioned output: header (path + size), version line (recorder identity if present, fallback for v1 cassettes), redactions summary by rule, then per-recording listing with index, command, args, cwd, redacted env keys, exit code (green for 0, red otherwise), duration, and stdout/stderr/allLines with line-count truncation. Color highlights placeholders in cyan and emphasis in bold.
+- **`--json` mode.** Structured payload locked at `showVersion: 1`.
+
+### Flags
+
+| Flag             | Default     | Description                                       |
+| ---------------- | ----------- | ------------------------------------------------- |
+| `--json`         | off         | Emit structured output.                           |
+| `--full`         | off         | Disable line truncation.                          |
+| `--lines <N>`    | 5           | Lines per stream in terminal mode.                |
+| `--no-color`     | env-aware   | Force color off.                                  |
+| `--color=always` | env-aware   | Force color on.                                   |
+| `--help`         |             | Print usage.                                      |
+
+### Exit codes
+
+| Code | Meaning                                             |
+| ---- | --------------------------------------------------- |
+| 0    | Cassette displayed.                                 |
+| 2    | Missing path, malformed cassette, conflicting flags. |
+
+### `--json` output shape
+
+Locked at `showVersion: 1`:
+
+```json
+{
+  "showVersion": 1,
+  "summary": {
+    "path": "tests/__cassettes__/foo.json",
+    "fileSize": 1234,
+    "version": 2,
+    "recordedBy": { "name": "shell-cassette", "version": "0.5.0" },
+    "recordingCount": 3,
+    "redactions": {
+      "total": 4,
+      "byRule": { "github-pat-classic": 2, "openai-api-key": 1, "aws-access-key-id": 1 },
+      "bySource": { "env": 1, "args": 1, "stdout": 2 }
+    }
+  },
+  "cassette": { "...": "full deserialized cassette JSON" }
+}
+```
+
+`cassette` is the entire deserialized file. For very large cassettes, prefer the `summary` field for piping to `jq`.
+
+### Examples
+
+```bash
+# Inspect a cassette
+shell-cassette show tests/__cassettes__/login.json
+
+# Just the summary
+shell-cassette show tests/__cassettes__/login.json --json | jq '.summary'
+
+# Full content, no truncation
+shell-cassette show tests/__cassettes__/login.json --full
+```
+
+---
+
+## `shell-cassette review <path>`
+
+Walk un-redacted findings interactively. Writes on confirm.
+
+### Synopsis
+
+```
+shell-cassette review <path> [--json] [--include-match] [--config <path>] [--no-color] [--color=always] [--help]
+```
+
+### Description
+
+Pre-scans the cassette for un-redacted findings using the same regex rules as `scan`, plus the env-key-match path (env values whose key is in the curated list). Then walks each finding one at a time. For each finding the user picks an action:
+
+| Key   | Action  | Description                                                                                                                                              |
+| ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `(a)` | accept  | Apply default redaction. The match becomes `<redacted:source:rule:N>` (counter-tagged).                                                                  |
+| `(s)` | skip    | Leave the match in body. Persists a `SuppressedEntry` so the match is not re-flagged on subsequent runs of `review` or `re-redact`.                     |
+| `(r)` | replace | Substitute a user-provided string. Not available for `args` (canonicalize-incompatible). Recorded as `rule: 'custom'` in the redaction summary.          |
+| `(d)` | delete  | Remove the entire recording from the cassette. Confirms before adding the decision.                                                                      |
+| `(b)` | back    | Revisit the previous finding. Removes the prior decision (the user must re-decide). Unwinds multi-step jumps from `(d)elete`.                            |
+| `(q)` | quit    | Discard all decisions and exit without writing.                                                                                                          |
+| `(?)` | help    | Print key reference.                                                                                                                                     |
+
+After all findings are walked, a summary screen lists decisions and asks `Apply changes? (y/N)`. `y` writes the cassette atomically; `n` discards.
+
+### Flags
+
+| Flag                | Default     | Description                                                                                                |
+| ------------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
+| `--json`            | off         | Read-only structured output. No prompts.                                                                   |
+| `--include-match`   | off         | With `--json`, include raw match values. **UNSAFE for piping to logs / CI artifacts.**                     |
+| `--config <path>`   |             | Override config discovery.                                                                                 |
+| `--no-color`        | env-aware   |                                                                                                            |
+| `--color=always`    | env-aware   |                                                                                                            |
+| `--help`            |             |                                                                                                            |
+
+### Exit codes
+
+| Code | Meaning                                              |
+| ---- | ---------------------------------------------------- |
+| 0    | Reviewed (with or without changes).                  |
+| 2    | Missing path, malformed cassette, conflicting flags. |
+
+### `--json` output shape
+
+Locked at `reviewVersion: 1`:
+
+```json
+{
+  "reviewVersion": 1,
+  "summary": {
+    "totalFindings": 12,
+    "byRule": { "github-pat-classic": 8, "openai-api-key": 4 },
+    "bySource": { "args": 3, "stdout": 9 }
+  },
+  "findings": [
+    {
+      "id": "rec2-stdout-4:15-github-pat-classic",
+      "recordingIndex": 2,
+      "source": "stdout",
+      "rule": "github-pat-classic",
+      "matchHash": "sha256:abc123...",
+      "matchLength": 40,
+      "matchPreview": "ghp_...7890",
+      "position": "4:15",
+      "context": {
+        "lineNumber": 4,
+        "before": ["...line 2...", "...line 3..."],
+        "line": "...line 4 with match...",
+        "after": ["...line 5...", "...line 6..."]
+      }
+    }
+  ]
+}
+```
+
+With `--include-match`, each finding gains a `match` field with the raw matched string. Treat the resulting JSON as sensitive.
+
+### Match preview format
+
+- Length >= 12: first 4 + `...` + last 4 (e.g., `ghp_...7890`).
+- Length < 12: full match.
+
+### Finding ID format
+
+`rec<recordingIndex>-<source>-<position>-<rule>`. Position varies by source:
+
+- `<line>:<col>` for stdout, stderr, allLines.
+- `<argIndex>:<col>` for args.
+- `<KEY>:0` for env values (env-key-match findings) or `<KEY>:<col>` for env values matched by regex.
+
+### Skip semantics
+
+`(s)kip` writes a `SuppressedEntry` to the recording's `_suppressed` array on apply. Both `review`'s pre-scan and `re-redact` consult `_suppressed` and skip matches whose `matchHash` is present. Skip is per-cassette and persists across runs. Quitting before apply discards all decisions, so skip is recoverable until you confirm.
+
+### Examples
+
+```bash
+# Walk findings interactively
+shell-cassette review tests/__cassettes__/foo.json
+
+# Inspect findings without prompting
+shell-cassette review tests/__cassettes__/foo.json --json
+
+# Get raw match values for offline review (do NOT pipe to logs)
+shell-cassette review tests/__cassettes__/foo.json --json --include-match
+```
+
+---
+
+## `shell-cassette prune <path>`
+
+Remove recordings by 0-based index. Writes.
+
+### Synopsis
+
+```
+shell-cassette prune <path> --delete <indexes>
+shell-cassette prune <path> --json
+shell-cassette prune <path> --help
+```
+
+### Description
+
+Two modes (one is required when a path is provided):
+
+- `--delete <indexes>` — comma-separated 0-based indexes. The named recordings are removed; the remaining recordings keep their relative order. Atomic write via the temp-file + rename pipeline.
+- `--json` — structured listing of recordings (`pruneVersion: 1`). Read-only.
+
+There is no interactive walk in v0.5. The typical workflow is `prune --json | jq` to choose indexes by command, args, or exit code, then `prune --delete <list>`.
+
+### Flags
+
+| Flag                  | Default   | Description                                          |
+| --------------------- | --------- | ---------------------------------------------------- |
+| `--delete <indexes>`  |           | Comma-separated 0-based indexes to remove.           |
+| `--json`              | off       | Read-only structured listing.                        |
+| `--quiet`             | off       | Suppress stdout summary on `--delete`.               |
+| `--no-color`          | env-aware |                                                      |
+| `--color=always`      | env-aware |                                                      |
+| `--help`              |           |                                                      |
+
+### Exit codes
+
+| Code | Meaning                                                                                                  |
+| ---- | -------------------------------------------------------------------------------------------------------- |
+| 0    | Listed (`--json`) or deleted successfully.                                                               |
+| 2    | Missing path, no mode flag, out-of-range index, duplicate index, empty `--delete=` list, malformed JSON. |
+
+### `--json` output shape
+
+Locked at `pruneVersion: 1`:
+
+```json
+{
+  "pruneVersion": 1,
+  "recordings": [
+    {
+      "index": 0,
+      "command": "gh",
+      "args": ["repo", "create", "..."],
+      "exitCode": 0,
+      "durationMs": 1234,
+      "redactionCount": 1
+    }
+  ]
+}
+```
+
+### Examples
+
+```bash
+# List all recordings
+shell-cassette prune tests/__cassettes__/foo.json --json
+
+# Pick non-zero-exit recordings via jq, then delete
+shell-cassette prune tests/__cassettes__/foo.json --json \
+  | jq -r '.recordings[] | select(.exitCode != 0) | .index' \
+  | paste -sd ','
+shell-cassette prune tests/__cassettes__/foo.json --delete 1,3,7
+
+# Delete a single recording without the summary line
+shell-cassette prune tests/__cassettes__/foo.json --delete 0 --quiet
+```
+
+When prune writes a cassette, it stamps `recordedBy` with the current shell-cassette identity so the file's recorder metadata reflects the most recent write (consistent with `re-redact` and `review`'s confirm-write).

--- a/docs/redact-patterns.md
+++ b/docs/redact-patterns.md
@@ -1,6 +1,6 @@
 # Bundled redaction patterns
 
-shell-cassette ships 25 default-on credential patterns. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format. Rule names are API-stable: they ship locked at v0.4 and are never renamed. New patterns may be added additively in any version; removing or renaming a rule name is a breaking change.
+shell-cassette provides 25 default-on credential patterns. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format.
 
 For ambiguous credential shapes (AWS Secret Access Keys, JWTs, generic 32-hex tokens), the bundle deliberately does not include a pattern. The long-value warning catches them at length 40+ when they don't look like a path. Custom rules cover the rest.
 

--- a/docs/tinyexec.md
+++ b/docs/tinyexec.md
@@ -73,7 +73,7 @@ tinyexec returns a richer object than `Promise<Result>` - it's structurally `Pro
 | `for await (line of result)` | Throws `UnsupportedOptionError` | Interleaving order between stdout and stderr is lost in storage |
 | Synchronous reads of `proc.pid`, `proc.killed`, `proc.aborted` BEFORE `await` | Returns `undefined` | Replay returns `Promise<Result>`, not the live ProcessPromise shape |
 
-**Workaround:** `await` the result first, then read fields on the resolved object. All v0.2 validation targets (varlet-release, cac, eslint-import-resolver-typescript) follow this pattern, so it's the common case.
+**Workaround:** `await` the result first, then read fields on the resolved object. The validation targets (varlet-release, cac, eslint-import-resolver-typescript) all follow this pattern.
 
 ## Lossy mappings
 
@@ -81,7 +81,7 @@ The cassette schema is narrower than tinyexec's runtime result. One mapping stil
 
 - **`signal` (string vs boolean)**: tinyexec exposes `killed: boolean` but not the actual signal name. We unconditionally store `'SIGTERM'` on kill. The real signal name is lost.
 
-`aborted` is preserved through record/replay since v0.2 (captured from tinyexec's `aborted: true` when AbortSignal triggered, synthesized back to `aborted` on replay).
+`aborted` is preserved through record/replay (captured from tinyexec's `aborted: true` when AbortSignal triggered, synthesized back to `aborted` on replay).
 
 ## Supported tinyexec options
 
@@ -91,7 +91,7 @@ The cassette schema is narrower than tinyexec's runtime result. One mapping stil
 | `timeout` | Supported, passed through |
 | `nodeOptions` (with `cwd`, `env`, etc.) | Supported, options destructured into the cassette `Call` shape |
 | `throwOnError` | Supported on record AND replay (synthesized error matches tinyexec's shape) |
-| `stdin` (string) | Accepted, not stored in cassette in v0.2 (record-only) |
+| `stdin` (string) | Accepted, not stored in cassette (record-only) |
 | `persist: true` | **Rejected** (subprocess outliving host can't replay) |
 | `stdin: Result` (pipe chaining) | **Rejected** (chaining requires live process) |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -138,7 +138,7 @@ If you previously relied on the mock for safety guards (e.g., refusing to run su
 
 ## `BinaryOutputError`
 
-Subprocess produced non-UTF-8 bytes in stdout/stderr. shell-cassette v0.2 only supports UTF-8 cassettes.
+Subprocess produced non-UTF-8 bytes in stdout/stderr. shell-cassette only supports UTF-8 cassettes.
 
 **Workaround:** if you control the subprocess, redirect binary output to a file:
 
@@ -169,11 +169,11 @@ The curated list (`TOKEN`, `SECRET`, `PASSWORD`, etc.) catches the common cases.
 
 ## What shell-cassette does NOT redact
 
-shell-cassette v0.4 redacts what it can detect with 100% reliability and warns on suspicious-looking unredacted values. The bundle covers 25 prefix-anchored credential formats (GitHub, AWS access key IDs, Stripe, OpenAI, Anthropic, Slack, npm, etc.; see [docs/redact-patterns.md](redact-patterns.md)) plus curated env-key matching plus your own custom rules. What it doesn't redact is below.
+shell-cassette redacts what it can detect with 100% reliability and warns on suspicious-looking unredacted values. The bundle covers 25 prefix-anchored credential formats (GitHub, AWS access key IDs, Stripe, OpenAI, Anthropic, Slack, npm, etc.; see [docs/redact-patterns.md](redact-patterns.md)) plus curated env-key matching plus your own custom rules. What it doesn't redact is below.
 
-### Residual risks and gaps in v0.4 redaction
+### Residual risks and gaps in redaction
 
-- **AWS Secret Access Keys.** 40-char base64 with no documented prefix. Indistinguishable from generic hashes/UUIDs/build IDs by pattern alone. The long-value warning catches them at length 40+ when the value doesn't look like a path. If you ship cassettes that may contain AWS Secret Access Keys, add them to `redact.envKeys` (so the env value is whole-value redacted by key match) or write a project-specific custom rule.
+- **AWS Secret Access Keys.** 40-char base64 with no documented prefix. Indistinguishable from generic hashes/UUIDs/build IDs by pattern alone. The long-value warning catches them at length 40+ when the value doesn't look like a path. If your cassettes may contain AWS Secret Access Keys, add them to `redact.envKeys` (so the env value is whole-value redacted by key match) or write a project-specific custom rule.
 - **JWTs.** Many JWTs in the wild are public ID tokens or JWKS responses, not bearer secrets. Bundling JWT detection produces false positives on routine OAuth flows. Opt-in via a custom rule when your JWTs are bearer-shaped:
   ```ts
   customPatterns: [{
@@ -182,9 +182,9 @@ shell-cassette v0.4 redacts what it can detect with 100% reliability and warns o
   }]
   ```
 - **Encoded credentials.** `Authorization: Basic <base64>` headers and base64-encoded YAML/JSON secrets pass through. shell-cassette doesn't decode. Add a custom rule if your test surface includes them.
-- **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8. Out of scope for v0.4.
+- **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8.
 - **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
-- **Subprocess `stdin`.** Not captured in v0.4; nothing on disk to redact. v0.5 will capture stdin and apply the same pipeline.
+- **Subprocess `stdin`.** Not captured; nothing on disk to redact.
 
 Each gap has a workaround: long-value warning catches length anomalies, custom rules cover project-specific shapes, suppress patterns silence known fixtures, and `useCassette({ redact: false })` disables the pipeline for cassettes that legitimately need raw values (DO NOT commit those).
 
@@ -243,7 +243,7 @@ After upgrading, commit the modified cassettes alongside the version bump. Revie
 
 ## When stdout contains a credential the test asserts on
 
-If your test asserts on stdout content that legitimately contains a credential (e.g., an OAuth flow test that prints a token), the v0.4 default pipeline replaces the credential with a placeholder. The replayed stdout your test sees is the placeholder, not the credential.
+If your test asserts on stdout content that legitimately contains a credential (e.g., an OAuth flow test that prints a token), the default redaction pipeline replaces the credential with a placeholder. The replayed stdout your test sees is the placeholder, not the credential.
 
 Two options, in order of preference:
 
@@ -312,7 +312,7 @@ Source code that memoizes a subprocess result at module level (`const hasCorepac
 2. **`vi.resetModules()` between tests.** Forces vitest to re-import modules, which re-fires the cache once per test inside that test's session. Works but adds overhead.
 3. **Use a single shared cassette per test file.** If the cached subprocess call genuinely should fire once per file, scope cassettes to the file (not the test) so all tests share the same recording. Requires custom path logic.
 
-shell-cassette can't auto-detect this pattern. The `_redactions` schema field and the path resolver work per-recording; a module-level cache is invisible to them. Tracked in [#76](https://github.com/slgoodrich/shell-cassette/issues/76); future work may add a shared-cassette mode.
+shell-cassette can't auto-detect this pattern. The `_redactions` schema field and the path resolver work per-recording; a module-level cache is invisible to them. Tracked in [#76](https://github.com/slgoodrich/shell-cassette/issues/76).
 
 ## Naive `resolve.alias` self-loops; use `shellCassetteAlias`
 
@@ -326,7 +326,7 @@ export default defineConfig({
 })
 ```
 
-shell-cassette ships a vite plugin that adds the importer guard:
+shell-cassette includes a vite plugin that adds the importer guard:
 
 ```ts
 // vitest.config.ts
@@ -357,13 +357,13 @@ Windows fails when total path length exceeds 240 chars. shell-cassette's path sa
 - **Shorten `cassetteDir`.** Default is `__cassettes__` (13 chars). If you've configured `tests/integration/__cassettes__/` (32 chars), consider moving cassettes to a shorter root.
 - **Move test files closer to the project root.** A test at `tests/feature.test.ts` produces a shorter cassette path than one at `packages/server/src/__tests__/integration/feature.test.ts`.
 
-A `cassettesRoot` config (project-root-relative cassette directory, decoupling cassette paths from test file location) is tracked in [#81](https://github.com/slgoodrich/shell-cassette/issues/81) for v0.5.
+A `cassettesRoot` config (project-root-relative cassette directory, decoupling cassette paths from test file location) is tracked in [#81](https://github.com/slgoodrich/shell-cassette/issues/81).
 
 ## `xSync` from shell-cassette/tinyexec throws
 
 shell-cassette/tinyexec's `xSync` is a stub that throws a clear error pointing to async `x`:
 
-> shell-cassette/tinyexec.xSync is not yet wrapped (tracked in #82). Sync subprocess wrapping requires synchronous lazy-load support, planned for v0.5.
+> shell-cassette/tinyexec.xSync is not yet wrapped (tracked in #82). Sync subprocess wrapping requires synchronous lazy-load support.
 
 **Why:** wrapping sync subprocess execution requires synchronous module loading for the peer dep, which shell-cassette doesn't currently support. The async `x` adapter uses top-level await for resolution.
 
@@ -371,7 +371,6 @@ shell-cassette/tinyexec's `xSync` is a stub that throws a clear error pointing t
 
 - **Use async `x`** (recommended). Refactor sync call sites to async; you get cassette coverage.
 - **Import `xSync` directly from `tinyexec`.** Those calls bypass shell-cassette and run real subprocess. Acceptable for pre-flight version checks and similar non-determinism-sensitive paths.
-- **Wait for v0.5** ([#82](https://github.com/slgoodrich/shell-cassette/issues/82)).
 
 ## `result.process` throws on tinyexec replay
 
@@ -385,4 +384,3 @@ Tests that read `result.process.stdout` (streaming) or `result.process.stderr` (
 
 - **Refactor to use `result.stdout` / `result.stderr`** (the buffered string fields). They contain the full captured output and are deterministic.
 - **`SHELL_CASSETTE_MODE=passthrough`** for tests that genuinely need stream access.
-- **Wait for v0.5**; future work may synthesize a fake stream from buffered output ([#83](https://github.com/slgoodrich/shell-cassette/issues/83)).

--- a/docs/vitest-plugin.md
+++ b/docs/vitest-plugin.md
@@ -20,7 +20,7 @@ export default defineConfig({
     setupFiles: ['./tests/sc-setup.ts'],
     server: {
       deps: {
-        inline: ['shell-cassette'],   // required - see Compatibility below
+        inline: ['shell-cassette'],   // required (see Compatibility below)
       },
     },
   },
@@ -48,7 +48,7 @@ Vitest externalizes node_modules packages by default. The plugin's top-level `be
 
 shell-cassette catches that throw at registration and rethrows as `VitestPluginRegistrationError` with the fix path inline (config snippets for both vitest 3.x and 4.x). You'll see the actionable error class instead of vitest's bare message.
 
-Add `'shell-cassette'` to `test.server.deps.inline` (vitest 3.x) or `test.deps.inline` (vitest 4.x). This is the standard pattern for vitest plugin packages - many plugins document it.
+Add `'shell-cassette'` to `test.server.deps.inline` (vitest 3.x) or `test.deps.inline` (vitest 4.x). This is the standard pattern for vitest plugin packages.
 
 See [troubleshooting](troubleshooting.md#vitestpluginregistrationerror-vitest-failed-to-find-the-runner) for the full snippet.
 
@@ -67,11 +67,11 @@ If your project already wraps the subprocess runner with `vi.mock` (e.g., for sa
 + import { x } from 'shell-cassette/tinyexec'
 ```
 
-If the existing `vi.mock` provided safety guards, you'll need to drop them or move them elsewhere. shell-cassette doesn't enforce sandbox-cwd or similar guards - it records and replays.
+If the existing `vi.mock` provided safety guards, you'll need to drop them or move them elsewhere. shell-cassette doesn't enforce sandbox-cwd or similar guards. It records and replays.
 
 ## Cassette path layout
 
-Default: cassettes land next to the test file in `__cassettes__/`:
+Default: cassettes are written next to the test file in `__cassettes__/`:
 
 ```
 tests/
@@ -118,7 +118,7 @@ Otherwise the cassette directory shows up as a phantom fixture on subsequent run
 
 The plugin uses a module-global to set the active cassette per test. Concurrent tests would race on this. The plugin throws `ConcurrencyError` at `beforeEach` time when it detects a `test.concurrent`.
 
-**Use `useCassette` explicitly inside concurrent tests instead** - its AsyncLocalStorage-based context isolates per call:
+**Use `useCassette` explicitly inside concurrent tests instead.** Its AsyncLocalStorage-based context isolates per call:
 
 ```ts
 import { useCassette } from 'shell-cassette'
@@ -156,4 +156,4 @@ For the curious. The plugin's behavior:
 - **`beforeEach(ctx)`**: derives the cassette path from `ctx.task` (file path + describe chain + test name, sanitized). Creates a `CassetteSession` and calls `setActiveCassette` to make it visible to wrapper calls.
 - **`afterEach()`**: persists `session.newRecordings` to disk (if any), emits the end-of-run summary, clears the active cassette.
 
-If you don't want auto-cassetting for a particular test (e.g., a test that's deliberately calling real subprocess for live state), there's no per-call mode override today. The escape hatch is to either move the test out of the auto-plugin's scope or stub manually.
+If you don't want auto-cassetting for a particular test (e.g., a test that's deliberately calling real subprocess for live state), there's no per-call mode override. The escape hatch is to either move the test out of the auto-plugin's scope or stub manually.

--- a/src/ack.ts
+++ b/src/ack.ts
@@ -18,7 +18,7 @@ What does NOT get redacted (residual risk):
   * Encoded credentials (Authorization: Basic base64, base64-encoded YAML/JSON secrets)
   * Binary output (BinaryOutputError prevents recording)
   * cwd values
-  * Subprocess stdin (not captured until v0.5)
+  * Subprocess stdin (not captured)
 
 Verify before committing:  shell-cassette scan <path>
 Migrate when bundle expands: shell-cassette re-redact <path>

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -8,8 +8,7 @@
  *   - default: interactive terminal walk
  *   - --json: read-only structured listing of findings (locked at reviewVersion: 1)
  *
- * Action keys (a/s/r/d/b/q/?) are API-locked. Renames would be a breaking
- * change. Prompt strings are NOT API.
+ * Prompt strings are not part of the API; bots should use --json instead.
  */
 import {
   applyTruncation,

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -6,8 +6,8 @@ const SCHEMA_VERSION = 2
 const REVIEW_WARNING =
   'REVIEW BEFORE COMMITTING. shell-cassette redacts bundled credential patterns + ' +
   'curated env-key values + your custom rules. It does NOT redact: AWS Secret Access Keys, ' +
-  'JWTs (without opt-in), encoded credentials, binary output, cwd, stdin (until v0.5 ships ' +
-  'option parity). Run `shell-cassette scan <path>` to verify before committing. ' +
+  'JWTs (without opt-in), encoded credentials, binary output, cwd, stdin. ' +
+  'Run `shell-cassette scan <path>` to verify before committing. ' +
   'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md'
 
 /**

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -157,20 +157,19 @@ export const exec = x
 
 /**
  * Stub for tinyexec's sync subprocess entry point. Wrapping sync execution
- * requires synchronous lazy-load support, which is planned for v0.5 (#82).
+ * requires synchronous lazy-load support; tracked in #82.
  *
- * For v0.4, calling xSync through this adapter throws a clear error instead
- * of failing silently or returning undefined. Users with sync subprocess
- * tests should either:
- * - Import xSync directly from `tinyexec` (those calls bypass shell-cassette)
- * - Refactor to use async `x` (recommended; gets cassette coverage)
- * - Wait for v0.5
+ * Calling xSync through this adapter throws a clear error instead of failing
+ * silently or returning undefined. Users with sync subprocess tests should
+ * either import xSync directly from `tinyexec` (those calls bypass
+ * shell-cassette), or refactor to use async `x` (recommended; gets cassette
+ * coverage).
  */
 export function xSync(): never {
   throw new ShellCassetteError(
     'shell-cassette/tinyexec.xSync is not yet wrapped (tracked in #82). ' +
-      'Sync subprocess wrapping requires synchronous lazy-load support, planned for v0.5. ' +
-      'For now: use async `x` (recommended; gets cassette coverage), or import xSync ' +
+      'Sync subprocess wrapping requires synchronous lazy-load support. ' +
+      'Use async `x` (recommended; gets cassette coverage), or import xSync ' +
       'directly from `tinyexec` (those calls will not be cassetted).',
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,9 +57,8 @@ export type RedactSource = 'env' | 'args' | 'stdout' | 'stderr' | 'allLines'
 
 export type RedactRule = {
   /**
-   * Stable kebab-case identifier. API-stable: rule names ship locked at v0.4 and
-   * are never renamed. New patterns may be added additively (any version);
-   * removing or renaming is a breaking change.
+   * Lowercase kebab-case identifier. Appears in placeholder strings as
+   * <redacted:source:rule-name:N>.
    */
   name: string
   /**

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -16,13 +16,12 @@ describe('tinyexec adapter', () => {
     expect(exec).toBe(x)
   })
 
-  test('xSync stub throws ShellCassetteError with v0.5 guidance', () => {
+  test('xSync stub throws ShellCassetteError pointing to issue #82', () => {
     expect(() => xSync()).toThrow(ShellCassetteError)
     try {
       xSync()
     } catch (e) {
       expect((e as Error).message).toContain('xSync')
-      expect((e as Error).message).toContain('v0.5')
       expect((e as Error).message).toContain('#82')
     }
   })


### PR DESCRIPTION
## What Changed

- New `docs/cli.md` with per-subcommand reference for `show`, `review`, and `prune` (synopsis, flags, exit codes, JSON shapes, examples).
- README CLI section: new `show`, `review`, `prune` subsections plus a "Cassette inspection workflow" recipe.
- CHANGELOG 0.5.0 entry.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` (601 passed, 1 skipped)
- [x] `npm run build` clean