### PR TITLE
chore: extract wrapFsError helper + drop phantom backlog references

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -4,6 +4,16 @@ import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { BinaryInputError, CassetteIOError } from './errors.js'
 
+/**
+ * Wraps a native fs error in CassetteIOError preserving cause. The action is
+ * a complete phrase including the verb, noun, and preposition (e.g.
+ * 'write cassette to' or 'read inputFile from'); it slots in directly between
+ * 'failed to' and the target path.
+ */
+function wrapFsError(action: string, target: string | URL, err: NodeJS.ErrnoException): never {
+  throw new CassetteIOError(`failed to ${action} ${String(target)}: ${err.message}`, err)
+}
+
 export async function writeCassetteFile(target: string, content: string): Promise<void> {
   const dir = path.dirname(target)
   await mkdir(dir, { recursive: true })
@@ -19,10 +29,7 @@ export async function writeCassetteFile(target: string, content: string): Promis
     } catch {
       // ignore
     }
-    throw new CassetteIOError(
-      `failed to write cassette to ${target}: ${(e as Error).message}`,
-      e as Error,
-    )
+    wrapFsError('write cassette to', target, e as NodeJS.ErrnoException)
   }
 }
 
@@ -32,7 +39,7 @@ export async function readCassetteFile(target: string): Promise<string | null> {
   } catch (e) {
     const err = e as NodeJS.ErrnoException
     if (err.code === 'ENOENT') return null
-    throw new CassetteIOError(`failed to read cassette from ${target}: ${err.message}`, err)
+    wrapFsError('read cassette from', target, err)
   }
 }
 
