### PR TITLE
docs: README tagline fix + credential-pattern URL refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Without shell-cassette, you're picking among three painful options:
 - **Hand-roll fixtures.** Fast and deterministic, but the fixtures drift from the wrapped CLI's actual behavior. Tests pass while reality wouldn't.
 - **`vi.mock` the runner and assert on call shape.** Brittle. Tests pass when the wrapper invokes the right command, but the wrapped CLI changed its actual output.
 
-shell-cassette captures real subprocess output once and replays it deterministically forever. Real like a subprocess, fast like a mock, accurate like neither.
+shell-cassette captures real subprocess output once and replays it deterministically forever. Real like a subprocess, fast like a mock.
 
 What this unlocks:
 

--- a/docs/redact-patterns.md
+++ b/docs/redact-patterns.md
@@ -8,30 +8,30 @@ For ambiguous credential shapes (AWS Secret Access Keys, JWTs, generic 32-hex to
 
 | Rule name | Provider | Prefix | Length | Doc |
 |---|---|---|---|---|
-| `github-pat-classic` | GitHub | `ghp_` | 36 char body | https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/ |
+| `github-pat-classic` | GitHub | `ghp_` | 36 char body | https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/ |
 | `github-pat-fine-grained` | GitHub | `github_pat_` | 82 char body | (same) |
 | `github-oauth` | GitHub | `gho_` | 36 | (same) |
 | `github-user-to-server` | GitHub | `ghu_` | 36 | (same) |
 | `github-server-to-server` | GitHub | `ghs_` | 36 | (same) |
 | `github-refresh` | GitHub | `ghr_` | 36 | (same) |
 | `aws-access-key-id` | AWS | `AKIA` / `ASIA` / `AROA` / `AIDA` / `AGPA` / `ANPA` / `ANVA` / `APKA` / `ABIA` / `ACCA` | 16 char body | https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html |
-| `stripe-secret-live` | Stripe | `sk_live_` | 24+ | https://stripe.com/docs/keys |
+| `stripe-secret-live` | Stripe | `sk_live_` | 24+ | https://docs.stripe.com/keys |
 | `stripe-secret-test` | Stripe | `sk_test_` | 24+ | (same) |
 | `stripe-restricted-live` | Stripe | `rk_live_` | 24+ | (same) |
 | `stripe-restricted-test` | Stripe | `rk_test_` | 24+ | (same) |
-| `anthropic-api-key` | Anthropic | `sk-ant-(api03\|sid01\|admin01)-` | 80+ | https://docs.anthropic.com/en/api/getting-started |
+| `anthropic-api-key` | Anthropic | `sk-ant-(api03\|sid01\|admin01)-` | 80+ | https://platform.claude.com/docs/en/api/getting-started |
 | `openai-api-key` | OpenAI | `sk-` (also `sk-proj-`, `sk-svcacct-`, `sk-admin-`) | 40+ | https://platform.openai.com/docs/api-reference/authentication |
-| `google-api-key` | Google | `AIza` | 35 | https://cloud.google.com/api-keys/docs/overview |
-| `slack-token` | Slack | `xox[baprso]-` | 10+ | https://api.slack.com/authentication/token-types |
+| `google-api-key` | Google | `AIza` | 35 | https://docs.cloud.google.com/api-keys/docs/overview |
+| `slack-token` | Slack | `xox[baprso]-` | 10+ | https://docs.slack.dev/authentication/tokens |
 | `slack-webhook-url` | Slack | `https://hooks.slack.com/services/T*/B*/*` | structured | (same) |
-| `gitlab-pat` | GitLab | `glpat-` | 20 | https://docs.gitlab.com/ee/security/token_overview.html |
+| `gitlab-pat` | GitLab | `glpat-` | 20 | https://docs.gitlab.com/security/tokens/ |
 | `npm-token` | npm | `npm_` | 36 | https://docs.npmjs.com/about-access-tokens |
 | `digitalocean-pat` | DigitalOcean | `dop_v1_` | 64 hex | https://docs.digitalocean.com/reference/api/create-personal-access-token/ |
-| `sendgrid-api-key` | SendGrid | `SG.` | 22 + `.` + 43 | https://docs.sendgrid.com/api-reference/api-keys/create-api-keys |
-| `mailgun-api-key` | Mailgun | `key-` | 32 hex | https://documentation.mailgun.com/en/latest/api-intro.html#authentication |
+| `sendgrid-api-key` | SendGrid | `SG.` | 22 + `.` + 43 | https://www.twilio.com/docs/sendgrid/api-reference/api-keys/create-api-keys |
+| `mailgun-api-key` | Mailgun | `key-` | 32 hex | https://documentation.mailgun.com/docs/mailgun/api-reference/mg-auth |
 | `huggingface-token` | Hugging Face | `hf_` | 34 | https://huggingface.co/docs/hub/security-tokens |
 | `pypi-token` | PyPI | `pypi-AgE` | 50+ | https://pypi.org/help/#apitoken |
-| `discord-bot-token` | Discord | `[MN]` | 23 + `.` + 6 + `.` + 27+ | https://discord.com/developers/docs/reference#authentication |
+| `discord-bot-token` | Discord | `[MN]` | 23 + `.` + 6 + `.` + 27+ | https://docs.discord.com/developers/reference |
 | `square-production-token` | Square | `EAAA` | 60+ | https://developer.squareup.com/docs/build-basics/access-tokens |
 
 Patterns apply to env values, args, stdout lines, stderr lines, and `allLines`. The same pattern is shared across all five sources; the placeholder records which source it fired in: `<redacted:source:rule-name:N>`.

--- a/src/redact-patterns.ts
+++ b/src/redact-patterns.ts
@@ -18,7 +18,7 @@ import type { RedactRule } from './types.js'
 
 export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   // GitHub family
-  // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+  // https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/
   {
     name: 'github-pat-classic',
     pattern: /ghp_[A-Za-z0-9]{36}/,
@@ -59,7 +59,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // Stripe
-  // https://stripe.com/docs/keys
+  // https://docs.stripe.com/keys
   {
     name: 'stripe-secret-live',
     pattern: /sk_live_[A-Za-z0-9]{24,}/,
@@ -83,7 +83,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // Anthropic
-  // https://docs.anthropic.com/en/api/getting-started
+  // https://platform.claude.com/docs/en/api/getting-started
   // Note: Anthropic must precede OpenAI in this list. The OpenAI pattern's
   // bare sk- prefix would otherwise match Anthropic keys (sk-ant-...) first
   // and tag them as openai-api-key in placeholders.
@@ -102,7 +102,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // Google API
-  // https://cloud.google.com/api-keys/docs/overview
+  // https://docs.cloud.google.com/api-keys/docs/overview
   {
     name: 'google-api-key',
     pattern: /AIza[A-Za-z0-9_-]{35}/,
@@ -110,7 +110,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // Slack
-  // https://api.slack.com/authentication/token-types
+  // https://docs.slack.dev/authentication/tokens
   {
     name: 'slack-token',
     pattern: /xox[baprso]-[A-Za-z0-9-]{10,}/,
@@ -123,7 +123,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // GitLab
-  // https://docs.gitlab.com/ee/security/token_overview.html
+  // https://docs.gitlab.com/security/tokens/
   {
     name: 'gitlab-pat',
     pattern: /glpat-[A-Za-z0-9_-]{20}/,
@@ -147,7 +147,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // SendGrid
-  // https://docs.sendgrid.com/api-reference/api-keys/create-api-keys
+  // https://www.twilio.com/docs/sendgrid/api-reference/api-keys/create-api-keys
   {
     name: 'sendgrid-api-key',
     pattern: /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/,
@@ -155,7 +155,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // Mailgun
-  // https://documentation.mailgun.com/en/latest/api-intro.html#authentication
+  // https://documentation.mailgun.com/docs/mailgun/api-reference/mg-auth
   {
     name: 'mailgun-api-key',
     pattern: /key-[a-f0-9]{32}/,
@@ -179,7 +179,7 @@ export const BUNDLED_PATTERNS: readonly RedactRule[] = [
   },
 
   // Discord
-  // https://discord.com/developers/docs/reference#authentication
+  // https://docs.discord.com/developers/reference
   {
     name: 'discord-bot-token',
     pattern: /[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}/,


### PR DESCRIPTION
## What Changed

**Credential-pattern source URLs (`6d22ba9`):**
- Updates 9 vendor doc URLs that have moved since v0.5: GitHub (post path moved to `/engineering/platform-security/`), Stripe (`docs.stripe.com`), Anthropic (`platform.claude.com`), Google (`docs.cloud.google.com`), Slack (`docs.slack.dev`), GitLab (`/security/tokens/`), SendGrid (Twilio acquisition path), Mailgun, Discord. URLs only; no rule patterns or behavior changed.

## Why

Stale third-party links in published docs misdirect users who click through to verify our credential-pattern claims. 

## Test Plan

- [x] `npm run lint` (biome auto-fixed nothing in this diff)
- [x] Spot-check a couple of the new URLs resolve (Anthropic, Google, Slack)

## Notes

URL-only changes in `src/redact-patterns.ts` are confined to `// https://...` comments above each rule; the rule `name`, `pattern`, and `kind` fields are untouched.