### PR TITLE
feat: foundation for stdin and inputFile capture

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,6 +27,10 @@ export class BinaryOutputError extends ShellCassetteError {
   static override code = 'CASSETTE_BINARY_OUTPUT'
 }
 
+export class BinaryInputError extends ShellCassetteError {
+  static override code = 'CASSETTE_BINARY_INPUT'
+}
+
 export class CassetteCorruptError extends ShellCassetteError {
   static override code = 'CASSETTE_CORRUPT'
 }

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -39,7 +39,7 @@ const execaHooks: RunnerHooks<Options, unknown> = {
   synthesize,
 }
 
-function buildCall(file: string, args: readonly string[], options: Options): Call {
+async function buildCall(file: string, args: readonly string[], options: Options): Promise<Call> {
   return {
     command: file,
     args: [...args],

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,6 +1,8 @@
+// Named import: @types/node ^22 omits isUtf8 from BufferConstructor, so Buffer.isUtf8(buf) fails to type-check.
+import { isUtf8 } from 'node:buffer'
 import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { CassetteIOError } from './errors.js'
+import { BinaryInputError, CassetteIOError } from './errors.js'
 
 export async function writeCassetteFile(target: string, content: string): Promise<void> {
   const dir = path.dirname(target)
@@ -32,4 +34,34 @@ export async function readCassetteFile(target: string): Promise<string | null> {
     if (err.code === 'ENOENT') return null
     throw new CassetteIOError(`failed to read cassette from ${target}: ${err.message}`, err)
   }
+}
+
+/**
+ * Reads a file intended to feed subprocess stdin (execa's `inputFile` option).
+ * Bytes are returned verbatim as a UTF-8 string; non-UTF-8 content rejects.
+ *
+ * No BOM stripping, no line-ending normalization. Real execa receives the
+ * same content via its own pipe of the file; this read is the capture path
+ * so the bytes can flow through canonicalization and the redact pipeline
+ * alongside args/stdout/stderr.
+ */
+export async function readInputFile(target: string | URL): Promise<string> {
+  let buf: Buffer
+  try {
+    buf = await readFile(target)
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException
+    throw new CassetteIOError(
+      `failed to read inputFile from ${String(target)}: ${err.message}`,
+      err,
+    )
+  }
+  if (!isUtf8(buf)) {
+    throw new BinaryInputError(
+      `inputFile contains non-UTF-8 bytes: ${String(target)}\n` +
+        `shell-cassette stores stdin as UTF-8. For binary stdin, run with ` +
+        `SHELL_CASSETTE_MODE=passthrough to bypass cassette mode for this test.`,
+    )
+  }
+  return buf.toString('utf8')
 }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -4,11 +4,14 @@ import { redact } from './redact.js'
 import { stripCounter } from './redact-pipeline.js'
 import type { Call, Canonicalize, MatcherStateLike, Recording, RedactConfig } from './types.js'
 
-// cwd/env/stdin are omitted: their values vary per-machine and would break
-// cross-machine replay. Users who need them must opt in via custom canonicalize.
+// cwd/env are omitted: their values vary per-machine and would break
+// cross-machine replay. stdin is included because its value is whatever
+// the test code chose to pass; different stdin should match different
+// recordings. Users who need cwd/env must opt in via custom canonicalize.
 export const defaultCanonicalize: Canonicalize = (call, redactConfig) => {
   return {
     command: call.command,
+    stdin: call.stdin,
     args: call.args.map((arg) => {
       // 1. v0.3: normalize mkdtemp paths
       const tmpNormalized = normalizeTmpPath(arg)

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -45,7 +45,11 @@ const tinyexecHooks: RunnerHooks<Partial<Options>, TinyResult> = {
   synthesize,
 }
 
-function buildCall(file: string, args: readonly string[], options: Partial<Options>): Call {
+async function buildCall(
+  file: string,
+  args: readonly string[],
+  options: Partial<Options>,
+): Promise<Call> {
   const nodeOptions = (options as { nodeOptions?: { cwd?: string; env?: NodeJS.ProcessEnv } })
     .nodeOptions
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,9 @@ export type Call = {
   args: readonly string[]
   cwd: string | null
   env: Record<string, string>
-  stdin: null // v0.1: stdin not supported
+  // String when the call passed `input: 'literal'`; null when no stdin
+  // was supplied. Buffer/stream inputs are rejected at the wrapper layer.
+  stdin: string | null
 }
 
 export type Result = {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -20,7 +20,7 @@ CI=true forces replay mode by default; without a session shell-cassette refuses 
 
 export type RunnerHooks<Opts, ResultShape> = {
   validate: (options: Opts | undefined) => void
-  buildCall: (file: string, args: readonly string[], options: Opts) => Call
+  buildCall: (file: string, args: readonly string[], options: Opts) => Promise<Call>
   realCall: (file: string, args: readonly string[], options: Opts) => Promise<ResultShape>
   // The wrapper measures elapsed time around realCall and passes it here.
   // Adapters use this value rather than reading runner-provided fields so
@@ -68,7 +68,7 @@ export async function runWrapped<Opts, ResultShape>(
     return hooks.realCall(file, args, options)
   }
 
-  const call = hooks.buildCall(file, args, options)
+  const call = await hooks.buildCall(file, args, options)
 
   if (mode === 'replay') {
     if (loaded.loadedFile === null) {

--- a/tests/integration/atomic-write.test.ts
+++ b/tests/integration/atomic-write.test.ts
@@ -1,7 +1,9 @@
-import { readFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, test } from 'vitest'
-import { readCassetteFile, writeCassetteFile } from '../../src/io.js'
+import { BinaryInputError, CassetteIOError, ShellCassetteError } from '../../src/errors.js'
+import { readCassetteFile, readInputFile, writeCassetteFile } from '../../src/io.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('writeCassetteFile (atomic)', () => {
@@ -51,6 +53,63 @@ describe('readCassetteFile', () => {
     const target = path.join(tmpDir.ref(), 'missing.json')
     const result = await readCassetteFile(target)
     expect(result).toBeNull()
+  })
+})
+
+describe('readInputFile', () => {
+  const tmpDir = useTmpDir()
+
+  test('returns UTF-8 string verbatim', async () => {
+    const target = path.join(tmpDir.ref(), 'in.txt')
+    await writeFile(target, 'hello world', 'utf8')
+    const result = await readInputFile(target)
+    expect(result).toBe('hello world')
+  })
+
+  test('preserves multibyte UTF-8 content without truncation', async () => {
+    const target = path.join(tmpDir.ref(), 'in.txt')
+    const value = 'héllo 世界 🎉'
+    await writeFile(target, value, 'utf8')
+    const result = await readInputFile(target)
+    expect(result).toBe(value)
+  })
+
+  test('accepts a URL path (string | URL signature)', async () => {
+    const target = path.join(tmpDir.ref(), 'in.txt')
+    const value = 'from a URL'
+    await writeFile(target, value, 'utf8')
+    const result = await readInputFile(pathToFileURL(target))
+    expect(result).toBe(value)
+  })
+
+  test('throws BinaryInputError on non-UTF-8 bytes', async () => {
+    const target = path.join(tmpDir.ref(), 'in.bin')
+    await writeFile(target, Buffer.from([0xff, 0xfe, 0x00, 0x01]))
+    let caught: unknown
+    try {
+      await readInputFile(target)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(BinaryInputError)
+    expect(caught).toBeInstanceOf(ShellCassetteError)
+    expect((caught as Error).message).toContain(target)
+    expect((caught as Error).message).toContain('non-UTF-8')
+  })
+
+  test('throws CassetteIOError when the file does not exist, preserving cause', async () => {
+    const target = path.join(tmpDir.ref(), 'missing.txt')
+    let caught: unknown
+    try {
+      await readInputFile(target)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(CassetteIOError)
+    expect((caught as Error).message).toContain(target)
+    const cause = (caught as { cause: NodeJS.ErrnoException }).cause
+    expect(cause).toBeDefined()
+    expect(cause.code).toBe('ENOENT')
   })
 })
 

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -96,13 +96,12 @@ describe('defaultCanonicalize properties', () => {
     )
   })
 
-  test('omits cwd, env, stdin from canonical form', () => {
+  test('omits cwd, env from canonical form', () => {
     fc.assert(
       fc.property(genCall, (call) => {
         const c = defaultCanonicalize(call, DEFAULT_CONFIG.redact)
         expect(c.cwd).toBeUndefined()
         expect(c.env).toBeUndefined()
-        expect(c.stdin).toBeUndefined()
       }),
       { numRuns: 100 },
     )

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -7,11 +7,12 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.cassetteDir).toBe('__cassettes__')
   })
 
-  test('default canonicalize returns command + args', () => {
+  test('default canonicalize returns command + args + stdin', () => {
     const call = { command: 'git', args: ['status'], cwd: null, env: {}, stdin: null } as const
     expect(DEFAULT_CONFIG.canonicalize(call, DEFAULT_CONFIG.redact)).toEqual({
       command: 'git',
       args: ['status'],
+      stdin: null,
     })
   })
 })

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   AckRequiredError,
+  BinaryInputError,
   BinaryOutputError,
   CassetteCollisionError,
   CassetteConfigError,
@@ -21,6 +22,7 @@ describe('error classes', () => {
     expect(new ReplayMissError('msg')).toBeInstanceOf(ShellCassetteError)
     expect(new ConcurrencyError('msg')).toBeInstanceOf(ShellCassetteError)
     expect(new BinaryOutputError('msg')).toBeInstanceOf(ShellCassetteError)
+    expect(new BinaryInputError('msg')).toBeInstanceOf(ShellCassetteError)
     expect(new CassetteCorruptError('msg')).toBeInstanceOf(ShellCassetteError)
     expect(new CassetteCollisionError('msg')).toBeInstanceOf(ShellCassetteError)
     expect(new CassetteIOError('msg', new Error('cause'))).toBeInstanceOf(ShellCassetteError)
@@ -35,6 +37,7 @@ describe('error classes', () => {
     expect(ReplayMissError.code).toBe('CASSETTE_REPLAY_MISS')
     expect(ConcurrencyError.code).toBe('CASSETTE_CONCURRENT')
     expect(BinaryOutputError.code).toBe('CASSETTE_BINARY_OUTPUT')
+    expect(BinaryInputError.code).toBe('CASSETTE_BINARY_INPUT')
     expect(CassetteCorruptError.code).toBe('CASSETTE_CORRUPT')
     expect(CassetteCollisionError.code).toBe('CASSETTE_COLLISION')
     expect(CassetteIOError.code).toBe('CASSETTE_IO')
@@ -52,5 +55,10 @@ describe('error classes', () => {
   test('all errors have name matching class name', () => {
     expect(new AckRequiredError('').name).toBe('AckRequiredError')
     expect(new ReplayMissError('').name).toBe('ReplayMissError')
+  })
+
+  test('BinaryInputError preserves the supplied message verbatim', () => {
+    const err = new BinaryInputError('inputFile contains non-UTF-8 bytes: /tmp/x.bin')
+    expect(err.message).toBe('inputFile contains non-UTF-8 bytes: /tmp/x.bin')
   })
 })

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -11,14 +11,39 @@ describe('defaultCanonicalize', () => {
     expect(canonical.args).toEqual(['status'])
   })
 
-  test('omits cwd, env, stdin from canonical form', () => {
+  test('omits cwd, env from canonical form', () => {
     const canonical = defaultCanonicalize(
       callOf('git', ['status'], { cwd: '/some/dir', env: { FOO: 'bar' } }),
       DEFAULT_CONFIG.redact,
     )
     expect(canonical.cwd).toBeUndefined()
     expect(canonical.env).toBeUndefined()
-    expect(canonical.stdin).toBeUndefined()
+  })
+
+  test('includes stdin in canonical form when stdin is a string', () => {
+    const canonical = defaultCanonicalize(
+      callOf('cat', [], { stdin: 'hello world' }),
+      DEFAULT_CONFIG.redact,
+    )
+    expect(canonical.stdin).toBe('hello world')
+  })
+
+  test('includes stdin in canonical form when stdin is null (field present, not omitted)', () => {
+    const canonical = defaultCanonicalize(callOf('cat', []), DEFAULT_CONFIG.redact)
+    expect('stdin' in canonical).toBe(true)
+    expect(canonical.stdin).toBeNull()
+  })
+
+  test('different stdin produces non-equal canonical forms', () => {
+    const a = defaultCanonicalize(callOf('cat', [], { stdin: 'one' }), DEFAULT_CONFIG.redact)
+    const b = defaultCanonicalize(callOf('cat', [], { stdin: 'two' }), DEFAULT_CONFIG.redact)
+    expect(a).not.toEqual(b)
+  })
+
+  test('empty-string stdin and null stdin are distinct canonical forms', () => {
+    const empty = defaultCanonicalize(callOf('cat', [], { stdin: '' }), DEFAULT_CONFIG.redact)
+    const nullish = defaultCanonicalize(callOf('cat', [], { stdin: null }), DEFAULT_CONFIG.redact)
+    expect(empty).not.toEqual(nullish)
   })
 
   test('normalizes mkdtemp paths in args', () => {

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -17,7 +17,7 @@ const baseHooks = (
   realCall: (file: string, args: readonly string[], options: FakeOpts) => Promise<FakeResult>,
 ): RunnerHooks<FakeOpts, FakeResult> => ({
   validate: () => {},
-  buildCall: (file, args) => ({
+  buildCall: async (file, args) => ({
     command: file,
     args: [...args],
     cwd: null,


### PR DESCRIPTION
## What Changed

Three structural commits that open the way for the rest of the v0.6 work. No new user-visible features in this PR alone — every change here is foundation that the next PRs build on.

- **`feat(matcher): include stdin in default canonical form`** — Widens `Call.stdin` from the literal `null` to `string | null`, and includes `stdin` in the partial returned by `defaultCanonicalize`. Empty string and null are distinct (`'' !== null`), so a call with `stdin: ''` and a call with `stdin: null` produce different canonical forms. The cassette schema version stays at 2; existing cassettes with `stdin: null` continue to parse and replay.

- **`feat(io): add readInputFile helper + BinaryInputError class`** — Adds `readInputFile(path: string \| URL): Promise<string>` to `src/io.ts`. Reads the file as a Buffer (no encoding so the binary check sees raw bytes), wraps fs failures in `CassetteIOError` with `cause` preserved, runs `isUtf8(buf)` from `node:buffer` and throws `BinaryInputError` if the bytes aren't UTF-8. Also adds the new `BinaryInputError` class with `static code = 'CASSETTE_BINARY_INPUT'`. Nothing wires this in yet.

- **`refactor(wrapper): make buildCall async in RunnerHooks`** — Changes `RunnerHooks.buildCall` from `(...) => Call` to `(...) => Promise<Call>`. `runWrapped` adds `await` at the call site; both adapter implementations gain the `async` keyword. Passthrough mode still short-circuits before `buildCall`, so it pays zero async overhead. Nothing reads from disk yet.

## Why

A future commit needs `buildCall` to read `inputFile` from disk so that the resolved stdin can join the canonical match-tuple. Reading the file synchronously inside the wrapper would block the event loop; matching by command+args alone (without resolving the file content) would silently ignore drift between the recorded stdin and the current file. Both options are wrong, so `buildCall` becomes async and `Call.stdin` widens to carry a string. The error class and helper are the rejection paths for non-UTF-8 input that the wrapper now needs to handle cleanly.

## Test Plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (624 passed, 1 skipped — same as baseline)
- [x] `npm run build`

## Notes

- `Buffer.isUtf8(buf)` is missing from `BufferConstructor` in `@types/node ^22`; `isUtf8` is imported as a named export from `node:buffer` instead. There is a one-line comment in `src/io.ts` explaining the deviation.
- `package.json` `engines.node` is `>=18` but `isUtf8` requires Node 18.14 / 19.4 or later. Real-world Node 18.0–18.13 users are vanishingly rare, but the declared floor is technically loose. Tracking as a follow-up rather than tightening it in this PR.