### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
-## [0.5.0] - 2026-XX-XX
+## [0.5.0] - 2026-04-28
 
 No public API changes from the main `shell-cassette` entry. The cassette schema stays at version 2 (additive `_suppressed` field, no v3 bump). v0.4 cassettes load and replay correctly under v0.5; v0.4 readers ignore the new field.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-cassette",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-cassette",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-cassette",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Polly.js, but for shell commands. Record subprocess calls once, replay them deterministically forever.",
   "keywords": [
     "subprocess",


### PR DESCRIPTION
## What Changed

- `package.json` 0.4.0 → 0.5.0
- `CHANGELOG.md` 0.5.0 date stamp

## Test Plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 601 passed, 1 skipped
- [x] `npm run build` — clean