### PR TITLE
test: bump timeout on flaky record-replay-node hint tests

### DIFF
--- a/tests/integration/record-replay-node.test.ts
+++ b/tests/integration/record-replay-node.test.ts
@@ -88,6 +88,10 @@ describe('record + replay with node: true and execaNode', () => {
     }
   })
 
+  // Both ReplayMissError node-flag-hint tests spawn a real `node` subprocess
+  // for the record cycle. Under full-suite load with concurrent fs writes,
+  // the default 5s vitest timeout occasionally trips. 10s leaves plenty of
+  // headroom without masking a real perf regression. See #116.
   test('ReplayMissError appends node-flag hint when call passed node:true', async () => {
     const cp = path.join(tmp.ref(), 'miss.json')
     const script = path.join(tmp.ref(), 'miss.mjs')
@@ -116,7 +120,7 @@ describe('record + replay with node: true and execaNode', () => {
     } finally {
       process.env.SHELL_CASSETTE_MODE = 'auto'
     }
-  })
+  }, 10000)
 
   test('ReplayMissError omits node-flag hint when call did NOT pass node:true', async () => {
     const cp = path.join(tmp.ref(), 'no-hint.json')
@@ -148,5 +152,5 @@ describe('record + replay with node: true and execaNode', () => {
     } finally {
       process.env.SHELL_CASSETTE_MODE = 'auto'
     }
-  })
+  }, 10000)
 })


### PR DESCRIPTION
## What Changed

Stacked on #115. Bumps the vitest timeout on two real-subprocess tests in \`tests/integration/record-replay-node.test.ts\` from the default 5s to 10s:

- \`ReplayMissError appends node-flag hint when call passed node:true\`
- \`ReplayMissError omits node-flag hint when call did NOT pass node:true\`

Adds a brief comment above the first test explaining the WHY (real-subprocess + concurrent-fs-writes contention under full-suite load) so a future maintainer doesn't blindly cut the budget back.

## Why

The flake on the second test was reproduced about 1 in 10 full-suite runs across the v0.6 PR review series. It always passes when run in isolation. The first test has the same shape; bumping both prevents future symmetric flakes.

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` (717 passed, 1 skipped — count unchanged)
- [x] \`npm run build\`

## Notes

- This is a defensive fix; no test logic or assertions changed. If the timeout ever needs to come back down, the underlying contention should be investigated first.
- Once #115 lands, this PR auto-retargets to main.

Closes #116.

(Replaces #117, which got into a stuck-closed state during a force-push amend.)