### PR TITLE
test: assert ShellCassetteError inheritance on every error-path

### DIFF
--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { loadConfigFromDir } from '../../src/config.js'
-import { CassetteConfigError } from '../../src/errors.js'
+import { CassetteConfigError, ShellCassetteError } from '../../src/errors.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 describe('loadConfigFromDir', () => {
@@ -37,6 +37,7 @@ describe('loadConfigFromDir', () => {
       'export default { syntax error here',
     )
     await expect(loadConfigFromDir(tmpDir.ref())).rejects.toThrow(CassetteConfigError)
+    await expect(loadConfigFromDir(tmpDir.ref())).rejects.toThrow(ShellCassetteError)
   })
 
   test('throws CassetteConfigError on invalid config shape', async () => {
@@ -45,6 +46,7 @@ describe('loadConfigFromDir', () => {
       'export default { cassetteDir: 42 }',
     )
     await expect(loadConfigFromDir(tmpDir.ref())).rejects.toThrow(CassetteConfigError)
+    await expect(loadConfigFromDir(tmpDir.ref())).rejects.toThrow(ShellCassetteError)
   })
 
   test('walks up parent directories looking for config', async () => {

--- a/tests/error-path/binary-input-error.test.ts
+++ b/tests/error-path/binary-input-error.test.ts
@@ -57,6 +57,7 @@ describe('BinaryInputError on inputFile', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(BinaryInputError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       expect((e as Error).message).toContain(fixture)
     } finally {
       process.env.SHELL_CASSETTE_MODE = 'auto'

--- a/tests/error-path/canonicalize-limits.test.ts
+++ b/tests/error-path/canonicalize-limits.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
-import { ReplayMissError } from '../../src/errors.js'
+import { ReplayMissError, ShellCassetteError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { writeCassetteFile } from '../../src/io.js'
 import { serialize } from '../../src/serialize.js'
@@ -54,6 +54,7 @@ describe('canonicalize limitations - documented current behavior', () => {
       await execa('node', ['-e', '../../tmp/foo'])
     })
     await expect(result).rejects.toBeInstanceOf(ReplayMissError)
+    await expect(result).rejects.toBeInstanceOf(ShellCassetteError)
     // Error message includes 'canonical' so users see what was compared.
     await expect(result).rejects.toThrow(/canonical/)
   })
@@ -71,5 +72,6 @@ describe('canonicalize limitations - documented current behavior', () => {
       await execa('node', ['-e', '/scratch/REPLAY/foo'])
     })
     await expect(result).rejects.toBeInstanceOf(ReplayMissError)
+    await expect(result).rejects.toBeInstanceOf(ShellCassetteError)
   })
 })

--- a/tests/error-path/error-classes.test.ts
+++ b/tests/error-path/error-classes.test.ts
@@ -56,6 +56,7 @@ describe('all error classes are instanceof ShellCassetteError', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
     }
   })
 