@@ -50,11 +57,7 @@ export async function readInputFile(target: string | URL): Promise<string> {
   try {
     buf = await readFile(target)
   } catch (e) {
-    const err = e as NodeJS.ErrnoException
-    throw new CassetteIOError(
-      `failed to read inputFile from ${String(target)}: ${err.message}`,
-      err,
-    )
+    wrapFsError('read inputFile from', target, e as NodeJS.ErrnoException)
   }
   if (!isUtf8(buf)) {
     throw new BinaryInputError(

--- a/src/options-execa.ts
+++ b/src/options-execa.ts
@@ -4,12 +4,10 @@ export function validateOptions(options: Record<string, unknown> | undefined): v
   if (!options) return
 
   if (options.buffer === false) {
-    throw new UnsupportedOptionError(
-      'execa option `buffer: false` (streaming) not supported. Tracked in backlog.',
-    )
+    throw new UnsupportedOptionError('execa option `buffer: false` (streaming) not supported.')
   }
   if (options.ipc === true) {
-    throw new UnsupportedOptionError('execa option `ipc: true` not supported. Tracked in backlog.')
+    throw new UnsupportedOptionError('execa option `ipc: true` not supported.')
   }
   // `input` accepts strings only. Uint8Array and Readable are rejected because
   // shell-cassette stores stdin as UTF-8 in the cassette; binary or streaming
@@ -18,7 +16,7 @@ export function validateOptions(options: Record<string, unknown> | undefined): v
   if (options.input !== undefined && options.input !== null && typeof options.input !== 'string') {
     throw new UnsupportedOptionError(
       'execa option `input` as Uint8Array or Readable not supported. ' +
-        'shell-cassette currently accepts `input: string` only. Tracked in backlog.',
+        'shell-cassette currently accepts `input: string` only.',
     )
   }
   // `input` and `inputFile` together is ambiguous: execa would silently prefer

--- a/src/options-tinyexec.ts
+++ b/src/options-tinyexec.ts
@@ -5,13 +5,13 @@ export function validateOptions(options: Record<string, unknown> | undefined): v
 
   if (options.persist === true) {
     throw new UnsupportedOptionError(
-      'tinyexec option `persist: true` not supported. Subprocesses outliving the host process cannot be replayed. Tracked in backlog.',
+      'tinyexec option `persist: true` not supported. Subprocesses outliving the host process cannot be replayed.',
     )
   }
 
   if (options.stdin !== undefined && options.stdin !== null && typeof options.stdin !== 'string') {
     throw new UnsupportedOptionError(
-      'tinyexec option `stdin` as Result (pipe chaining) not supported. Pass a string for buffered stdin. Tracked in backlog.',
+      'tinyexec option `stdin` as Result (pipe chaining) not supported. Pass a string for buffered stdin.',
     )
   }
 }

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -101,7 +101,7 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
     killed,
     pipe: () => {
       throw new UnsupportedOptionError(
-        'tinyexec result.pipe() not supported on replay (no live subprocess). Tracked in backlog.',
+        'tinyexec result.pipe() not supported on replay (no live subprocess).',
       )
     },
     kill: () => {
@@ -109,7 +109,7 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
     },
     [Symbol.asyncIterator]: () => {
       throw new UnsupportedOptionError(
-        'tinyexec async iteration `for await (line of result)` not supported on replay. Tracked in backlog.',
+        'tinyexec async iteration `for await (line of result)` not supported on replay.',
       )
     },
   }

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -75,7 +75,7 @@ function captureResult(raw: unknown, durationMs: number): CassetteResult {
   //
   // tinyexec exposes only `killed: boolean`, not the actual signal name (SIGINT,
   // SIGKILL, etc.). We unconditionally record SIGTERM on kill; the real signal is
-  // lost. Tracked in backlog: "preserve exact signal for tinyexec recording".
+  // lost. Known limitation; tinyexec does not expose the signal name.
   return {
     stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
     stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],

--- a/tests/error-path/tinyexec-errors.test.ts
+++ b/tests/error-path/tinyexec-errors.test.ts
@@ -42,13 +42,12 @@ describe('tinyexec error paths', () => {
     }
   })
 
-  test('UnsupportedOptionError message contains option name and backlog reference', async () => {
+  test('UnsupportedOptionError message contains the option name', async () => {
     try {
       await x('echo', [], { persist: true })
       throw new Error('should have thrown')
     } catch (e) {
       expect((e as Error).message).toContain('persist')
-      expect((e as Error).message).toContain('backlog')
     }
   })
 

--- a/tests/unit/options-execa.test.ts
+++ b/tests/unit/options-execa.test.ts
@@ -51,12 +51,11 @@ describe('validateOptions', () => {
     expect(() => validateOptions({ node: true })).not.toThrow()
   })
 
-  test('error message includes the option name and backlog reference', () => {
+  test('error message includes the option name', () => {
     try {
       validateOptions({ ipc: true })
     } catch (e) {
       expect((e as Error).message).toContain('ipc')
-      expect((e as Error).message).toContain('Tracked in backlog')
     }
   })
 

--- a/tests/unit/options-tinyexec.test.ts
+++ b/tests/unit/options-tinyexec.test.ts
@@ -15,14 +15,13 @@ describe('validateOptions (tinyexec)', () => {
     expect(() => validateOptions({ persist: true })).toThrow(UnsupportedOptionError)
   })
 
-  test('error message for persist:true mentions persist and backlog', () => {
+  test('error message for persist:true mentions persist', () => {
     try {
       validateOptions({ persist: true })
       throw new Error('should have thrown')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
       expect((e as Error).message).toContain('persist')
-      expect((e as Error).message).toContain('backlog')
     }
   })
 


### PR DESCRIPTION
Combined cleanup PR for #105 and #109. (Replaces #114, which got into a stuck-closed state during a force-push reopen.)

## #105 — \`wrapFsError\` helper extraction in \`src/io.ts\`

Three callsites (\`writeCassetteFile\`, \`readCassetteFile\`, \`readInputFile\`) had the same try-catch-wrap pattern. Extracted to a private \`wrapFsError(action, target, err): never\` helper. Each callsite passes the full action phrase (\`'write cassette to'\`, \`'read cassette from'\`, \`'read inputFile from'\`) so the formatted error messages stay byte-identical. The \`: never\` return type lets the catch block satisfy definite assignment for \`let buf: Buffer\` in \`readInputFile\` without a non-null assertion.

## #109 — drop phantom "Tracked in backlog" references

Audited every \`UnsupportedOptionError\` message across \`src/options-execa.ts\`, \`src/options-tinyexec.ts\`, and the runtime stubs in \`src/tinyexec.ts\`. The phrase \"Tracked in backlog\" appeared at 7 sites. \`gh issue list\` audit found no real tracking issue exists for any. Per \`tone-and-voice.md\` typewriter test, dropped the phrase at all 7 sites:

- \`options-execa.ts\`: \`buffer: false\`, \`ipc: true\`, non-string \`input\` rejections
- \`options-tinyexec.ts\`: \`persist: true\`, non-string \`stdin\` rejections
- \`tinyexec.ts\`: \`result.pipe()\` and async iterator runtime stubs on replay

Also rephrased the inline comment at \`tinyexec.ts:78\` (signal-name fidelity gap) from \"Tracked in backlog: ...\" to \"Known limitation; ...\" for consistency. Test assertions on \`'backlog'\` substrings dropped from 3 test files; instanceof / option-name / \"should not reach\" guards retained.

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` (count unchanged from baseline)
- [x] \`npm run build\`

Closes #105.
Closes #109.