### PR TITLE
feat: stdin redaction + CLI extension + v0.6 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-30
+
+Surface coverage for stdin and the previously-rejected execa input options. The cassette schema stays at version 2; v0.5 cassettes load and replay unchanged. v0.5 cassettes have `stdin: null` and continue to match calls that pass no input option.
+
+### Added
+
+- **`input: 'string'` on execa.** Buffered stdin is stored on `Call.stdin` and included in the default match-tuple. Non-string `input` (Uint8Array, Readable) is still rejected.
+- **`inputFile` on execa.** The file is read by shell-cassette before the matcher runs, stored on `Call.stdin`, and included in the match-tuple. UTF-8 only.
+- **`node: true` on execa, plus `execaNode` named export.** Routed to real `execaNode` on record. The `node` flag is not stored in the cassette, so recordings made via `node: true` and `execaNode(...)` are interchangeable.
+- **`stdin: 'string'` on tinyexec is now stored in cassettes** and included in the match-tuple. Calls carrying stdin match only against recordings made with the same stdin.
+- **`lines` object form on execa** (`{ stdout, stderr, all, fd1, fd2 }`). Toggles per-stream array vs. string output.
+- **`BinaryInputError` typed `ShellCassetteError` subclass.** Thrown when `inputFile` points at a non-UTF-8 file. Static code: `CASSETTE_BINARY_INPUT`.
+- **Stdin in the default canonicalize.** `defaultCanonicalize` now includes `stdin` (with the same redaction-normalization as args/stdout/stderr). Custom canonicalize functions that omit stdin keep their existing behavior.
+- **Stdin redaction.** `RedactSource` extends to include `'stdin'`. Bundled patterns, custom rules, and the suppress list all apply to stdin values.
+
+### Changed
+
+- **Cassette `_warning` text drops `stdin` from the not-redacted list.** The text continues to enumerate the residual gaps that remain (AWS Secret Access Keys, JWTs, encoded credentials, binary output, cwd).
+- **`defaultCanonicalize` includes `stdin`.** Existing cassettes recorded under v0.5 stored `Call.stdin` as `null`; those continue to match calls that pass no input option.
+- **`RunnerHooks.buildCall` is now async.** This is an internal API; users importing only the high-level entries (`shell-cassette/execa`, `shell-cassette/tinyexec`) are unaffected. The async signature is required to read `inputFile` before the matcher runs.
+
+### Notes
+
+- **Cassette schema stays at version 2.** v0.5 cassettes load and replay correctly under v0.6. The `stdin` field on `Call` was already present in v0.5 cassettes (as `null` for calls without stdin); v0.6 just starts storing values into it.
+- **`inputFile` is read twice** on the record path (once by shell-cassette to populate `Call.stdin`, once by real execa). Tracked for v0.7 optimization; functionally equivalent today.
+
 ## [0.5.1] - 2026-04-29
 
 Heuristic refinement to the long-value warning. No API or schema changes from 0.5.0; cassettes recorded under any prior version load and replay unchanged.