@@ -76,6 +77,7 @@ describe('all error classes are instanceof ShellCassetteError', () => {
         throw new Error('should not reach')
       } catch (e) {
         expect(e).toBeInstanceOf(ReplayMissError)
+        expect(e).toBeInstanceOf(ShellCassetteError)
       }
     } finally {
       delete process.env.SHELL_CASSETTE_MODE
@@ -84,7 +86,7 @@ describe('all error classes are instanceof ShellCassetteError', () => {
   })
 
   test('ConcurrencyError', () => {
-    expect(() =>
+    const trigger = () =>
       deriveCassettePathFromTask(
         {
           name: 'x',
@@ -92,12 +94,14 @@ describe('all error classes are instanceof ShellCassetteError', () => {
           concurrent: true,
         } as never,
         '__cassettes__',
-      ),
-    ).toThrow(ConcurrencyError)
+      )
+    expect(trigger).toThrow(ConcurrencyError)
+    expect(trigger).toThrow(ShellCassetteError)
   })
 
   test('CassetteCorruptError', () => {
     expect(() => deserialize('{ bad json')).toThrow(CassetteCorruptError)
+    expect(() => deserialize('{ bad json')).toThrow(ShellCassetteError)
   })
 
   test('CassetteCollisionError', async () => {
@@ -118,6 +122,7 @@ describe('all error classes are instanceof ShellCassetteError', () => {
           /* swallow */
         })
         expect(e).toBeInstanceOf(CassetteCollisionError)
+        expect(e).toBeInstanceOf(ShellCassetteError)
       }
     } finally {
       await rm(tmp, { recursive: true, force: true })
@@ -127,6 +132,7 @@ describe('all error classes are instanceof ShellCassetteError', () => {
   test('CassetteIOError on long path', () => {
     const longPath = `/repo/${'a'.repeat(300)}/test.ts`
     expect(() => cassettePath(longPath, [], 'test', '__cassettes__')).toThrow(CassetteIOError)
+    expect(() => cassettePath(longPath, [], 'test', '__cassettes__')).toThrow(ShellCassetteError)
   })
 
   test('CassetteNotFoundError carries the missing path', () => {

--- a/tests/error-path/input-file-conflict.test.ts
+++ b/tests/error-path/input-file-conflict.test.ts
@@ -37,6 +37,7 @@ describe('input + inputFile conflict (validator)', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
     }
   })
 
@@ -47,6 +48,7 @@ describe('input + inputFile conflict (validator)', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
     }
   })
 

--- a/tests/error-path/tinyexec-errors.test.ts
+++ b/tests/error-path/tinyexec-errors.test.ts
@@ -56,6 +56,7 @@ describe('tinyexec error paths', () => {
     delete process.env.SHELL_CASSETTE_ACK_REDACTION
 
     await expect(x('echo', ['hi'])).rejects.toBeInstanceOf(AckRequiredError)
+    await expect(x('echo', ['hi'])).rejects.toBeInstanceOf(ShellCassetteError)
     expect(realXMock).not.toHaveBeenCalled()
   })
 
@@ -64,6 +65,7 @@ describe('tinyexec error paths', () => {
     process.env.SHELL_CASSETTE_MODE = 'replay'
 
     await expect(x('echo', ['unrecorded'])).rejects.toBeInstanceOf(ReplayMissError)
+    await expect(x('echo', ['unrecorded'])).rejects.toBeInstanceOf(ShellCassetteError)
   })
 
   test('ReplayMissError message includes the call signature', async () => {
@@ -75,6 +77,7 @@ describe('tinyexec error paths', () => {
       throw new Error('should have thrown')
     } catch (e) {
       expect(e).toBeInstanceOf(ReplayMissError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       expect((e as Error).message).toContain('git status --porcelain')
       expect((e as Error).message).toContain('To re-record')
     }

--- a/tests/error-path/tinyexec-errors.test.ts
+++ b/tests/error-path/tinyexec-errors.test.ts
@@ -55,8 +55,9 @@ describe('tinyexec error paths', () => {
     setActiveCassette(makeSession({ loadedFile: null }))
     delete process.env.SHELL_CASSETTE_ACK_REDACTION
 
-    await expect(x('echo', ['hi'])).rejects.toBeInstanceOf(AckRequiredError)
-    await expect(x('echo', ['hi'])).rejects.toBeInstanceOf(ShellCassetteError)
+    const result = x('echo', ['hi'])
+    await expect(result).rejects.toBeInstanceOf(AckRequiredError)
+    await expect(result).rejects.toBeInstanceOf(ShellCassetteError)
     expect(realXMock).not.toHaveBeenCalled()
   })
 
@@ -64,8 +65,9 @@ describe('tinyexec error paths', () => {
     setActiveCassette(makeSession({ loadedFile: { version: 1, recordedBy: null, recordings: [] } }))
     process.env.SHELL_CASSETTE_MODE = 'replay'
 
-    await expect(x('echo', ['unrecorded'])).rejects.toBeInstanceOf(ReplayMissError)
-    await expect(x('echo', ['unrecorded'])).rejects.toBeInstanceOf(ShellCassetteError)
+    const result = x('echo', ['unrecorded'])
+    await expect(result).rejects.toBeInstanceOf(ReplayMissError)
+    await expect(result).rejects.toBeInstanceOf(ShellCassetteError)
   })
 
   test('ReplayMissError message includes the call signature', async () => {

--- a/tests/integration/atomic-write.test.ts
+++ b/tests/integration/atomic-write.test.ts
@@ -106,6 +106,7 @@ describe('readInputFile', () => {
       caught = e
     }
     expect(caught).toBeInstanceOf(CassetteIOError)
+    expect(caught).toBeInstanceOf(ShellCassetteError)
     expect((caught as Error).message).toContain(target)
     const cause = (caught as { cause: NodeJS.ErrnoException }).cause
     expect(cause).toBeDefined()

--- a/tests/integration/loader.test.ts
+++ b/tests/integration/loader.test.ts
@@ -1,7 +1,7 @@
 import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { CassetteCorruptError } from '../../src/errors.js'
+import { CassetteCorruptError, ShellCassetteError } from '../../src/errors.js'
 import { loadCassette } from '../../src/loader.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
@@ -26,11 +26,13 @@ describe('loadCassette', () => {
     const target = path.join(tmpDir.ref(), 'bad.json')
     await writeFile(target, '{ not json', 'utf8')
     await expect(loadCassette(target)).rejects.toThrow(CassetteCorruptError)
+    await expect(loadCassette(target)).rejects.toThrow(ShellCassetteError)
   })
 
   test('throws CassetteCorruptError on unknown version', async () => {
     const target = path.join(tmpDir.ref(), 'unknown.json')
     await writeFile(target, JSON.stringify({ version: 99 }), 'utf8')
     await expect(loadCassette(target)).rejects.toThrow(CassetteCorruptError)
+    await expect(loadCassette(target)).rejects.toThrow(ShellCassetteError)
   })
 })

--- a/tests/integration/loader.test.ts
+++ b/tests/integration/loader.test.ts
@@ -25,14 +25,16 @@ describe('loadCassette', () => {
   test('throws CassetteCorruptError on bad JSON', async () => {
     const target = path.join(tmpDir.ref(), 'bad.json')
     await writeFile(target, '{ not json', 'utf8')
-    await expect(loadCassette(target)).rejects.toThrow(CassetteCorruptError)
-    await expect(loadCassette(target)).rejects.toThrow(ShellCassetteError)
+    const result = loadCassette(target)
+    await expect(result).rejects.toThrow(CassetteCorruptError)
+    await expect(result).rejects.toThrow(ShellCassetteError)
   })
 
   test('throws CassetteCorruptError on unknown version', async () => {
     const target = path.join(tmpDir.ref(), 'unknown.json')
     await writeFile(target, JSON.stringify({ version: 99 }), 'utf8')
-    await expect(loadCassette(target)).rejects.toThrow(CassetteCorruptError)
-    await expect(loadCassette(target)).rejects.toThrow(ShellCassetteError)
+    const result = loadCassette(target)
+    await expect(result).rejects.toThrow(CassetteCorruptError)
+    await expect(result).rejects.toThrow(ShellCassetteError)
   })
 })

--- a/tests/integration/record-replay-input-file.test.ts
+++ b/tests/integration/record-replay-input-file.test.ts
@@ -1,7 +1,7 @@
 import { readFile, unlink, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { CassetteIOError, ReplayMissError } from '../../src/errors.js'
+import { CassetteIOError, ReplayMissError, ShellCassetteError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
@@ -54,6 +54,7 @@ describe('e2e record + replay with inputFile', () => {
           throw new Error('should not reach')
         } catch (e) {
           expect(e).toBeInstanceOf(ReplayMissError)
+          expect(e).toBeInstanceOf(ShellCassetteError)
         }
       })
     } finally {
@@ -81,6 +82,7 @@ describe('e2e record + replay with inputFile', () => {
           throw new Error('should not reach')
         } catch (e) {
           expect(e).toBeInstanceOf(CassetteIOError)
+          expect(e).toBeInstanceOf(ShellCassetteError)
           expect((e as Error).message).toContain(fixture)
         }
       })

--- a/tests/integration/record-replay-node.test.ts
+++ b/tests/integration/record-replay-node.test.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { ReplayMissError } from '../../src/errors.js'
+import { ReplayMissError, ShellCassetteError } from '../../src/errors.js'
 import { execa, execaNode } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
@@ -107,6 +107,7 @@ describe('record + replay with node: true and execaNode', () => {
           throw new Error('should not reach')
         } catch (e) {
           expect(e).toBeInstanceOf(ReplayMissError)
+          expect(e).toBeInstanceOf(ShellCassetteError)
           const msg = (e as Error).message
           expect(msg).toContain('canonical forms ignore the `node` flag')
           expect(msg).toContain('execaNode(f)')
@@ -139,6 +140,7 @@ describe('record + replay with node: true and execaNode', () => {
           throw new Error('should not reach')
         } catch (e) {
           expect(e).toBeInstanceOf(ReplayMissError)
+          expect(e).toBeInstanceOf(ShellCassetteError)
           const msg = (e as Error).message
           expect(msg).not.toContain('canonical forms ignore the `node` flag')
         }

--- a/tests/integration/record-replay-stdin.test.ts
+++ b/tests/integration/record-replay-stdin.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { ReplayMissError } from '../../src/errors.js'
+import { ReplayMissError, ShellCassetteError } from '../../src/errors.js'
 import { execa } from '../../src/execa.js'
 import { x } from '../../src/tinyexec.js'
 import { useCassette } from '../../src/use-cassette.js'
@@ -53,6 +53,7 @@ describe('e2e record + replay with input: string', () => {
           throw new Error('should not reach')
         } catch (e) {
           expect(e).toBeInstanceOf(ReplayMissError)
+          expect(e).toBeInstanceOf(ShellCassetteError)
         }
       })
     } finally {
@@ -100,6 +101,7 @@ describe('tinyexec stdin', () => {
           throw new Error('should not reach')
         } catch (e) {
           expect(e).toBeInstanceOf(ReplayMissError)
+          expect(e).toBeInstanceOf(ShellCassetteError)
         }
       })
     } finally {

--- a/tests/security/ack-gate.test.ts
+++ b/tests/security/ack-gate.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { requireAckGate } from '../../src/ack.js'
-import { AckRequiredError } from '../../src/errors.js'
+import { AckRequiredError, ShellCassetteError } from '../../src/errors.js'
 
 const originalEnv = process.env.SHELL_CASSETTE_ACK_REDACTION
 
@@ -19,16 +19,19 @@ afterEach(() => {
 describe('requireAckGate', () => {
   test('throws AckRequiredError when env var unset', () => {
     expect(() => requireAckGate()).toThrow(AckRequiredError)
+    expect(() => requireAckGate()).toThrow(ShellCassetteError)
   })
 
   test('throws when env var is empty string', () => {
     process.env.SHELL_CASSETTE_ACK_REDACTION = ''
     expect(() => requireAckGate()).toThrow(AckRequiredError)
+    expect(() => requireAckGate()).toThrow(ShellCassetteError)
   })
 
   test('throws when env var is "false"', () => {
     process.env.SHELL_CASSETTE_ACK_REDACTION = 'false'
     expect(() => requireAckGate()).toThrow(AckRequiredError)
+    expect(() => requireAckGate()).toThrow(ShellCassetteError)
   })
 
   test('passes when env var is "true"', () => {
@@ -107,5 +110,6 @@ describe('requireAckGate', () => {
     expect(() => requireAckGate()).not.toThrow()
     delete process.env.SHELL_CASSETTE_ACK_REDACTION
     expect(() => requireAckGate()).toThrow(AckRequiredError)
+    expect(() => requireAckGate()).toThrow(ShellCassetteError)
   })
 })

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { DEFAULT_CONFIG, mergeWithDefaults, validateConfig } from '../../src/config.js'
-import { CassetteConfigError } from '../../src/errors.js'
+import { CassetteConfigError, ShellCassetteError } from '../../src/errors.js'
 
 describe('DEFAULT_CONFIG', () => {
   test('has cassetteDir = __cassettes__', () => {
@@ -46,16 +46,21 @@ describe('validateConfig', () => {
 
   test('throws CassetteConfigError on non-object', () => {
     expect(() => validateConfig(null)).toThrow(CassetteConfigError)
+    expect(() => validateConfig(null)).toThrow(ShellCassetteError)
     expect(() => validateConfig('string')).toThrow(CassetteConfigError)
+    expect(() => validateConfig('string')).toThrow(ShellCassetteError)
     expect(() => validateConfig(42)).toThrow(CassetteConfigError)
+    expect(() => validateConfig(42)).toThrow(ShellCassetteError)
   })
 
   test('throws if cassetteDir is not string', () => {
     expect(() => validateConfig({ cassetteDir: 42 })).toThrow(CassetteConfigError)
+    expect(() => validateConfig({ cassetteDir: 42 })).toThrow(ShellCassetteError)
   })
 
   test('throws if canonicalize is not function', () => {
     expect(() => validateConfig({ canonicalize: 'foo' })).toThrow(CassetteConfigError)
+    expect(() => validateConfig({ canonicalize: 'foo' })).toThrow(ShellCassetteError)
   })
 })
 
@@ -192,11 +197,12 @@ describe('validateConfig: redact field', () => {
   })
 
   test('rejects custom rule with empty name', () => {
-    expect(() =>
+    const trigger = () =>
       validateConfig({
         redact: { customPatterns: [{ name: '', pattern: /A/ }] },
-      }),
-    ).toThrow(CassetteConfigError)
+      })
+    expect(trigger).toThrow(CassetteConfigError)
+    expect(trigger).toThrow(ShellCassetteError)
   })
 
   test('rejects duplicate custom rule names', () => {

--- a/tests/unit/options-execa.test.ts
+++ b/tests/unit/options-execa.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { UnsupportedOptionError } from '../../src/errors.js'
+import { ShellCassetteError, UnsupportedOptionError } from '../../src/errors.js'
 import { validateOptions } from '../../src/options-execa.js'
 
 describe('validateOptions', () => {
@@ -17,11 +17,13 @@ describe('validateOptions', () => {
 
   test('throws on buffer:false', () => {
     expect(() => validateOptions({ buffer: false })).toThrow(UnsupportedOptionError)
+    expect(() => validateOptions({ buffer: false })).toThrow(ShellCassetteError)
     expect(() => validateOptions({ buffer: false })).toThrow(/buffer/)
   })
 
   test('throws on ipc:true', () => {
     expect(() => validateOptions({ ipc: true })).toThrow(UnsupportedOptionError)
+    expect(() => validateOptions({ ipc: true })).toThrow(ShellCassetteError)
   })
 
   test('accepts inputFile as a string path', () => {
@@ -37,6 +39,7 @@ describe('validateOptions', () => {
     expect(() => validateOptions({ input: new Uint8Array([1, 2, 3]) })).toThrow(
       UnsupportedOptionError,
     )
+    expect(() => validateOptions({ input: new Uint8Array([1, 2, 3]) })).toThrow(ShellCassetteError)
     expect(() => validateOptions({ input: new Uint8Array([1, 2, 3]) })).toThrow(/input/)
   })
 
@@ -45,6 +48,7 @@ describe('validateOptions', () => {
     // (object, number, boolean, ...) hits the same path. A bare object stands in
     // for a Readable here without pulling node:stream into the test.
     expect(() => validateOptions({ input: { read: () => null } })).toThrow(UnsupportedOptionError)
+    expect(() => validateOptions({ input: { read: () => null } })).toThrow(ShellCassetteError)
   })
 
   test('accepts node:true (execaNode is supported)', () => {
@@ -65,6 +69,7 @@ describe('validateOptions', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       expect((e as Error).message).not.toMatch(/v0\.\d/)
     }
   })
@@ -78,6 +83,9 @@ describe('validateOptions', () => {
       expect(() => validateOptions({ input: 'foo', inputFile: '/tmp/x' })).toThrow(
         UnsupportedOptionError,
       )
+      expect(() => validateOptions({ input: 'foo', inputFile: '/tmp/x' })).toThrow(
+        ShellCassetteError,
+      )
       expect(() => validateOptions({ input: 'foo', inputFile: '/tmp/x' })).toThrow(/inputFile/)
     })
 
@@ -85,11 +93,15 @@ describe('validateOptions', () => {
       expect(() => validateOptions({ input: '', inputFile: '/tmp/x' })).toThrow(
         UnsupportedOptionError,
       )
+      expect(() => validateOptions({ input: '', inputFile: '/tmp/x' })).toThrow(ShellCassetteError)
     })
 
     test('input: null with inputFile rejects (null is still defined)', () => {
       expect(() => validateOptions({ input: null, inputFile: '/tmp/x' })).toThrow(
         UnsupportedOptionError,
+      )
+      expect(() => validateOptions({ input: null, inputFile: '/tmp/x' })).toThrow(
+        ShellCassetteError,
       )
     })
   })

--- a/tests/unit/options-tinyexec.test.ts
+++ b/tests/unit/options-tinyexec.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { UnsupportedOptionError } from '../../src/errors.js'
+import { ShellCassetteError, UnsupportedOptionError } from '../../src/errors.js'
 import { validateOptions } from '../../src/options-tinyexec.js'
 
 describe('validateOptions (tinyexec)', () => {
@@ -13,6 +13,7 @@ describe('validateOptions (tinyexec)', () => {
 
   test('throws UnsupportedOptionError for persist:true', () => {
     expect(() => validateOptions({ persist: true })).toThrow(UnsupportedOptionError)
+    expect(() => validateOptions({ persist: true })).toThrow(ShellCassetteError)
   })
 
   test('error message for persist:true mentions persist', () => {
@@ -21,6 +22,7 @@ describe('validateOptions (tinyexec)', () => {
       throw new Error('should have thrown')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       expect((e as Error).message).toContain('persist')
     }
   })
@@ -32,6 +34,7 @@ describe('validateOptions (tinyexec)', () => {
   test('throws UnsupportedOptionError for stdin as object (Result piping)', () => {
     const fakeResult = { stdout: 'foo', stderr: '', exitCode: 0 }
     expect(() => validateOptions({ stdin: fakeResult })).toThrow(UnsupportedOptionError)
+    expect(() => validateOptions({ stdin: fakeResult })).toThrow(ShellCassetteError)
   })
 
   test('error message for stdin-as-object mentions stdin and string', () => {
@@ -40,6 +43,7 @@ describe('validateOptions (tinyexec)', () => {
       throw new Error('should have thrown')
     } catch (e) {
       expect(e).toBeInstanceOf(UnsupportedOptionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       expect((e as Error).message).toContain('stdin')
       expect((e as Error).message).toContain('string')
     }

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { CassetteIOError } from '../../src/errors.js'
+import { CassetteIOError, ShellCassetteError } from '../../src/errors.js'
 import { cassettePath, sanitizeName } from '../../src/paths.js'
 
 describe('sanitizeName', () => {
@@ -73,5 +73,8 @@ describe('cassettePath', () => {
   test('throws CassetteIOError if total path > 240 chars (Windows safe)', () => {
     const longTestPath = `/repo/${'a'.repeat(300)}/foo.test.ts`
     expect(() => cassettePath(longTestPath, [], 'test', '__cassettes__')).toThrow(CassetteIOError)
+    expect(() => cassettePath(longTestPath, [], 'test', '__cassettes__')).toThrow(
+      ShellCassetteError,
+    )
   })
 })

--- a/tests/unit/serialize-v2.test.ts
+++ b/tests/unit/serialize-v2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { CassetteCorruptError } from '../../src/errors.js'
+import { CassetteCorruptError, ShellCassetteError } from '../../src/errors.js'
 import { deserialize, serialize } from '../../src/serialize.js'
 import type { CassetteFile } from '../../src/types.js'
 
@@ -168,25 +168,30 @@ describe('deserialize: version rejection', () => {
   test('version 3 throws CassetteCorruptError', () => {
     const json = JSON.stringify({ version: 3, recordings: [] })
     expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+    expect(() => deserialize(json)).toThrow(ShellCassetteError)
   })
 
   test('version 0 throws CassetteCorruptError', () => {
     const json = JSON.stringify({ version: 0, recordings: [] })
     expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+    expect(() => deserialize(json)).toThrow(ShellCassetteError)
   })
 
   test('version "1" (string) throws CassetteCorruptError (must be numeric)', () => {
     const json = JSON.stringify({ version: '1', recordings: [] })
     expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+    expect(() => deserialize(json)).toThrow(ShellCassetteError)
   })
 
   test('missing version field throws CassetteCorruptError', () => {
     const json = JSON.stringify({ recordings: [] })
     expect(() => deserialize(json)).toThrow(CassetteCorruptError)
+    expect(() => deserialize(json)).toThrow(ShellCassetteError)
   })
 
   test('malformed JSON throws CassetteCorruptError', () => {
     expect(() => deserialize('{not valid')).toThrow(CassetteCorruptError)
+    expect(() => deserialize('{not valid')).toThrow(ShellCassetteError)
   })
 
   test('version 3 error message instructs to upgrade', () => {

--- a/tests/unit/serialize.test.ts
+++ b/tests/unit/serialize.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, test } from 'vitest'
-import { BinaryOutputError, CassetteCorruptError } from '../../src/errors.js'
+import { BinaryOutputError, CassetteCorruptError, ShellCassetteError } from '../../src/errors.js'
 import { deserialize, serialize } from '../../src/serialize.js'
 import type { CassetteFile } from '../../src/types.js'
 import { makeRecording } from '../helpers/recording.js'
@@ -24,14 +24,17 @@ describe('deserialize', () => {
 
   test('throws CassetteCorruptError on missing version', () => {
     expect(() => deserialize(fixture('no-version'))).toThrow(CassetteCorruptError)
+    expect(() => deserialize(fixture('no-version'))).toThrow(ShellCassetteError)
   })
 
   test('throws CassetteCorruptError on unknown version', () => {
     expect(() => deserialize(fixture('unknown-version'))).toThrow(CassetteCorruptError)
+    expect(() => deserialize(fixture('unknown-version'))).toThrow(ShellCassetteError)
   })
 
   test('throws CassetteCorruptError on malformed JSON', () => {
     expect(() => deserialize(fixture('malformed'))).toThrow(CassetteCorruptError)
+    expect(() => deserialize(fixture('malformed'))).toThrow(ShellCassetteError)
   })
 })
 
@@ -157,5 +160,6 @@ describe('serialize', () => {
       ],
     } as CassetteFile
     expect(() => serialize(bad)).toThrow(BinaryOutputError)
+    expect(() => serialize(bad)).toThrow(ShellCassetteError)
   })
 })

--- a/tests/unit/state.test.ts
+++ b/tests/unit/state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'vitest'
-import { CassetteCollisionError } from '../../src/errors.js'
+import { CassetteCollisionError, ShellCassetteError } from '../../src/errors.js'
 import {
   clearActiveCassette,
   getActiveCassette,
@@ -71,6 +71,7 @@ describe('CassetteCollisionError detection via path map', () => {
   test('registering same path twice throws', () => {
     registerSessionPath('/tmp/foo.json', 'opener-a')
     expect(() => registerSessionPath('/tmp/foo.json', 'opener-b')).toThrow(CassetteCollisionError)
+    expect(() => registerSessionPath('/tmp/foo.json', 'opener-b')).toThrow(ShellCassetteError)
     unregisterSessionPath('/tmp/foo.json')
   })
 

--- a/tests/unit/vitest-plugin-error.test.ts
+++ b/tests/unit/vitest-plugin-error.test.ts
@@ -34,12 +34,14 @@ describe('wrapRegistrationError', () => {
   test('non-Error throws are coerced to Error before wrapping', () => {
     const wrapped = wrapRegistrationError('a string was thrown')
     expect(wrapped).toBeInstanceOf(VitestPluginRegistrationError)
+    expect(wrapped).toBeInstanceOf(ShellCassetteError)
     expect(wrapped.message).toContain('a string was thrown')
   })
 
   test('undefined throw still produces a wrapped message with deps.inline guidance', () => {
     const wrapped = wrapRegistrationError(undefined)
     expect(wrapped).toBeInstanceOf(VitestPluginRegistrationError)
+    expect(wrapped).toBeInstanceOf(ShellCassetteError)
     // No dead-end message when the original "error" was undefined.
     expect(wrapped.message).toContain('deps: { inline:')
   })

--- a/tests/unit/wrapper.test.ts
+++ b/tests/unit/wrapper.test.ts
@@ -3,6 +3,7 @@ import {
   AckRequiredError,
   NoActiveSessionError,
   ReplayMissError,
+  ShellCassetteError,
   UnsupportedOptionError,
 } from '../../src/errors.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
@@ -77,6 +78,7 @@ describe('runWrapped (envelope)', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(NoActiveSessionError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       const msg = (e as Error).message
       expect(msg).toContain('replay mode')
       expect(msg).toContain('useCassette')
@@ -89,9 +91,14 @@ describe('runWrapped (envelope)', () => {
   test('NoActiveSessionError when SHELL_CASSETTE_MODE=replay and no session is bound', async () => {
     process.env.SHELL_CASSETTE_MODE = 'replay'
     const realCall = vi.fn()
-    await expect(
-      runWrapped('echo', ['hi'], {}, baseHooks(realCall as never)),
-    ).rejects.toBeInstanceOf(NoActiveSessionError)
+    let caught: unknown
+    try {
+      await runWrapped('echo', ['hi'], {}, baseHooks(realCall as never))
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(NoActiveSessionError)
+    expect(caught).toBeInstanceOf(ShellCassetteError)
     expect(realCall).not.toHaveBeenCalled()
   })
 
@@ -113,7 +120,14 @@ describe('runWrapped (envelope)', () => {
       ...baseHooks(realCall as never),
       validate,
     }
-    await expect(runWrapped('echo', [], {}, hooks)).rejects.toBeInstanceOf(UnsupportedOptionError)
+    let caught: unknown
+    try {
+      await runWrapped('echo', [], {}, hooks)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(UnsupportedOptionError)
+    expect(caught).toBeInstanceOf(ShellCassetteError)
     expect(validate).toHaveBeenCalledOnce()
     expect(realCall).not.toHaveBeenCalled()
   })
@@ -122,9 +136,14 @@ describe('runWrapped (envelope)', () => {
     const session = makeSession({ scopeDefault: 'auto', loadedFile: null })
     setActiveCassette(session)
     const realCall = vi.fn(async () => ({ stdout: 'x', exitCode: 0 }))
-    await expect(runWrapped('echo', [], {}, baseHooks(realCall))).rejects.toBeInstanceOf(
-      AckRequiredError,
-    )
+    let caught: unknown
+    try {
+      await runWrapped('echo', [], {}, baseHooks(realCall))
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(AckRequiredError)
+    expect(caught).toBeInstanceOf(ShellCassetteError)
     expect(realCall).not.toHaveBeenCalled()
     clearActiveCassette()
   })
@@ -155,9 +174,14 @@ describe('runWrapped (envelope)', () => {
     process.env.SHELL_CASSETTE_MODE = 'replay'
 
     const realCall = vi.fn()
-    await expect(
-      runWrapped('echo', ['hi'], {}, baseHooks(realCall as never)),
-    ).rejects.toBeInstanceOf(ReplayMissError)
+    let caught: unknown
+    try {
+      await runWrapped('echo', ['hi'], {}, baseHooks(realCall as never))
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ReplayMissError)
+    expect(caught).toBeInstanceOf(ShellCassetteError)
     clearActiveCassette()
   })
 
@@ -213,6 +237,7 @@ describe('runWrapped (envelope)', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(AckRequiredError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       const msg = (e as Error).message
       expect(msg).toContain('auto mode')
       expect(msg).toContain('no recording matched')
@@ -237,6 +262,7 @@ describe('runWrapped (envelope)', () => {
       throw new Error('should not reach')
     } catch (e) {
       expect(e).toBeInstanceOf(AckRequiredError)
+      expect(e).toBeInstanceOf(ShellCassetteError)
       const msg = (e as Error).message
       // Positive assertion: explicit-record path returns the unmodified ack
       // help text from src/ack.ts, which starts with "shell-cassette is about".


### PR DESCRIPTION
Mechanical audit: every test that asserts \`expect(e).toBeInstanceOf(<ShellCassetteSubclass>)\` now also asserts \`expect(e).toBeInstanceOf(ShellCassetteError)\`. Replaces #115 (stuck-closed during force-push reopen).

User code catches errors programmatically with \`if (e instanceof ShellCassetteError) {...}\`, so the inheritance chain is part of the API surface. Without the paired assertion, breaking the chain on a specific subclass would silently regress without triggering a test failure.

## Files updated (21 total)

| File | Assertions added |
|---|---|
| \`tests/config/loader.test.ts\` | 2 |
| \`tests/error-path/binary-input-error.test.ts\` | 1 |
| \`tests/error-path/canonicalize-limits.test.ts\` | 2 |
| \`tests/error-path/error-classes.test.ts\` | 5 |
| \`tests/error-path/input-file-conflict.test.ts\` | 2 |
| \`tests/error-path/tinyexec-errors.test.ts\` | 3 |
| \`tests/integration/atomic-write.test.ts\` | 1 |
| \`tests/integration/loader.test.ts\` | 2 |
| \`tests/integration/record-replay-input-file.test.ts\` | 2 |
| \`tests/integration/record-replay-node.test.ts\` | 2 |
| \`tests/integration/record-replay-stdin.test.ts\` | 2 |
| \`tests/security/ack-gate.test.ts\` | 4 |
| \`tests/unit/config.test.ts\` | 5 |
| \`tests/unit/options-execa.test.ts\` | 7 |
| \`tests/unit/options-tinyexec.test.ts\` | 4 |
| \`tests/unit/paths.test.ts\` | 1 |
| \`tests/unit/serialize-v2.test.ts\` | 5 |
| \`tests/unit/serialize.test.ts\` | 4 |
| \`tests/unit/state.test.ts\` | 1 |
| \`tests/unit/vitest-plugin-error.test.ts\` | 2 |
| \`tests/unit/wrapper.test.ts\` | 7 |

~64 paired assertions added. Net diff: +130 / -34.

Four \`tests/unit/wrapper.test.ts\` tests were converted from chained \`await expect(promise).rejects.toBeInstanceOf(X)\` to \`try/catch\` with explicit assertions, because the chained pattern double-invokes the underlying expression and would have broken adjacent mock-call-count assertions (\`expect(realCall).not.toHaveBeenCalled()\`, \`expect(validate).toHaveBeenCalledOnce()\`).

Two test sites deliberately not paired:
- \`tests/error-path/tinyexec-errors.test.ts:33\` is covered by a dedicated separate test (lines 36-43) that asserts \`instanceof ShellCassetteError\` for the same call expression.
- \`tests/error-path/input-file-conflict.test.ts:63\` uses \`expect(e).not.toBeInstanceOf(UnsupportedOptionError)\` — the test's intent is asserting a non-shell-cassette error is thrown by real execa downstream of the validator. Adding the paired \`not.toBeInstanceOf(ShellCassetteError)\` would change the test's meaning.

A second commit collapses two duplicate-call patterns from the audit into the single-promise shape used by \`canonicalize-limits.test.ts\`. Each test now runs the operation once instead of twice.

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` (count unchanged)
- [x] \`npm run build\`

Closes #106.