### PR TITLE
fix: reduce length-warning noise on ANSI banners and benign Windows env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-29
+
+Heuristic refinement to the long-value warning. No API or schema changes from 0.5.0; cassettes recorded under any prior version load and replay unchanged.
+
+### Added
+
+- **`config.redact.suppressLengthWarningKeys: readonly string[]`**. Env-var keys (case-insensitive substring) that suppress the long-value warning, additive to a curated default list (`PATHEXT`, `WSLENV`, `__INTELLIJ_COMMAND_HISTFILE__`, `PSMODULEPATH`, `SHELL_SESSION_HISTFILE`).
+
+### Changed
+
+- The long-value warning strips ANSI escape sequences before measuring length. ANSI-decorated banners no longer trigger the warning when their visible length is below the threshold.
+- The pipeline skips the warning entirely for env-var keys that match the curated default list above. `PATHEXT` and `WSLENV` no longer emit warnings on Windows cassettes by default.
+- `RedactInput` (internal pipeline shape) gains an optional `key?: string` field. Callers that pass env values populate the key; other sources leave it undefined.
+
+### Notes
+
+- Only the warning behavior changes. Redaction itself is unchanged: nothing that was redacted before is now exposed, and nothing newly redacted. The warning is informational; this fix reduces log noise so genuine warnings (a real candidate credential not in any rule) are easier to spot.
+- Closes [#78](https://github.com/slgoodrich/shell-cassette/issues/78).
+
 ## [0.5.0] - 2026-04-28
 
 No public API changes from the main `shell-cassette` entry. The cassette schema stays at version 2 (additive `_suppressed` field, no v3 bump). v0.4 cassettes load and replay correctly under v0.5; v0.4 readers ignore the new field.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Workarounds for each gap are in [docs/troubleshooting.md](docs/troubleshooting.m
 
 ### Long-value warnings
 
-Values 40+ characters that did NOT match any rule emit a warning at record time. The warning is logged but the value is NOT redacted (shell-cassette can't pattern-match an unknown shape safely). The threshold (default 40) and a path heuristic (skip warning when the value contains `/`, `\`, `:`, or whitespace) are tunable via `Config.redact.warnLengthThreshold` and `Config.redact.warnPathHeuristic`.
+Values 40+ characters that did NOT match any rule emit a warning at record time. The warning is logged but the value is NOT redacted (shell-cassette can't pattern-match an unknown shape safely). The pipeline strips ANSI escape sequences before measuring length (so a 30-char colored banner is not flagged as a 60-char candidate). The threshold (default 40) and a path heuristic (skip warning when the value contains `/`, `\`, `:`, or whitespace) are tunable via `Config.redact.warnLengthThreshold` and `Config.redact.warnPathHeuristic`. A curated list of env-var keys (`PATHEXT`, `WSLENV`, `__INTELLIJ_COMMAND_HISTFILE__`, `PSMODULEPATH`, `SHELL_SESSION_HISTFILE`) skip the warning by default; extend via `Config.redact.suppressLengthWarningKeys`.
 
 End-of-run summaries make redaction events visible:
 

--- a/docs/redact-patterns.md
+++ b/docs/redact-patterns.md
@@ -106,11 +106,26 @@ export default {
   redact: {
     warnLengthThreshold: 40,    // default
     warnPathHeuristic: true,    // default
+    suppressLengthWarningKeys: ['MY_LONG_BENIGN_VAR'],   // additive to curated default
   },
 }
 ```
 
 The 40-char threshold catches GitHub PATs, OpenAI keys, Stripe restricted, AWS Secret Access Keys without nagging on common path-shaped env vars. Tune lower (e.g., 24) if your workload has shorter unknown-shape secrets; tune higher if you see noise.
+
+The pipeline also strips ANSI escape sequences before measuring length, so a colored 30-char banner (raw bytes ~50 chars due to ANSI codes) does not trigger the warning. Stripping is internal to the heuristic; the recorded value keeps its original bytes.
+
+A curated default list of env-var keys (case-insensitive substring match) skip the length warning entirely:
+
+| Key prefix | Reason |
+|---|---|
+| `PATHEXT` | Windows path-extension list (`.COM;.EXE;.BAT;...`), 30-70 chars typical. |
+| `WSLENV` | WSL forwarded-env list, often long without path-heuristic chars. |
+| `__INTELLIJ_COMMAND_HISTFILE__` | IDE pollution; ~70 chars. |
+| `PSMODULEPATH` | PowerShell module search path on Windows. |
+| `SHELL_SESSION_HISTFILE` | Shell session history file path. |
+
+`suppressLengthWarningKeys` extends this list. Substring match: `MY_PROJECT` matches `MY_PROJECT_TOKEN_LIST`, `MY_PROJECT_BACKUP`, etc.
 
 ## See also
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-cassette",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-cassette",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-cassette",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Polly.js, but for shell commands. Record subprocess calls once, replay them deterministically forever.",
   "keywords": [
     "subprocess",

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -236,7 +236,7 @@ function reRedactRecording(
 
   const env: Record<string, string> = {}
   for (const [key, value] of Object.entries(rec.call.env)) {
-    const r = redact({ source: 'env', value }, config, {
+    const r = redact({ source: 'env', key, value }, config, {
       counted: true,
       counters,
       suppressedHashes,

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -466,8 +466,8 @@ export function applyDecisions(
     }
 
     const newRedactEntries: RedactionEntry[] = []
-    const redactValue = (source: RedactSource, value: string): string => {
-      const r = redact({ source, value }, config, {
+    const redactValue = (source: RedactSource, value: string, key?: string): string => {
+      const r = redact({ source, value, key }, config, {
         counted: true,
         counters,
         suppressedHashes: skipSet,
@@ -478,7 +478,7 @@ export function applyDecisions(
 
     const env: Record<string, string> = {}
     for (const [key, value] of Object.entries(rec.call.env)) {
-      env[key] = redactValue('env', value)
+      env[key] = redactValue('env', value, key)
     }
     const args = rec.call.args.map((arg) => redactValue('args', arg))
     const stdoutLines = rec.result.stdoutLines.map((line) => redactValue('stdout', line))

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ const DEFAULT_REDACT: Readonly<RedactConfig> = Object.freeze({
   envKeys: Object.freeze([]) as readonly string[],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
+  suppressLengthWarningKeys: Object.freeze([]) as readonly string[],
 })
 
 export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
@@ -52,6 +53,9 @@ export function mergeWithDefaults(input: PartialConfig | undefined): Readonly<Co
     envKeys: userRedact.envKeys ? Object.freeze([...userRedact.envKeys]) : DEFAULT_REDACT.envKeys,
     warnLengthThreshold: userRedact.warnLengthThreshold ?? DEFAULT_REDACT.warnLengthThreshold,
     warnPathHeuristic: userRedact.warnPathHeuristic ?? DEFAULT_REDACT.warnPathHeuristic,
+    suppressLengthWarningKeys: userRedact.suppressLengthWarningKeys
+      ? Object.freeze([...userRedact.suppressLengthWarningKeys])
+      : DEFAULT_REDACT.suppressLengthWarningKeys,
   }
 
   return Object.freeze({
@@ -144,6 +148,17 @@ function validateRedact(redact: unknown): void {
 
   if (r.warnPathHeuristic !== undefined && typeof r.warnPathHeuristic !== 'boolean') {
     throw new CassetteConfigError('config.redact.warnPathHeuristic must be boolean')
+  }
+
+  if (r.suppressLengthWarningKeys !== undefined) {
+    if (!Array.isArray(r.suppressLengthWarningKeys)) {
+      throw new CassetteConfigError('config.redact.suppressLengthWarningKeys must be an array')
+    }
+    if (!r.suppressLengthWarningKeys.every((k) => typeof k === 'string')) {
+      throw new CassetteConfigError(
+        'config.redact.suppressLengthWarningKeys items must all be strings',
+      )
+    }
   }
 }
 

--- a/src/curated-suppress-length-keys.ts
+++ b/src/curated-suppress-length-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * Env-var keys whose values commonly exceed the length-warning threshold
+ * without containing credentials. The redact pipeline skips the
+ * "long unredacted value" warning when an env-var's key matches any of
+ * these via case-insensitive substring.
+ *
+ * Matching is intentionally loose (substring): WSLENV matches WSLENV_BACKUP,
+ * PSMODULEPATH matches PSModulePath_OLD, etc. The same loose semantics that
+ * govern the curated env-key redaction list.
+ *
+ * Users extend the list via `Config.redact.suppressLengthWarningKeys`.
+ */
+export const DEFAULT_SUPPRESS_LENGTH_KEYS: readonly string[] = Object.freeze([
+  // Windows path-extension list (.COM;.EXE;.BAT;.CMD;...) typically 30-70 chars.
+  'PATHEXT',
+  // WSL forwarded-env list, often long without path-heuristic chars.
+  'WSLENV',
+  // IDE pollution; common ~70 chars.
+  '__INTELLIJ_COMMAND_HISTFILE__',
+  // PowerShell module search path; long on Windows dev machines.
+  'PSMODULEPATH',
+  // Shell session HISTFILE; tools sometimes set long values.
+  'SHELL_SESSION_HISTFILE',
+])

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -42,7 +42,7 @@ function redactCall(call: Call, session: CassetteSession): Call {
       log(`redacted env var ${key} → ${session.path}`)
     } else {
       // Value-based: run through the pipeline for pattern-based detection.
-      const r = redact({ source: 'env', value }, session.redactConfig, {
+      const r = redact({ source: 'env', key, value }, session.redactConfig, {
         counted: true,
         counters: session.redactCounters,
       })

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { DEFAULT_SUPPRESS_LENGTH_KEYS } from './curated-suppress-length-keys.js'
 import { ShellCassetteError } from './errors.js'
 import { BUNDLED_PATTERNS } from './redact-patterns.js'
 import type {
@@ -12,6 +13,13 @@ import type {
 export type RedactInput = {
   source: RedactSource
   value: string
+  /**
+   * Optional env-var key. Only meaningful when source is 'env'. Used by the
+   * length-warning suppress logic to skip warnings on known-benign system env
+   * vars (PATHEXT, WSLENV, etc.) and any user-extended keys via
+   * `config.redact.suppressLengthWarningKeys`.
+   */
+  key?: string
 }
 
 /**
@@ -64,6 +72,27 @@ const G_FLAGGED_BUNDLE: { name: string; pattern: RegExp }[] = BUNDLED_PATTERNS.f
 }))
 
 const PATH_OR_WHITESPACE_REGEX = /[/\\: ]/
+
+// CSI sequences (ESC [ params final-byte) cover the common color/style codes.
+// Used only for the length-warning heuristic so an ANSI-decorated 30-char
+// banner does not get flagged as a 60-char "candidate credential".
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ESC byte is the literal ANSI prefix
+const ANSI_ESCAPE_REGEX = /\x1B\[[0-9;]*[a-zA-Z]/g
+
+function suppressLengthWarningForKey(
+  key: string | undefined,
+  userKeys: readonly string[],
+): boolean {
+  if (key === undefined) return false
+  const upper = key.toUpperCase()
+  for (const candidate of DEFAULT_SUPPRESS_LENGTH_KEYS) {
+    if (upper.includes(candidate.toUpperCase())) return true
+  }
+  for (const candidate of userKeys) {
+    if (upper.includes(candidate.toUpperCase())) return true
+  }
+  return false
+}
 
 /**
  * Apply the redact pipeline to a single value.
@@ -138,12 +167,14 @@ export function runPipeline(
   }
 
   const noRuleFired = output === value
-  const exceedsThreshold = output.length > config.warnLengthThreshold
+  const strippedLength = output.replace(ANSI_ESCAPE_REGEX, '').length
+  const exceedsThreshold = strippedLength > config.warnLengthThreshold
   const suppressedByHeuristic = config.warnPathHeuristic && PATH_OR_WHITESPACE_REGEX.test(output)
+  const suppressedByKey = suppressLengthWarningForKey(input.key, config.suppressLengthWarningKeys)
 
-  if (noRuleFired && exceedsThreshold && !suppressedByHeuristic) {
+  if (noRuleFired && exceedsThreshold && !suppressedByHeuristic && !suppressedByKey) {
     warnings.push(
-      `${input.source} value (${output.length} chars) exceeds threshold ${config.warnLengthThreshold} ` +
+      `${input.source} value (${strippedLength} chars) exceeds threshold ${config.warnLengthThreshold} ` +
         `and contains no path/whitespace characters; may be a credential not in any rule. ` +
         `Review or add a pattern to config.redact.customPatterns.`,
     )

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,15 +1,15 @@
 import { BUNDLED_PATTERNS as _BUNDLED } from './redact-patterns.js'
-import { type RedactOptions, type RedactOutput, runPipeline } from './redact-pipeline.js'
+import {
+  type RedactInput,
+  type RedactOptions,
+  type RedactOutput,
+  runPipeline,
+} from './redact-pipeline.js'
 import type { RedactConfig, RedactionEntry, RedactRule, RedactSource } from './types.js'
 
 export const BUNDLED_PATTERNS: readonly RedactRule[] = _BUNDLED
 
-export type RedactInput = {
-  source: RedactSource
-  value: string
-}
-
-export type { RedactOptions, RedactOutput }
+export type { RedactInput, RedactOptions, RedactOutput }
 
 /**
  * Apply the redact pipeline to a single value.

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,14 @@ export type RedactConfig = {
    * connection strings) without missing bare credential strings.
    */
   warnPathHeuristic: boolean
+  /**
+   * Env-var keys that suppress the length warning. Substring (case-insensitive)
+   * match against env-var keys, additive to a curated default list (PATHEXT,
+   * WSLENV, PSModulePath, __INTELLIJ_COMMAND_HISTFILE__). Use for project-
+   * specific env vars that always exceed the threshold without containing
+   * credentials.
+   */
+  suppressLengthWarningKeys: readonly string[]
 }
 
 export type UseCassetteOptions = {

--- a/tests/integration/suppressed-respected.test.ts
+++ b/tests/integration/suppressed-respected.test.ts
@@ -17,6 +17,7 @@ const baseConfig: RedactConfig = {
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
+  suppressLengthWarningKeys: [],
 }
 
 // Both PATs are exactly ghp_ + 36 alphanumerics = 40 chars (the

--- a/tests/property/redact.property.test.ts
+++ b/tests/property/redact.property.test.ts
@@ -25,6 +25,7 @@ const baseConfig: RedactConfig = {
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
+  suppressLengthWarningKeys: [],
 }
 
 const sourceArb = fc.constantFrom<RedactSource>('env', 'args', 'stdout', 'stderr', 'allLines')

--- a/tests/property/scan-record-symmetry.property.test.ts
+++ b/tests/property/scan-record-symmetry.property.test.ts
@@ -51,6 +51,7 @@ const baseConfig: RedactConfig = {
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
+  suppressLengthWarningKeys: [],
 }
 
 const tmpDir = useTmpDir('sc-symmetry-')

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -76,6 +76,10 @@ describe('Config defaults: redact field', () => {
     expect(DEFAULT_CONFIG.redact.suppressPatterns).toEqual([])
     expect(DEFAULT_CONFIG.redact.envKeys).toEqual([])
   })
+
+  test('suppressLengthWarningKeys defaults to empty array (additive to curated default)', () => {
+    expect(DEFAULT_CONFIG.redact.suppressLengthWarningKeys).toEqual([])
+  })
 })
 
 describe('mergeWithDefaults: redact field', () => {
@@ -136,6 +140,14 @@ describe('mergeWithDefaults: redact field', () => {
     expect(Object.isFrozen(merged.redact.envKeys)).toBe(true)
     userArray.push('OPENAI_KEY')
     expect(merged.redact.envKeys.length).toBe(1)
+  })
+
+  test('user-supplied suppressLengthWarningKeys array is defensively copied and frozen', () => {
+    const userArray = ['MY_PROJECT_VAR']
+    const merged = mergeWithDefaults({ redact: { suppressLengthWarningKeys: userArray } })
+    expect(Object.isFrozen(merged.redact.suppressLengthWarningKeys)).toBe(true)
+    userArray.push('OTHER')
+    expect(merged.redact.suppressLengthWarningKeys.length).toBe(1)
   })
 })
 
@@ -258,6 +270,18 @@ describe('validateConfig: redact field', () => {
   test('rejects envKeys with non-string entries', () => {
     expect(() => validateConfig({ redact: { envKeys: [1, 2] } })).toThrow(
       /items must all be strings/,
+    )
+  })
+
+  test('rejects non-array suppressLengthWarningKeys', () => {
+    expect(() => validateConfig({ redact: { suppressLengthWarningKeys: 'foo' } })).toThrow(
+      /suppressLengthWarningKeys must be an array$/,
+    )
+  })
+
+  test('rejects suppressLengthWarningKeys with non-string entries', () => {
+    expect(() => validateConfig({ redact: { suppressLengthWarningKeys: [1, 2] } })).toThrow(
+      /suppressLengthWarningKeys items must all be strings/,
     )
   })
 

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -14,6 +14,7 @@ const baseConfig: RedactConfig = {
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
+  suppressLengthWarningKeys: [],
 }
 
 describe('redact-pipeline: suppress short-circuit', () => {
@@ -327,6 +328,82 @@ describe('redact-pipeline: length warning', () => {
     const value = SAMPLE_GITHUB_PAT_CLASSIC
     const result = runPipeline({ source: 'stdout', value }, config, { counted: false })
     expect(result.warnings).toEqual([])
+  })
+})
+
+describe('redact-pipeline: length warning (ANSI strip)', () => {
+  test('ANSI-coded value below stripped-length threshold: no warning', () => {
+    // 35 visible chars wrapped in compound ANSI; raw length > 40, stripped length = 35.
+    const value = `\x1B[1;31;42m${'a'.repeat(35)}\x1B[0m`
+    expect(value.length).toBeGreaterThan(40)
+    const result = runPipeline({ source: 'stdout', value }, baseConfig, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('ANSI-coded value above stripped-length threshold: warning fires with stripped length', () => {
+    const value = `\x1B[31m${'a'.repeat(50)}\x1B[0m`
+    const result = runPipeline({ source: 'stdout', value }, baseConfig, { counted: false })
+    expect(result.warnings.length).toBe(1)
+    expect(result.warnings[0]).toContain('50')
+  })
+
+  test('multiple ANSI sequences stripped before measurement', () => {
+    // 35 visible chars across 3 ANSI groups; stripped = 35 (below default 40).
+    const value =
+      `\x1B[1m${'a'.repeat(10)}\x1B[0m` +
+      `\x1B[31m${'b'.repeat(10)}\x1B[0m` +
+      `\x1B[32m${'c'.repeat(15)}\x1B[0m`
+    const result = runPipeline({ source: 'stdout', value }, baseConfig, { counted: false })
+    expect(result.warnings).toEqual([])
+  })
+})
+
+describe('redact-pipeline: length warning (env-key suppress list)', () => {
+  test('PATHEXT env value: no warning at default config', () => {
+    const value = '.COM;.EXE;.BAT;.CMD;.VBS;.JS;.PS1;.PSC1;.MSC;.WSF'
+    const result = runPipeline({ source: 'env', key: 'PATHEXT', value }, baseConfig, {
+      counted: false,
+    })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('WSLENV env value: no warning at default config', () => {
+    const value = 'a'.repeat(60)
+    const result = runPipeline({ source: 'env', key: 'WSLENV', value }, baseConfig, {
+      counted: false,
+    })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('case-insensitive substring match: WSLENV_BACKUP also suppressed', () => {
+    const value = 'a'.repeat(60)
+    const result = runPipeline({ source: 'env', key: 'wslenv_backup', value }, baseConfig, {
+      counted: false,
+    })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('user-extended suppress key: no warning', () => {
+    const config: RedactConfig = { ...baseConfig, suppressLengthWarningKeys: ['MY_PROJECT_VAR'] }
+    const value = 'a'.repeat(60)
+    const result = runPipeline({ source: 'env', key: 'MY_PROJECT_VAR', value }, config, {
+      counted: false,
+    })
+    expect(result.warnings).toEqual([])
+  })
+
+  test('non-suppressed env key still warns', () => {
+    const value = 'a'.repeat(60)
+    const result = runPipeline({ source: 'env', key: 'OTHER_VAR', value }, baseConfig, {
+      counted: false,
+    })
+    expect(result.warnings.length).toBe(1)
+  })
+
+  test('no key provided: no env-key suppression (existing behavior preserved)', () => {
+    const value = 'a'.repeat(60)
+    const result = runPipeline({ source: 'stdout', value }, baseConfig, { counted: false })
+    expect(result.warnings.length).toBe(1)
   })
 })
 

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -10,6 +10,7 @@ const baseConfig: RedactConfig = {
   envKeys: [],
   warnLengthThreshold: 40,
   warnPathHeuristic: true,
+  suppressLengthWarningKeys: [],
 }
 
 describe('public redact() wraps pipeline', () => {


### PR DESCRIPTION
## What Changed

- The long-value warning strips ANSI escape sequences before measuring length. A 30-char colored banner is no longer flagged as a 60-char candidate credential. Stripping is internal to the heuristic; the recorded value keeps its original bytes.
- A curated default list of env-var keys skip the warning (case-insensitive substring): `PATHEXT`, `WSLENV`, `__INTELLIJ_COMMAND_HISTFILE__`, `PSMODULEPATH`, `SHELL_SESSION_HISTFILE`.
- New config field `Config.redact.suppressLengthWarningKeys: readonly string[]` extends the curated list with project-specific keys.
- `RedactInput` (internal pipeline shape) gains an optional `key?: string`. Callers that pass env values populate it; other sources leave it undefined.
- Version bump to 0.5.1.

## Why

False-positive warnings drown out genuine ones. `PATHEXT` (~70 chars on Windows) and ANSI-decorated banners (raw bytes 2x visible length) were triggering the warning on every run. This is a heuristic refinement only; redaction itself is unchanged.

## Related Issues

Closes #78.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` 614 passed, 1 skipped (13 new tests covering ANSI strip, env-key suppress at default and via user-extended list, validation)
- [x] `npm run build` clean