--- a/README.md
+++ b/README.md
@@ -449,8 +449,8 @@ export default {
 
   // Custom canonicalize fn (default: defaultCanonicalize, command exact +
   // args with absolute mkdtemp paths normalized to <tmp>; cwd, env omitted
-  // from the canonical form so cassettes are portable across machines.
-  // stdin is included by default; opt out via custom canonicalize if needed.)
+  // from the canonical form so cassettes are portable across machines;
+  // stdin is included by default; opt out via custom canonicalize if needed)
   canonicalize: (call) => ({
     ...defaultCanonicalize(call),
     command: basenameCommand(call.command),  // /usr/bin/git matches git

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ shell-cassette redacts what it can detect reliably and warns on suspicious-looki
 - **Encoded credentials.** `Authorization: Basic <base64>` headers, base64-encoded YAML/JSON secrets. shell-cassette doesn't decode. Add a custom rule if relevant.
 - **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8.
 - **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
-- **Subprocess `stdin`.** Not captured.
+- **Subprocess `stdin`.** Captured and redacted via the same pipeline as args/stdout/stderr (bundled patterns, custom rules, suppress list). The bundle catches well-shaped credentials passed on stdin; the same residual gaps above (AWS Secret Access Keys, JWTs, encoded credentials) apply.
 
 Workarounds for each gap are in [docs/troubleshooting.md](docs/troubleshooting.md#residual-risks-and-gaps-in-redaction).
 
@@ -448,8 +448,9 @@ export default {
   },
 
   // Custom canonicalize fn (default: defaultCanonicalize, command exact +
-  // args with absolute mkdtemp paths normalized to <tmp>; cwd, env, stdin
-  // omitted from the canonical form so cassettes are portable across machines)
+  // args with absolute mkdtemp paths normalized to <tmp>; cwd, env omitted
+  // from the canonical form so cassettes are portable across machines.
+  // stdin is included by default; opt out via custom canonicalize if needed.)
   canonicalize: (call) => ({
     ...defaultCanonicalize(call),
     command: basenameCommand(call.command),  // /usr/bin/git matches git
@@ -459,9 +460,25 @@ export default {
 
 Full reference for the redact config is in [docs/redact-patterns.md](docs/redact-patterns.md).
 
+## What's in the match-tuple
+
+The default matcher compares a call to a recording by deep-equality of their canonical forms. By default the canonical form is:
+
+| Field | Matched? | Notes |
+|---|---|---|
+| `command` | yes | exact (use `basenameCommand` for cross-machine portability) |
+| `args` | yes | absolute mkdtemp paths normalized to `<tmp>`; counter-tagged placeholders stripped |
+| `stdin` | yes | redaction-normalized so a redacted cassette stdin matches a fresh call carrying the raw value |
+| `cwd` | no | recorded for diagnostic display, not part of the tuple |
+| `env` | no | recorded (with redaction applied) for diagnostic display, not part of the tuple |
+
+For execa, `node: true` and `execaNode(...)` produce identical `Call` shapes: the user-provided file is stored as `Call.command`, and the `node` flag itself is not stored in the cassette. A recording made via `execa(file, args, { node: true })` replays a call made via `execaNode(file, args)` and vice versa.
+
+If you need cwd or env in the match-tuple, or want to drop stdin, write a custom `canonicalize` function.
+
 ## Customizing matching
 
-shell-cassette matches a call to a recording by deep-equality of their canonical forms. The default canonical form covers the common case (command + tmp-normalized args). For everything else, write a `canonicalize` function.
+shell-cassette matches a call to a recording by deep-equality of their canonical forms. The default canonical form covers the common case (command + tmp-normalized args + stdin). For everything else, write a `canonicalize` function.
 
 ```ts
 import { basenameCommand, defaultCanonicalize, useCassette } from 'shell-cassette'

--- a/docs/execa.md
+++ b/docs/execa.md
@@ -105,14 +105,15 @@ execa's options pass through to the wrapped call. shell-cassette validates them 
 | Option | Status |
 |---|---|
 | `cwd`, `env`, `timeout`, `signal`, `argv0`, `cleanup`, etc. | Supported, passed to real execa on record, captured in cassette where relevant |
-| `lines: true` | Supported (returns `string[]` from stdout/stderr) |
+| `lines: true` | Supported. Boolean form returns `string[]` from stdout/stderr; object form (`{ stdout, stderr, all, fd1, fd2 }`) toggles per-stream array vs. string output |
 | `all: true` | Supported (merged stdout+stderr in `result.all`) |
 | `reject: false` | Supported on both record and replay |
+| `input: 'string'` | Supported. Buffered stdin is stored on `Call.stdin` and included in the match-tuple. Non-string `input` (Uint8Array, Readable) is rejected. |
+| `inputFile` | Supported. The file is read by shell-cassette before the matcher runs, stored on `Call.stdin`, and included in the match-tuple. Non-UTF-8 input throws `BinaryInputError`. |
+| `node: true` | Supported. Routed to real `execaNode` on record; the `node` flag is not stored in the cassette so recordings made via `node: true` and `execaNode(...)` are interchangeable. |
+| `execaNode(file, args, options)` (named export) | Supported. Equivalent to `execa(file, args, { ...options, node: true })`. |
 | `buffer: false` | **Rejected** (streaming) |
 | `ipc: true` | **Rejected** (IPC channels) |
-| `inputFile` | **Rejected** (stdin from file) |
-| `input: 'string'` | **Rejected** (buffered stdin) |
-| `node: true` | **Rejected** (execaNode) |
 
 Rejected options throw `UnsupportedOptionError` at the record-mode wrapper entry.
 

--- a/docs/tinyexec.md
+++ b/docs/tinyexec.md
@@ -91,7 +91,7 @@ The cassette schema is narrower than tinyexec's runtime result. One mapping stil
 | `timeout` | Supported, passed through |
 | `nodeOptions` (with `cwd`, `env`, etc.) | Supported, options destructured into the cassette `Call` shape |
 | `throwOnError` | Supported on record AND replay (synthesized error matches tinyexec's shape) |
-| `stdin` (string) | Accepted, not stored in cassette (record-only) |
+| `stdin` (string) | Supported. Stored on `Call.stdin` and included in the match-tuple, so a call carrying stdin only matches a recording made with the same stdin. |
 | `persist: true` | **Rejected** (subprocess outliving host can't replay) |
 | `stdin: Result` (pipe chaining) | **Rejected** (chaining requires live process) |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,7 +184,7 @@ shell-cassette redacts what it can detect with 100% reliability and warns on sus
 - **Encoded credentials.** `Authorization: Basic <base64>` headers and base64-encoded YAML/JSON secrets pass through. shell-cassette doesn't decode. Add a custom rule if your test surface includes them.
 - **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8.
 - **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
-- **Subprocess `stdin`.** Not captured; nothing on disk to redact.
+- **Subprocess `stdin`.** Captured and redacted via the same pipeline as args/stdout/stderr (bundled patterns, custom rules, suppress list). The same residual gaps above (AWS Secret Access Keys, JWTs, encoded credentials) apply to stdin.
 
 Each gap has a workaround: long-value warning catches length anomalies, custom rules cover project-specific shapes, suppress patterns silence known fixtures, and `useCassette({ redact: false })` disables the pipeline for cassettes that legitimately need raw values (DO NOT commit those).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,7 +184,7 @@ shell-cassette redacts what it can detect with 100% reliability and warns on sus
 - **Encoded credentials.** `Authorization: Basic <base64>` headers and base64-encoded YAML/JSON secrets pass through. shell-cassette doesn't decode. Add a custom rule if your test surface includes them.
 - **Binary output.** `BinaryOutputError` blocks recording when the subprocess emits non-UTF-8.
 - **`cwd` values.** Credentials in working-directory paths are vanishingly rare; not redacted.
-- **Subprocess `stdin`.** Captured and redacted via the same pipeline as args/stdout/stderr (bundled patterns, custom rules, suppress list). The same residual gaps above (AWS Secret Access Keys, JWTs, encoded credentials) apply to stdin.
+- **Subprocess `stdin`.** Stdin (from `input: 'string'`, `inputFile`, or tinyexec `stdin: 'string'`) flows through the same redaction stage as args, stdout, and stderr. Bundled patterns plus any custom rules in the user's config run against stdin; matches use placeholders of the form `<redacted:stdin:<rule>:<N>>`. The residual gaps above (AWS Secret Access Keys, JWTs without opt-in, encoded credentials) apply to stdin too.
 
 Each gap has a workaround: long-value warning catches length anomalies, custom rules cover project-specific shapes, suppress patterns silence known fixtures, and `useCassette({ redact: false })` disables the pipeline for cassettes that legitimately need raw values (DO NOT commit those).
 

--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -257,6 +257,20 @@ function reRedactRecording(
     return r.output
   })
 
+  // stdin: single string source. Re-redact mirrors the args block's shape but
+  // skips entirely when the call had no stdin.
+  let stdin: string | null = rec.call.stdin
+  if (stdin !== null) {
+    const r = redact({ source: 'stdin', value: stdin }, config, {
+      counted: true,
+      counters,
+      suppressedHashes,
+    })
+    newEntries.push(...r.entries)
+    newCount += r.entries.reduce((s, e) => s + e.count, 0)
+    stdin = r.output
+  }
+
   const stdoutLines = rec.result.stdoutLines.map((line) => {
     const r = redact({ source: 'stdout', value: line }, config, {
       counted: true,
@@ -298,7 +312,7 @@ function reRedactRecording(
 
   return {
     recording: {
-      call: { ...rec.call, env, args },
+      call: { ...rec.call, env, args, stdin },
       result: { ...rec.result, stdoutLines, stderrLines, allLines },
       redactions: aggregated,
       // suppressed is user intent; never mutated by re-redact.

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -135,6 +135,11 @@ function scanRecording(
     )
   }
 
+  // stdin: single string source. Position label is '0' (no line/index dimension).
+  if (rec.call.stdin !== null) {
+    findings.push(...scanValue(rec.call.stdin, 'stdin', '0', index, rules, config, skipSet, [], 1))
+  }
+
   for (let lineIdx = 0; lineIdx < rec.result.stdoutLines.length; lineIdx++) {
     findings.push(
       ...scanValue(
@@ -481,6 +486,7 @@ export function applyDecisions(
       env[key] = redactValue('env', value, key)
     }
     const args = rec.call.args.map((arg) => redactValue('args', arg))
+    const stdin = rec.call.stdin === null ? null : redactValue('stdin', rec.call.stdin)
     const stdoutLines = rec.result.stdoutLines.map((line) => redactValue('stdout', line))
     const stderrLines = rec.result.stderrLines.map((line) => redactValue('stderr', line))
     const allLines =
@@ -500,7 +506,7 @@ export function applyDecisions(
     }
 
     updatedRecordings.push({
-      call: { ...rec.call, env, args },
+      call: { ...rec.call, env, args, stdin },
       result: { ...rec.result, stdoutLines, stderrLines, allLines },
       redactions: aggregateEntries([...rec.redactions, ...newCustomEntries, ...newRedactEntries]),
       suppressed: newSuppressed,
@@ -516,12 +522,16 @@ export function applyDecisions(
 
 /**
  * Replace the match span identified by `finding` with `replacement`.
- * Position is structured: env values are whole-value, args/stdout/stderr/
+ * Position is structured: env and stdin are whole-value, args/stdout/stderr/
  * allLines have line+col.
  *
- * Replace is documented as not available for args during the interactive
- * loop (canonicalize-incompatible), but applyReplace handles args
+ * Replace is documented as not available for args or stdin during the
+ * interactive loop (canonicalize-incompatible), but applyReplace handles both
  * defensively in case the user's --json mode bypasses the dispatcher.
+ *
+ * The cascading-if pattern below has no compile-time exhaustiveness guarantee
+ * over RedactSource members; conversion to a switch with `never` exhaustion
+ * is tracked separately in #101.
  */
 function applyReplace(rec: Recording, finding: Finding, replacement: string): Recording {
   const { source } = finding
@@ -538,6 +548,12 @@ function applyReplace(rec: Recording, finding: Finding, replacement: string): Re
     const arg = args[argIdx]!
     args[argIdx] = arg.slice(0, col) + replacement + arg.slice(col + finding.matchLength)
     return { ...rec, call: { ...rec.call, args } }
+  }
+  if (source === 'stdin') {
+    // Whole-value replacement; stdin is a single string. Defensive parallel to
+    // env's branch. Should not be reached in normal flow because readNextAction
+    // gates 'r' for stdin findings.
+    return { ...rec, call: { ...rec.call, stdin: replacement } }
   }
   const lineNumber = Number.parseInt(finding.position.split(':')[0] ?? '1', 10)
   const col = Number.parseInt(finding.position.split(':')[1] ?? '0', 10)
@@ -801,9 +817,12 @@ function countDecisions(state: ReviewState): {
 async function readNextAction(state: ReviewState): Promise<ReviewAction> {
   // biome-ignore lint/style/noNonNullAssertion: cursor in range when reviewing
   const finding = state.findings[state.cursor]!
-  // (r)eplace is unavailable for args (canonicalize-incompatible).
+  // (r)eplace is unavailable for sources participating in canonicalize-then-match
+  // (args and stdin: both feed into the matcher tuple).
   const allowed =
-    finding.source === 'args' ? ['a', 's', 'd', 'b', 'q', '?'] : ['a', 's', 'r', 'd', 'b', 'q', '?']
+    finding.source === 'args' || finding.source === 'stdin'
+      ? ['a', 's', 'd', 'b', 'q', '?']
+      : ['a', 's', 'r', 'd', 'b', 'q', '?']
   while (true) {
     const key = await promptAction(allowed)
     if (key === '?') {

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -590,7 +590,7 @@ Usage:
 Walks unredacted findings interactively. For each finding the user picks:
   (a) accept     apply default redaction (counter-tagged placeholder)
   (s) skip       leave match in body, persist via _suppressed
-  (r) replace    substitute user-provided string (NOT for args)
+  (r) replace    substitute user-provided string (NOT for args or stdin)
   (d) delete     remove the entire recording
   (b) back       revisit previous finding
   (q) quit       discard all decisions

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -276,6 +276,11 @@ function findingsForRecording(
     findings.push(...scanValue(arg, 'args', argIdx.toString(), index, rules, config, includeMatch))
   }
 
+  // stdin: single string source. Position label is '0' (no line/index dimension).
+  if (rec.call.stdin !== null) {
+    findings.push(...scanValue(rec.call.stdin, 'stdin', '0', index, rules, config, includeMatch))
+  }
+
   // stdout lines: use 1-based line number as position label
   for (const [lineIdx, line] of rec.result.stdoutLines.entries()) {
     findings.push(

--- a/src/cli-show.ts
+++ b/src/cli-show.ts
@@ -220,6 +220,8 @@ function printRecording(rec: Recording, index: number, total: number, flags: Sho
     stdout('  env: (none redacted)')
   }
 
+  printStdin(rec.call.stdin, flags)
+
   const exitColor = rec.result.exitCode === 0 ? color.green : color.red
   stdout(`  exit: ${exitColor(String(rec.result.exitCode))}  duration: ${rec.result.durationMs}ms`)
 
@@ -232,6 +234,18 @@ function printRecording(rec: Recording, index: number, total: number, flags: Sho
   const redactionCount = rec.redactions.reduce((s, e) => s + e.count, 0)
   stdout(`  redactions: ${redactionCount}`)
   stdout('')
+}
+
+/**
+ * Prints the call's stdin section. Skipped when stdin is null (no `input:`
+ * passed to execa). Stdin is a single string, not an array of lines, so this
+ * is a small variant of printLines rather than reusing it.
+ */
+function printStdin(value: string | null, flags: ShowFlags): void {
+  if (value === null) return
+  stdout(`  stdin (${value.length} chars):`)
+  const truncated = flags.full ? value : applyTruncation(value, 80)
+  stdout(`    ${highlightPlaceholders(truncated)}`)
 }
 
 function printLines(name: string, lines: readonly string[], flags: ShowFlags): void {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -11,7 +11,16 @@ import type { Call, Canonicalize, MatcherStateLike, Recording, RedactConfig } fr
 export const defaultCanonicalize: Canonicalize = (call, redactConfig) => {
   return {
     command: call.command,
-    stdin: call.stdin,
+    // stdin canonicalize mirrors args (minus tmp normalization, which is
+    // path-specific). Counter strip + counted:false redact lets a redacted
+    // cassette stdin (`<redacted:stdin:github-pat-classic:1>`) round-trip
+    // match against a fresh call with the raw token in `input`.
+    stdin:
+      call.stdin === null
+        ? null
+        : redact({ source: 'stdin', value: stripCounter(call.stdin) }, redactConfig, {
+            counted: false,
+          }).output,
     args: call.args.map((arg) => {
       // 1. v0.3: normalize mkdtemp paths
       const tmpNormalized = normalizeTmpPath(arg)

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -52,30 +52,13 @@ function redactCall(call: Call, session: CassetteSession): Call {
     }
   }
 
-  const args = call.args.map((arg) => {
-    const r = redact({ source: 'args', value: arg }, session.redactConfig, {
-      counted: true,
-      counters: session.redactCounters,
-    })
-    session.redactionEntries.push(...r.entries)
-    session.warnings.push(...r.warnings)
-    return r.output
-  })
+  const args = call.args.map((arg) => redactLine('args', arg, session))
 
   // Stdin can carry credentials (raw API responses with embedded tokens,
   // hand-typed credentials, etc.) that no env-key match would catch.
   // Run the bundled + custom regex pipeline against the raw stdin string
   // when present; skip entirely for null stdin (no input was supplied).
-  let stdin: string | null = null
-  if (call.stdin !== null) {
-    const r = redact({ source: 'stdin', value: call.stdin }, session.redactConfig, {
-      counted: true,
-      counters: session.redactCounters,
-    })
-    session.redactionEntries.push(...r.entries)
-    session.warnings.push(...r.warnings)
-    stdin = r.output
-  }
+  const stdin = call.stdin === null ? null : redactLine('stdin', call.stdin, session)
 
   return { ...call, env, args, stdin }
 }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -62,7 +62,22 @@ function redactCall(call: Call, session: CassetteSession): Call {
     return r.output
   })
 
-  return { ...call, env, args }
+  // Stdin can carry credentials (raw API responses with embedded tokens,
+  // hand-typed credentials, etc.) that no env-key match would catch.
+  // Run the bundled + custom regex pipeline against the raw stdin string
+  // when present; skip entirely for null stdin (no input was supplied).
+  let stdin: string | null = null
+  if (call.stdin !== null) {
+    const r = redact({ source: 'stdin', value: call.stdin }, session.redactConfig, {
+      counted: true,
+      counters: session.redactCounters,
+    })
+    session.redactionEntries.push(...r.entries)
+    session.warnings.push(...r.warnings)
+    stdin = r.output
+  }
+
+  return { ...call, env, args, stdin }
 }
 
 function redactResult(result: Result, session: CassetteSession): Result {

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -301,6 +301,7 @@ function walkStringsForPlaceholders(
   const values = [
     ...Object.values(rec.call.env),
     ...rec.call.args,
+    ...(rec.call.stdin !== null ? [rec.call.stdin] : []),
     ...rec.result.stdoutLines,
     ...rec.result.stderrLines,
     ...(rec.result.allLines ?? []),

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -6,7 +6,7 @@ const SCHEMA_VERSION = 2
 const REVIEW_WARNING =
   'REVIEW BEFORE COMMITTING. shell-cassette redacts bundled credential patterns + ' +
   'curated env-key values + your custom rules. It does NOT redact: AWS Secret Access Keys, ' +
-  'JWTs (without opt-in), encoded credentials, binary output, cwd, stdin. ' +
+  'JWTs (without opt-in), encoded credentials, binary output, cwd. ' +
   'Run `shell-cassette scan <path>` to verify before committing. ' +
   'See https://github.com/slgoodrich/shell-cassette/blob/main/docs/troubleshooting.md'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export type CassetteFile = {
 
 export type Canonicalize = (call: Call, redactConfig: Readonly<RedactConfig>) => Partial<Call>
 
-export type RedactSource = 'env' | 'args' | 'stdout' | 'stderr' | 'allLines'
+export type RedactSource = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
 
 export type RedactRule = {
   /**

--- a/tests/cli/re-redact.test.ts
+++ b/tests/cli/re-redact.test.ts
@@ -234,6 +234,84 @@ describe('runReRedact: --quiet', () => {
   })
 })
 
+describe('runReRedact: stdin source', () => {
+  test('re-redacts a credential in call.stdin into a placeholder', async () => {
+    const target = path.join(tmpDir.ref(), 'stdin.json')
+    const cassette = {
+      version: 2,
+      _warning: 'REVIEW',
+      _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: `Bearer ${SAMPLE_GITHUB_PAT_CLASSIC}`,
+          },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    await writeFile(target, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    captureOutput()
+    const code = await runReRedact([target, '--no-color'])
+    expect(code).toBe(1)
+
+    const after = JSON.parse(await readFile(target, 'utf8'))
+    expect(after.recordings[0].call.stdin).toBe('Bearer <redacted:stdin:github-pat-classic:1>')
+    expect(after.recordings[0]._redactions).toContainEqual({
+      rule: 'github-pat-classic',
+      source: 'stdin',
+      count: 1,
+    })
+  })
+
+  test('cassette with stdin: null is unchanged by re-redact', async () => {
+    const target = path.join(tmpDir.ref(), 'stdin-null.json')
+    const cassette = {
+      version: 2,
+      _warning: 'REVIEW',
+      _recorded_by: { name: 'shell-cassette', version: '0.5.0' },
+      recordings: [
+        {
+          call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['hi'],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const before = `${JSON.stringify(cassette, null, 2)}\n`
+    await writeFile(target, before)
+
+    captureOutput()
+    const code = await runReRedact([target, '--no-color'])
+    expect(code).toBe(0)
+
+    const after = await readFile(target, 'utf8')
+    expect(after).toBe(before)
+  })
+})
+
 describe('runReRedact: --config <path>', () => {
   test('--config <path> loads explicit config and custom rules apply', async () => {
     const target = path.join(tmpDir.ref(), 'cassette.json')

--- a/tests/cli/scan.test.ts
+++ b/tests/cli/scan.test.ts
@@ -329,6 +329,132 @@ describe('runScan: --json + --quiet interaction', () => {
   })
 })
 
+describe('runScan: stdin source', () => {
+  test('stdin with credential: finding produced with source=stdin and 0:<col> position', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-stdin-'))
+    try {
+      const cassettePath = path.join(tmp, 'stdin.json')
+      // Match begins at col 7 within "Token: ghp_..."
+      await writeFile(
+        cassettePath,
+        JSON.stringify({
+          version: 2,
+          _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+          recordings: [
+            {
+              call: {
+                command: 'curl',
+                args: [],
+                cwd: null,
+                env: {},
+                stdin: `Token: ${SAMPLE_GITHUB_PAT_CLASSIC}`,
+              },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+          ],
+        }),
+        'utf8',
+      )
+      captureOutput()
+      const code = await runScan([cassettePath, '--json', '--include-match'])
+      expect(code).toBe(1)
+      const parsed = JSON.parse(stdoutBuf)
+      expect(parsed.cassettes[0].findings).toHaveLength(1)
+      const finding = parsed.cassettes[0].findings[0]
+      expect(finding.source).toBe('stdin')
+      expect(finding.rule).toBe('github-pat-classic')
+      expect(finding.match).toBe(SAMPLE_GITHUB_PAT_CLASSIC)
+      expect(finding.matchHash).toBe(matchHash(SAMPLE_GITHUB_PAT_CLASSIC))
+      expect(finding.id).toBe('rec0-stdin-0:7-github-pat-classic')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('stdin null: no stdin findings', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-stdin-null-'))
+    try {
+      const cassettePath = path.join(tmp, 'stdin-null.json')
+      await writeFile(
+        cassettePath,
+        JSON.stringify({
+          version: 2,
+          _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+          recordings: [
+            {
+              call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+          ],
+        }),
+        'utf8',
+      )
+      captureOutput()
+      const code = await runScan([cassettePath, '--json'])
+      expect(code).toBe(0)
+      const parsed = JSON.parse(stdoutBuf)
+      expect(parsed.cassettes[0].status).toBe('clean')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('stdin empty string: no findings (no patterns can match an empty string)', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'scan-stdin-empty-'))
+    try {
+      const cassettePath = path.join(tmp, 'stdin-empty.json')
+      await writeFile(
+        cassettePath,
+        JSON.stringify({
+          version: 2,
+          _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+          recordings: [
+            {
+              call: { command: 'echo', args: [], cwd: null, env: {}, stdin: '' },
+              result: {
+                stdoutLines: [],
+                stderrLines: [],
+                allLines: null,
+                exitCode: 0,
+                signal: null,
+                durationMs: 0,
+                aborted: false,
+              },
+              _redactions: [],
+            },
+          ],
+        }),
+        'utf8',
+      )
+      captureOutput()
+      const code = await runScan([cassettePath, '--json'])
+      expect(code).toBe(0)
+      const parsed = JSON.parse(stdoutBuf)
+      expect(parsed.cassettes[0].status).toBe('clean')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('runScan: isSuppressed g-flag lastIndex bug (closes #62)', () => {
   test('g-flagged suppress pattern suppresses all three consecutive matching recordings', async () => {
     // Without resetting lastIndex before each .test() call, a g-flagged suppress

--- a/tests/security/redact-stdin.test.ts
+++ b/tests/security/redact-stdin.test.ts
@@ -1,0 +1,243 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { record } from '../../src/recorder.js'
+import { seedCountersFromCassette } from '../../src/redact-pipeline.js'
+import { useCassette } from '../../src/use-cassette.js'
+import {
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_GITHUB_PAT_CLASSIC_2,
+} from '../helpers/credential-fixtures.js'
+import { makeResult } from '../helpers/recording.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { makeSession } from '../helpers/session.js'
+import { NODE_ECHO_STDIN } from '../helpers/subprocess-targets.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+describe('recorder redacts stdin via the bundle', () => {
+  test('GitHub PAT in stdin is replaced with counter-tagged placeholder', () => {
+    const session = makeSession()
+    record(
+      {
+        command: 'curl',
+        args: [],
+        cwd: null,
+        env: {},
+        stdin: `prefix ${SAMPLE_GITHUB_PAT_CLASSIC} suffix`,
+      },
+      makeResult(),
+      session,
+    )
+    expect(session.newRecordings[0]?.call.stdin).toBe(
+      'prefix <redacted:stdin:github-pat-classic:1> suffix',
+    )
+    expect(session.newRecordings[0]?.redactions).toEqual([
+      { rule: 'github-pat-classic', source: 'stdin', count: 1 },
+    ])
+  })
+
+  test('multiple PATs in same stdin: counter increments per occurrence', () => {
+    const session = makeSession()
+    record(
+      {
+        command: 'curl',
+        args: [],
+        cwd: null,
+        env: {},
+        stdin: `${SAMPLE_GITHUB_PAT_CLASSIC} and ${SAMPLE_GITHUB_PAT_CLASSIC_2}`,
+      },
+      makeResult(),
+      session,
+    )
+    expect(session.newRecordings[0]?.call.stdin).toBe(
+      '<redacted:stdin:github-pat-classic:1> and <redacted:stdin:github-pat-classic:2>',
+    )
+  })
+
+  test('empty-string stdin is preserved verbatim', () => {
+    const session = makeSession()
+    record({ command: 'curl', args: [], cwd: null, env: {}, stdin: '' }, makeResult(), session)
+    expect(session.newRecordings[0]?.call.stdin).toBe('')
+    expect(session.newRecordings[0]?.redactions).toEqual([])
+  })
+
+  test('null stdin is preserved verbatim and skips the redact step', () => {
+    const session = makeSession()
+    record({ command: 'curl', args: [], cwd: null, env: {}, stdin: null }, makeResult(), session)
+    expect(session.newRecordings[0]?.call.stdin).toBeNull()
+    expect(session.newRecordings[0]?.redactions).toEqual([])
+  })
+
+  test('custom rule applied to stdin redacts as expected', () => {
+    const session = makeSession({
+      redactConfig: {
+        ...makeSession().redactConfig,
+        bundledPatterns: false,
+        customPatterns: [{ name: 'my-secret', pattern: /MYSECRET-[A-Z0-9]+/ }],
+      },
+    })
+    record(
+      {
+        command: 'curl',
+        args: [],
+        cwd: null,
+        env: {},
+        stdin: 'value MYSECRET-ABC123 trailing',
+      },
+      makeResult(),
+      session,
+    )
+    expect(session.newRecordings[0]?.call.stdin).toBe('value <redacted:stdin:my-secret:1> trailing')
+  })
+
+  test('redactEnabled: false bypasses stdin redaction', () => {
+    const session = makeSession()
+    session.redactEnabled = false
+    record(
+      {
+        command: 'curl',
+        args: [],
+        cwd: null,
+        env: {},
+        stdin: SAMPLE_GITHUB_PAT_CLASSIC,
+      },
+      makeResult(),
+      session,
+    )
+    expect(session.newRecordings[0]?.call.stdin).toBe(SAMPLE_GITHUB_PAT_CLASSIC)
+    expect(session.newRecordings[0]?.redactions).toEqual([])
+  })
+})
+
+describe('counter seeding for stdin source', () => {
+  test('cassette with <redacted:stdin:gh-pat:N> placeholder seeds counter', () => {
+    const seeded = seedCountersFromCassette({
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: 'token: <redacted:stdin:github-pat-classic:5>',
+          },
+          result: makeResult(),
+          redactions: [],
+          suppressed: [],
+        },
+      ],
+    })
+    expect(seeded.get('stdin:github-pat-classic')).toBe(5)
+  })
+
+  test('next emission continues from seeded ceiling', () => {
+    const session = makeSession()
+    session.loadedFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: 'token: <redacted:stdin:github-pat-classic:3>',
+          },
+          result: makeResult(),
+          redactions: [{ rule: 'github-pat-classic', source: 'stdin', count: 3 }],
+          suppressed: [],
+        },
+      ],
+    }
+    const seeded = seedCountersFromCassette(session.loadedFile)
+    for (const [k, v] of seeded) {
+      session.redactCounters.set(k, v)
+    }
+
+    record(
+      {
+        command: 'curl',
+        args: [],
+        cwd: null,
+        env: {},
+        stdin: SAMPLE_GITHUB_PAT_CLASSIC,
+      },
+      makeResult(),
+      session,
+    )
+    // Body has :3 and metadata has count 3; max + 1 = :4
+    expect(session.newRecordings[0]?.call.stdin).toBe('<redacted:stdin:github-pat-classic:4>')
+  })
+})
+
+describe('e2e: stdin credential round-trips redacted in cassette JSON', () => {
+  const tmp = useTmpDir('sc-redact-stdin-')
+
+  test('input containing GitHub PAT lands as placeholder in cassette body', async () => {
+    const cp = path.join(tmp.ref(), 'redact-stdin.json')
+    await useCassette(cp, async () => {
+      await execa('node', NODE_ECHO_STDIN, { input: SAMPLE_GITHUB_PAT_CLASSIC })
+    })
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings).toHaveLength(1)
+    expect(cassette.recordings[0].call.stdin).toBe('<redacted:stdin:github-pat-classic:1>')
+    // Cassette text never contains the raw token, even though the subprocess
+    // echoed it to stdout (where redaction also fires for the stdout source).
+    const cassetteText = await readFile(cp, 'utf8')
+    expect(cassetteText).not.toContain(SAMPLE_GITHUB_PAT_CLASSIC)
+    // The stdin entry is in the redaction summary; stdout may also appear
+    // because NODE_ECHO_STDIN pipes stdin to stdout.
+    expect(cassette.recordings[0]._redactions).toContainEqual({
+      rule: 'github-pat-classic',
+      source: 'stdin',
+      count: 1,
+    })
+  })
+})
+
+describe('logging never includes stdin content', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  const originalLog = process.env.SHELL_CASSETTE_LOG
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    delete process.env.SHELL_CASSETTE_LOG
+  })
+
+  afterEach(() => {
+    stderrSpy.mockRestore()
+    if (originalLog === undefined) {
+      delete process.env.SHELL_CASSETTE_LOG
+    } else {
+      process.env.SHELL_CASSETTE_LOG = originalLog
+    }
+  })
+
+  test('recorder does not log raw stdin value when it contains a credential', () => {
+    const session = makeSession()
+    record(
+      {
+        command: 'curl',
+        args: [],
+        cwd: null,
+        env: {},
+        stdin: SAMPLE_GITHUB_PAT_CLASSIC,
+      },
+      makeResult(),
+      session,
+    )
+    // Walk every stderr write the recorder/log made; none may contain the
+    // raw token. Per the project rule, log lines about stdin redaction may
+    // emit the source label but never the value.
+    for (const call of stderrSpy.mock.calls) {
+      const text = String(call[0])
+      expect(text).not.toContain(SAMPLE_GITHUB_PAT_CLASSIC)
+    }
+  })
+})

--- a/tests/security/redact-stdin.test.ts
+++ b/tests/security/redact-stdin.test.ts
@@ -199,6 +199,38 @@ describe('e2e: stdin credential round-trips redacted in cassette JSON', () => {
       count: 1,
     })
   })
+
+  test('replay matches when cassette has redacted stdin and fresh call has raw token', async () => {
+    const cp = path.join(tmp.ref(), 'redact-stdin-replay.json')
+
+    // Record: stdin contains a real PAT. Cassette captures redacted form.
+    await useCassette(cp, async () => {
+      await execa('node', NODE_ECHO_STDIN, { input: SAMPLE_GITHUB_PAT_CLASSIC })
+    })
+
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings).toHaveLength(1)
+    expect(cassette.recordings[0].call.stdin).toBe('<redacted:stdin:github-pat-classic:1>')
+
+    // Replay-strict: same call with the same raw token must match the
+    // redacted recording. defaultCanonicalize must reduce both arms to the
+    // same stripped placeholder. Without this fix the replay throws
+    // ReplayMissError because cassette stdin is the placeholder while the
+    // fresh call's stdin is the raw token.
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        // The replayed result is whatever the cassette stored (the redacted
+        // stdout), but the assertion that matters is that the call matched
+        // at all — no ReplayMissError thrown.
+        const r = await execa('node', NODE_ECHO_STDIN, { input: SAMPLE_GITHUB_PAT_CLASSIC })
+        expect(r.exitCode).toBe(0)
+        expect(r.stdout).toBe('<redacted:stdout:github-pat-classic:1>')
+      })
+    } finally {
+      process.env.SHELL_CASSETTE_MODE = 'auto'
+    }
+  })
 })
 
 describe('logging never includes stdin content', () => {

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -4,7 +4,13 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { type Reader, setReader } from '../../src/cli-prompt.js'
 import type { Finding, ReviewState } from '../../src/cli-review.js'
-import { applyAction, preScan, runReview } from '../../src/cli-review.js'
+import {
+  applyAction,
+  applyDecisions,
+  type Decision,
+  preScan,
+  runReview,
+} from '../../src/cli-review.js'
 import { ENV_KEY_MATCH_RULE, matchHash } from '../../src/redact-pipeline.js'
 import type { CassetteFile, RedactConfig } from '../../src/types.js'
 import { makeRecording } from '../helpers/recording.js'
@@ -181,6 +187,48 @@ describe('preScan', () => {
     const config: RedactConfig = { ...minimalConfig, envKeys: ['TOKEN'] }
     expect(preScan(cassette, config)).toEqual([])
   })
+
+  test('stdin with credential: finding produced with source=stdin and 0:<col> position', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: `Bearer ${pat}`,
+          },
+        }),
+      ],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      recordingIndex: 0,
+      source: 'stdin',
+      rule: 'github-pat-classic',
+      position: '0:7',
+      matchLength: pat.length,
+    })
+    expect(findings[0]?.id).toBe('rec0-stdin-0:7-github-pat-classic')
+  })
+
+  test('stdin null: no stdin findings', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: { command: 'echo', args: [], cwd: null, env: {}, stdin: null },
+        }),
+      ],
+    }
+    expect(preScan(cassette, minimalConfig)).toEqual([])
+  })
 })
 
 function mkFinding(
@@ -309,6 +357,95 @@ describe('applyAction', () => {
     state = applyAction(state, { kind: 'discard' })
     expect(state.step).toBe('done')
     expect(state.decisions.size).toBe(0)
+  })
+})
+
+describe('applyDecisions: stdin source', () => {
+  test('replace decision on stdin finding writes call.stdin = replacement', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: `Bearer ${pat}`,
+          },
+        }),
+      ],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    expect(findings).toHaveLength(1)
+    // biome-ignore lint/style/noNonNullAssertion: assertion above
+    const finding = findings[0]!
+    expect(finding.source).toBe('stdin')
+    const decisions = new Map<string, Decision>([[finding.id, { kind: 'replace', with: 'STUB' }]])
+    const updated = applyDecisions(cassette, findings, decisions, minimalConfig)
+    // The replace branch substitutes the entire stdin value (whole-value, like env).
+    // This mirrors env's defensive branch; readNextAction normally gates 'r' for
+    // stdin, so this asserts the defensive path works when decisions arrive
+    // through a non-interactive path.
+    expect(updated.recordings[0]?.call.stdin).toBe('STUB')
+  })
+
+  test('accept decision on stdin finding produces a redacted placeholder in stdin', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: `Bearer ${pat}`,
+          },
+        }),
+      ],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    // biome-ignore lint/style/noNonNullAssertion: preScan finds one match
+    const finding = findings[0]!
+    const decisions = new Map<string, Decision>([[finding.id, { kind: 'accept' }]])
+    const updated = applyDecisions(cassette, findings, decisions, minimalConfig)
+    expect(updated.recordings[0]?.call.stdin).toBe('Bearer <redacted:stdin:github-pat-classic:1>')
+  })
+
+  test('skip decision on stdin finding leaves stdin verbatim and adds a SuppressedEntry', () => {
+    const pat = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        makeRecording({
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: `Bearer ${pat}`,
+          },
+        }),
+      ],
+    }
+    const findings = preScan(cassette, minimalConfig)
+    // biome-ignore lint/style/noNonNullAssertion: preScan finds one match
+    const finding = findings[0]!
+    const decisions = new Map<string, Decision>([[finding.id, { kind: 'skip' }]])
+    const updated = applyDecisions(cassette, findings, decisions, minimalConfig)
+    expect(updated.recordings[0]?.call.stdin).toBe(`Bearer ${pat}`)
+    expect(updated.recordings[0]?.suppressed).toContainEqual({
+      source: 'stdin',
+      rule: 'github-pat-classic',
+      position: '0:7',
+      matchHash: finding.matchHash,
+    })
   })
 })
 
@@ -515,6 +652,53 @@ describe('runReview interactive (driven via fake reader)', () => {
     )
     // Sanity check: stdout was actually captured (renderFinding ran).
     expect(outBuf.join('')).toContain('[Finding')
+  })
+
+  test('stdin finding: prompt omits replace key (gated like args)', async () => {
+    const PAT = 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: null,
+      recordings: [
+        {
+          call: { command: 'curl', args: [], cwd: null, env: {}, stdin: `Bearer ${PAT}` },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 0,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'stdin-dirty.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const prompts: string[] = []
+    const queue = ['a', 'y']
+    setReader({
+      question: async (p: string) => {
+        prompts.push(p)
+        return queue.shift() ?? ''
+      },
+      close: () => {},
+    })
+    const exit = await runReview([fixturePath, '--no-color'])
+    expect(exit).toBe(0)
+    // The action prompt for the stdin finding must NOT include 'r' but MUST
+    // include the gated set: a, s, d, b, q, ?.
+    const actionPrompt = prompts.find((p) => p.startsWith('Action?'))
+    expect(actionPrompt).toBeDefined()
+    expect(actionPrompt).not.toMatch(/\br\b/)
+    expect(actionPrompt).toContain('a/s/d/b/q/?')
+    // Sanity: the cassette was actually written with stdin redacted.
+    const after = JSON.parse(await readFile(fixturePath, 'utf8'))
+    expect(after.recordings[0].call.stdin).toBe('Bearer <redacted:stdin:github-pat-classic:1>')
   })
 
   test('quit discards decisions; cassette unchanged', async () => {

--- a/tests/unit/cli-show.test.ts
+++ b/tests/unit/cli-show.test.ts
@@ -179,3 +179,88 @@ describe('runShow --json', () => {
     expect(outBuf.join('')).toContain('Usage:')
   })
 })
+
+describe('runShow terminal: stdin section', () => {
+  let tmp: string
+  let outBuf: string[]
+  const origStdout = process.stdout.write.bind(process.stdout)
+  const origStderr = process.stderr.write.bind(process.stderr)
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-show-stdin-'))
+    outBuf = []
+    process.stdout.write = ((s: string) => {
+      outBuf.push(s)
+      return true
+    }) as typeof process.stdout.write
+    process.stderr.write = (() => true) as typeof process.stderr.write
+  })
+  afterEach(async () => {
+    process.stdout.write = origStdout
+    process.stderr.write = origStderr
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  test('non-null stdin: terminal output includes a stdin section', async () => {
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+      recordings: [
+        {
+          call: { command: 'curl', args: [], cwd: null, env: {}, stdin: 'hello world' },
+          result: {
+            stdoutLines: [],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 5,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'stdin.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const exit = await runShow([fixturePath, '--no-color'])
+    expect(exit).toBe(0)
+    const out = outBuf.join('')
+    expect(out).toContain('stdin (11 chars):')
+    expect(out).toContain('hello world')
+  })
+
+  test('null stdin: terminal output omits the stdin section entirely', async () => {
+    const cassette = {
+      version: 2,
+      _warning: '',
+      _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+      recordings: [
+        {
+          call: { command: 'echo', args: ['hi'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['hi'],
+            stderrLines: [],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 5,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    const fixturePath = path.join(tmp, 'stdin-null.json')
+    await writeFile(fixturePath, `${JSON.stringify(cassette, null, 2)}\n`)
+
+    const exit = await runShow([fixturePath, '--no-color'])
+    expect(exit).toBe(0)
+    const out = outBuf.join('')
+    // The stdin section header is `  stdin (<N> chars):`; assert that exact
+    // shape is absent. Substring 'stdin' alone would match 'stdout'.
+    expect(out).not.toMatch(/^\s+stdin\s*\(/m)
+  })
+})

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test, vi } from 'vitest'
 import { DEFAULT_CONFIG } from '../../src/config.js'
 import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
 import type { Call, Canonicalize } from '../../src/types.js'
+import {
+  SAMPLE_GITHUB_PAT_CLASSIC,
+  SAMPLE_STRIPE_SECRET_LIVE,
+} from '../helpers/credential-fixtures.js'
 import { callOf, recordingOf } from '../helpers/fixtures.js'
 
 describe('defaultCanonicalize', () => {
@@ -59,6 +63,45 @@ describe('defaultCanonicalize', () => {
     expect(defaultCanonicalize(c, DEFAULT_CONFIG.redact)).toEqual(
       defaultCanonicalize(c, DEFAULT_CONFIG.redact),
     )
+  })
+
+  test('raw stdin token round-trips against redacted placeholder', () => {
+    // Fresh-call canonical: raw token is matched and reduced to stripped form.
+    const fresh = defaultCanonicalize(
+      callOf('curl', [], { stdin: SAMPLE_GITHUB_PAT_CLASSIC }),
+      DEFAULT_CONFIG.redact,
+    )
+    // Cassette canonical: counter-tagged placeholder strips to the same form.
+    const recorded = defaultCanonicalize(
+      callOf('curl', [], { stdin: '<redacted:stdin:github-pat-classic:1>' }),
+      DEFAULT_CONFIG.redact,
+    )
+    expect(fresh.stdin).toBe(recorded.stdin)
+    expect(fresh.stdin).toBe('<redacted:stdin:github-pat-classic>')
+  })
+
+  test('counter-stripped equivalence: different counter values produce equal canonical', () => {
+    const a = defaultCanonicalize(
+      callOf('curl', [], { stdin: '<redacted:stdin:github-pat-classic:5>' }),
+      DEFAULT_CONFIG.redact,
+    )
+    const b = defaultCanonicalize(
+      callOf('curl', [], { stdin: '<redacted:stdin:github-pat-classic:99>' }),
+      DEFAULT_CONFIG.redact,
+    )
+    expect(a.stdin).toBe(b.stdin)
+  })
+
+  test('different rules do not collapse: stripe key and github PAT remain distinct', () => {
+    const stripe = defaultCanonicalize(
+      callOf('curl', [], { stdin: SAMPLE_STRIPE_SECRET_LIVE }),
+      DEFAULT_CONFIG.redact,
+    )
+    const githubPat = defaultCanonicalize(
+      callOf('curl', [], { stdin: SAMPLE_GITHUB_PAT_CLASSIC }),
+      DEFAULT_CONFIG.redact,
+    )
+    expect(stripe.stdin).not.toBe(githubPat.stdin)
   })
 })
 

--- a/tests/unit/redact-pipeline.test.ts
+++ b/tests/unit/redact-pipeline.test.ts
@@ -625,6 +625,42 @@ describe('seedCountersFromCassette', () => {
     expect(counters.get('allLines:r')).toBe(5)
   })
 
+  test('walks call.stdin when non-null', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          ...emptyRec(),
+          call: {
+            command: 'curl',
+            args: [],
+            cwd: null,
+            env: {},
+            stdin: 'token: <redacted:stdin:github-pat-classic:8>',
+          },
+        },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.get('stdin:github-pat-classic')).toBe(8)
+  })
+
+  test('null stdin does not contribute to seeded counters', () => {
+    const cassette: CassetteFile = {
+      version: 2,
+      recordedBy: null,
+      recordings: [
+        {
+          ...emptyRec(),
+          call: { command: 'curl', args: [], cwd: null, env: {}, stdin: null },
+        },
+      ],
+    }
+    const counters = seedCountersFromCassette(cassette)
+    expect(counters.size).toBe(0)
+  })
+
   test('multiple recordings: counts accumulate (sum) across recordings', () => {
     const cassette: CassetteFile = {
       version: 2,

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -49,4 +49,35 @@ describe('public redact() wraps pipeline', () => {
     expect(names).toContain('aws-access-key-id')
     expect(names).toContain('openai-api-key')
   })
+
+  test('source: "stdin" routes through the bundle pipeline', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const r = redact({ source: 'stdin', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
+      counted: false,
+    })
+    expect(r.output).toBe('<redacted:stdin:github-pat-classic>')
+  })
+
+  test('source: "stdin", counted: true — counter is per (stdin, rule)', () => {
+    const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
+    const counters = new Map<string, number>()
+    const r = redact({ source: 'stdin', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
+      counted: true,
+      counters,
+    })
+    expect(r.output).toBe('<redacted:stdin:github-pat-classic:1>')
+    expect(counters.get('stdin:github-pat-classic')).toBe(1)
+  })
+
+  test('source: "stdin" — custom regex rule fires', () => {
+    const config: RedactConfig = {
+      ...baseConfig,
+      customPatterns: [{ name: 'my-secret', pattern: /SECRET-[A-Z0-9]+/ }],
+    }
+    const r = redact({ source: 'stdin', value: 'wrap SECRET-ABC123 wrap' }, config, {
+      counted: false,
+    })
+    expect(r.output).toBe('wrap <redacted:stdin:my-secret> wrap')
+    expect(r.entries).toEqual([{ rule: 'my-secret', source: 'stdin', count: 1 }])
+  })
 })


### PR DESCRIPTION
## What Changed

The final PR of v0.6. Stacked on #111. Three logical chunks:

### Redaction extension (Task A)
- \`RedactSource\` union extends with \`'stdin'\`. \`RedactionEntry.source\` and \`SuppressedEntry.source\` pick it up automatically.
- \`recorder.redactCall\` runs the redact pipeline on \`Call.stdin\` when non-null. Bundled patterns plus user custom rules apply uniformly with args/stdout/stderr.
- Counter seeding (\`walkStringsForPlaceholders\`) walks \`call.stdin\` so auto-additive appends continue from the existing per-(source, rule) ceiling.
- \`REVIEW_WARNING\` drops \`stdin\` from the not-redacted list (the cassette-top banner is now accurate again).
- **\`defaultCanonicalize\` applies \`stripCounter\` + \`redact(counted: false)\` to stdin** (mirroring args's transform, minus tmp normalization). Without this, a cassette with a redacted stdin placeholder would not match a fresh call carrying the raw token, breaking replay for any user with a credential in their stdin. Same shape as the toLines fix in #110.

### CLI extension (Task B)
- \`cli-scan\` and \`cli-review\` pre-scan walk \`call.stdin\` (when non-null), produce \`Finding\` entries with \`source: 'stdin'\` and position label \`'0:<col>'\`.
- \`cli-review.readNextAction\` gates \`(r) replace\` for stdin findings the same way it does for args (both participate in canonicalize-then-match, replace would invalidate the recording).
- \`cli-review.applyReplace\` cascade gains a defensive \`'stdin'\` branch (parallel to env's, not normally reachable but kept for symmetry).
- \`cli-review.applyDecisions\` gains a stdin arm — without it, an \`(a) accept\` decision on a stdin finding silently no-ops because the decision-application loop iterates env/args/stdout/stderr/allLines and would skip stdin. **Spec gap fix.**
- \`cli-re-redact\` re-redact loop reapplies current rules to \`call.stdin\` (mirrors the args block; skips on null).
- \`cli-show\` adds a \`stdin (N chars):\` section in the human-display output (only when non-null).

### Documentation (Task C)
- README rewrites the \"Subprocess stdin. Not captured.\" residual-risk bullet (now captured and redacted); updates the canonicalize example comment; adds a new \"What's in the match-tuple\" section with a 5-row table covering command/args/stdin (matched) vs cwd/env (recorded but not matched), plus a paragraph documenting the \`node: true\` ↔ \`execaNode\` shared-canonical-form relationship.
- \`docs/troubleshooting.md\` parallel stdin bullet rewrite (deliberately distinct phrasing from README — spells out source surfaces and placeholder format).
- \`docs/execa.md\` updates: \`lines: true\` row also describes object form; \`inputFile\` row marked supported (UTF-8 only; \`BinaryInputError\`); \`input: 'string'\` marked supported; \`node: true\` marked supported; new \`execaNode\` row.
- \`docs/tinyexec.md\`: \`stdin\` row updated to mention cassette storage AND match-tuple inclusion.
- New \`## [0.6.0]\` CHANGELOG entry under \`## [Unreleased]\`. Sections: Added (8), Changed (3), Notes (2).

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` (717 passed, 1 skipped)
- [x] \`npm run build\`

New test files: \`tests/security/redact-stdin.test.ts\`. Extended: \`tests/unit/redact.test.ts\`, \`tests/unit/redact-pipeline.test.ts\`, \`tests/unit/matcher.test.ts\`, \`tests/cli/scan.test.ts\`, \`tests/unit/cli-review.test.ts\`, \`tests/cli/re-redact.test.ts\`, \`tests/unit/cli-show.test.ts\`. +32 tests total.

The \`tests/security/redact-stdin.test.ts:replay matches when cassette has redacted stdin and fresh call has raw token\` test is the end-to-end proof for the canonicalize fix: record a call with a real PAT in stdin, replay-strict the same call with the same raw token, no \`ReplayMissError\`.

## Notes

- Cassette schema stays at version 2; v0.5 cassettes load with \`stdin: null\` and continue to match calls without an input option. Zero internal fixtures needed re-recording.
- The \`applyReplace\` cascade pattern remains fragile (no \`never\`-exhaustive guarantee that all \`RedactSource\` members are handled). Tracked as #101 for a future switch-with-\`never\` conversion; out of scope here.
- Once #104, #107, #110, #111 land, this PR auto-retargets to main.

Closes the v0.6 missing-surface design.