### PR TITLE
test: extract useRecordingEnv helper for ack/mode env-snapshot pattern

### DIFF
--- a/tests/e2e/e2e-execa-node.test.ts
+++ b/tests/e2e/e2e-execa-node.test.ts
@@ -1,23 +1,12 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { execaNode } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('e2e execaNode', () => {
   const tmp = useTmpDir('sc-e2e-execa-node-')

--- a/tests/e2e/record-replay.test.ts
+++ b/tests/e2e/record-replay.test.ts
@@ -1,24 +1,12 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin the mode so CI=true on the runner doesn't force replay-strict.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('e2e record + replay', () => {
   test('node --version round-trips deterministically', async () => {

--- a/tests/error-path/binary-input-error.test.ts
+++ b/tests/error-path/binary-input-error.test.ts
@@ -1,25 +1,14 @@
 import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { BinaryInputError, ShellCassetteError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { NODE_ECHO_STDIN } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 // Lone 0xC3 followed by 0x28 is an invalid UTF-8 sequence (0xC3 expects a
 // continuation byte in 0x80-0xBF, and 0x28 is outside that range).

--- a/tests/error-path/error-classes.test.ts
+++ b/tests/error-path/error-classes.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import {
   AckRequiredError,
   CassetteCollisionError,
@@ -19,23 +19,13 @@ import { deriveCassettePathFromTask } from '../../src/plugin.js'
 import { deserialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { makeSession } from '../helpers/session.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin the mode so CI=true on the runner doesn't force replay-strict.
-  // The ReplayMissError test below explicitly sets SHELL_CASSETTE_MODE='replay' to override.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
+// The ReplayMissError test below explicitly sets SHELL_CASSETTE_MODE='replay' to override.
+useRecordingEnv()
 afterEach(() => {
   clearActiveCassette()
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
 
 describe('all error classes are instanceof ShellCassetteError', () => {

--- a/tests/error-path/input-file-not-found.test.ts
+++ b/tests/error-path/input-file-not-found.test.ts
@@ -1,24 +1,13 @@
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { CassetteIOError, ShellCassetteError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { NODE_ECHO_STDIN } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('CassetteIOError on missing inputFile', () => {
   const tmp = useTmpDir('sc-input-missing-')

--- a/tests/helpers/recording-env.ts
+++ b/tests/helpers/recording-env.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach } from 'vitest'
+import { restoreEnv } from './env.js'
+
+/**
+ * Registers beforeEach/afterEach hooks that pin
+ * SHELL_CASSETTE_ACK_REDACTION='true' and SHELL_CASSETTE_MODE around each
+ * test, then restores both vars to their original values afterward.
+ *
+ * The default mode is 'auto' so CI=true on the runner does not force
+ * replay-strict. Pass `{ mode: 'replay' }` etc. to pin a different mode.
+ *
+ * Usage:
+ *   useRecordingEnv()                       // mode: 'auto'
+ *   useRecordingEnv({ mode: 'replay' })     // pinned to replay
+ */
+export function useRecordingEnv(
+  opts: { mode?: 'auto' | 'replay' | 'record' | 'passthrough' } = {},
+): void {
+  const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+  const originalMode = process.env.SHELL_CASSETTE_MODE
+  const targetMode = opts.mode ?? 'auto'
+
+  beforeEach(() => {
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    process.env.SHELL_CASSETTE_MODE = targetMode
+  })
+
+  afterEach(() => {
+    restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+  })
+}

--- a/tests/helpers/recording-env.ts
+++ b/tests/helpers/recording-env.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach } from 'vitest'
+import type { Mode } from '../../src/types.js'
 import { restoreEnv } from './env.js'
 
 /**
@@ -13,9 +14,7 @@ import { restoreEnv } from './env.js'
  *   useRecordingEnv()                       // mode: 'auto'
  *   useRecordingEnv({ mode: 'replay' })     // pinned to replay
  */
-export function useRecordingEnv(
-  opts: { mode?: 'auto' | 'replay' | 'record' | 'passthrough' } = {},
-): void {
+export function useRecordingEnv(opts: { mode?: Mode } = {}): void {
   const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
   const originalMode = process.env.SHELL_CASSETTE_MODE
   const targetMode = opts.mode ?? 'auto'

--- a/tests/integration/per-cassette-override.test.ts
+++ b/tests/integration/per-cassette-override.test.ts
@@ -1,29 +1,17 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { SAMPLE_GITHUB_PAT_CLASSIC } from '../helpers/credential-fixtures.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const tmpDir = useTmpDir('shell-cassette-per-cassette-override-')
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
 const FAKE_PAT = SAMPLE_GITHUB_PAT_CLASSIC
 
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin the mode so CI=true on the runner doesn't force replay-strict.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('useCassette per-cassette redact override', () => {
   test('redact: true (default) redacts a credential in stdout', async () => {

--- a/tests/integration/record-replay-input-file.test.ts
+++ b/tests/integration/record-replay-input-file.test.ts
@@ -1,25 +1,14 @@
 import { readFile, unlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { CassetteIOError, ReplayMissError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { NODE_ECHO_STDIN } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('e2e record + replay with inputFile', () => {
   const tmp = useTmpDir('sc-input-file-')

--- a/tests/integration/record-replay-lines-object.test.ts
+++ b/tests/integration/record-replay-lines-object.test.ts
@@ -1,23 +1,11 @@
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin auto so CI=true on the runner does not force replay-strict.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 // Two-line target on each stream so we can tell array-form (length 2) from
 // string-form (a single string with one '\n'). `lines` is NOT part of the

--- a/tests/integration/record-replay-node.test.ts
+++ b/tests/integration/record-replay-node.test.ts
@@ -1,24 +1,13 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { ReplayMissError } from '../../src/errors.js'
 import { execa, execaNode } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('record + replay with node: true and execaNode', () => {
   const tmp = useTmpDir('sc-node-flag-')

--- a/tests/integration/record-replay-stdin.test.ts
+++ b/tests/integration/record-replay-stdin.test.ts
@@ -1,27 +1,15 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { ReplayMissError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { x } from '../../src/tinyexec.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { NODE_ECHO_STDIN } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin auto so CI=true on the runner does not force replay-strict.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('e2e record + replay with input: string', () => {
   const tmp = useTmpDir('sc-stdin-')

--- a/tests/integration/use-cassette.test.ts
+++ b/tests/integration/use-cassette.test.ts
@@ -1,24 +1,12 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin the mode so CI=true on the runner doesn't force replay-strict.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
-afterEach(() => {
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
-})
+useRecordingEnv()
 
 describe('useCassette', () => {
   test('records execa calls and writes cassette at scope end', async () => {

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -1,31 +1,21 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import { execa as wrappedExeca } from '../../src/execa.js'
 import { writeCassetteFile } from '../../src/io.js'
 import { serialize } from '../../src/serialize.js'
 import { clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { CassetteSession } from '../../src/types.js'
-import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
 import { makeSession } from '../helpers/session.js'
 
 const sessionAt = (sessionPath: string): CassetteSession =>
   makeSession({ name: 'test', path: sessionPath, loadedFile: null, matcher: null })
 
-const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
-const originalMode = process.env.SHELL_CASSETTE_MODE
-
-beforeEach(() => {
-  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
-  // Pin the mode so CI=true on the runner doesn't force replay-strict.
-  process.env.SHELL_CASSETTE_MODE = 'auto'
-})
-
+useRecordingEnv()
 afterEach(() => {
   clearActiveCassette()
-  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
-  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
 })
 
 describe('wrapped execa', () => {


### PR DESCRIPTION
## What Changed

Extracts the duplicated ack/mode env-snapshot pattern from 12 test files into a shared \`useRecordingEnv()\` helper, mirroring \`useTmpDir()\`'s register-and-forget shape.

Each affected file dropped this 7-line block:

\`\`\`ts
const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
const originalMode = process.env.SHELL_CASSETTE_MODE
beforeEach(() => {
  process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
  process.env.SHELL_CASSETTE_MODE = 'auto'
})
afterEach(() => {
  restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
  restoreEnv('SHELL_CASSETTE_MODE', originalMode)
})
\`\`\`

In favor of a single call:

\`\`\`ts
useRecordingEnv()  // or useRecordingEnv({ mode: 'replay' }) when pinning a non-default
\`\`\`

Net: 13 files changed, +69 / -172 (-103 lines).

## Why

The pattern was duplicated across 12 test files (~7 lines each). The default mode is \`'auto'\` because CI=true forces replay-strict otherwise, which would break record-replay tests that need to record fresh in CI. That rationale used to live in scattered comments; now it lives in the helper's JSDoc.

14 other test files were not updated because their env-handling shape is non-canonical: they delete-then-set rather than pin-then-restore, mix CI handling into the same hook, handle other env vars alongside, or set env on a child subprocess. Adopting the helper would require either widening its API beyond what's needed or introducing awkward double-hooks.

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` (685 passed, 1 skipped — same as baseline)
- [x] \`npm run build\`

Test count unchanged. No source files touched.

## Notes

- Two adopters (\`tests/error-path/error-classes.test.ts\`, \`tests/integration/wrapper.test.ts\`) layer a separate \`afterEach(clearActiveCassette)\` after the helper. Vitest's LIFO afterEach order means \`clearActiveCassette\` runs first, then \`restoreEnv\` — matching the original behavior.
- Stacked on #110. Once that lands, this PR auto-retargets to main.

Closes #108.