### PR TITLE
refactor: compile-time exhaustiveness over RedactSource

### DIFF
--- a/src/cli-re-redact.ts
+++ b/src/cli-re-redact.ts
@@ -21,7 +21,13 @@ import {
   seedCountersFromCassette,
 } from './redact-pipeline.js'
 import { serialize } from './serialize.js'
-import type { CassetteFile, Recording, RedactConfig, RedactionEntry } from './types.js'
+import type {
+  CassetteFile,
+  Recording,
+  RedactConfig,
+  RedactionEntry,
+  RedactSource,
+} from './types.js'
 import { RECORDED_BY } from './version.js'
 
 const RE_REDACT_HELP = `\
@@ -231,6 +237,13 @@ function reRedactRecording(
   counters: Map<string, number>,
   suppressedHashes: ReadonlySet<string>,
 ): { recording: Recording; newCountInRecording: number } {
+  // Compile-time exhaustiveness: each source is redacted explicitly below.
+  // The type-level assertion fails compilation if a new RedactSource variant
+  // is added without a corresponding redact() call here.
+  type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+  const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+  void _exhaustive
+
   const newEntries: RedactionEntry[] = []
   let newCount = 0
 

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -98,6 +98,13 @@ function scanRecording(
   config: Readonly<RedactConfig>,
   skipSet: ReadonlySet<string>,
 ): Finding[] {
+  // Compile-time exhaustiveness: each source is scanned explicitly below.
+  // The type-level assertion fails compilation if a new RedactSource variant
+  // is added without a corresponding scan block here.
+  type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+  const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+  void _exhaustive
+
   const findings: Finding[] = []
 
   for (const [key, value] of Object.entries(rec.call.env)) {
@@ -481,6 +488,14 @@ export function applyDecisions(
       return r.output
     }
 
+    // Compile-time exhaustiveness: each source is dispatched explicitly
+    // below. The type-level assertion here fails compilation if a new
+    // RedactSource variant is added without a corresponding redactValue()
+    // call in this block.
+    type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+    const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+    void _exhaustive
+
     const env: Record<string, string> = {}
     for (const [key, value] of Object.entries(rec.call.env)) {
       env[key] = redactValue('env', value, key)
@@ -529,56 +544,62 @@ export function applyDecisions(
  * interactive loop (canonicalize-incompatible), but applyReplace handles both
  * defensively in case the user's --json mode bypasses the dispatcher.
  *
- * The cascading-if pattern below has no compile-time exhaustiveness guarantee
- * over RedactSource members; conversion to a switch with `never` exhaustion
- * is tracked separately in #101.
+ * Switch+`never` exhaustiveness: adding a new RedactSource variant without a
+ * case here fails compilation at the `default` arm.
  */
 function applyReplace(rec: Recording, finding: Finding, replacement: string): Recording {
   const { source } = finding
-  if (source === 'env') {
-    const key = finding.position.split(':')[0] ?? ''
-    const env = { ...rec.call.env, [key]: replacement }
-    return { ...rec, call: { ...rec.call, env } }
-  }
-  if (source === 'args') {
-    const argIdx = Number.parseInt(finding.position.split(':')[0] ?? '0', 10)
+  // Local helper used by the line-shaped sources (stdout / stderr / allLines).
+  // Hoisted to function scope so each case body is a flat single-source
+  // expression, keeping the switch's variant-to-action mapping obvious.
+  const replaceInLines = (lines: readonly string[]): string[] => {
+    const lineNumber = Number.parseInt(finding.position.split(':')[0] ?? '1', 10)
     const col = Number.parseInt(finding.position.split(':')[1] ?? '0', 10)
-    const args = [...rec.call.args]
-    // biome-ignore lint/style/noNonNullAssertion: argIdx in range when reached
-    const arg = args[argIdx]!
-    args[argIdx] = arg.slice(0, col) + replacement + arg.slice(col + finding.matchLength)
-    return { ...rec, call: { ...rec.call, args } }
-  }
-  if (source === 'stdin') {
-    // Whole-value replacement; stdin is a single string. Defensive parallel to
-    // env's branch. Should not be reached in normal flow because readNextAction
-    // gates 'r' for stdin findings.
-    return { ...rec, call: { ...rec.call, stdin: replacement } }
-  }
-  const lineNumber = Number.parseInt(finding.position.split(':')[0] ?? '1', 10)
-  const col = Number.parseInt(finding.position.split(':')[1] ?? '0', 10)
-  const lineIdx = lineNumber - 1
-  const replaceInLines = (lines: string[]): string[] => {
+    const lineIdx = lineNumber - 1
     const out = [...lines]
     // biome-ignore lint/style/noNonNullAssertion: lineIdx in range when reached
     const line = out[lineIdx]!
     out[lineIdx] = line.slice(0, col) + replacement + line.slice(col + finding.matchLength)
     return out
   }
-  if (source === 'stdout') {
-    return {
-      ...rec,
-      result: { ...rec.result, stdoutLines: replaceInLines(rec.result.stdoutLines) },
+  switch (source) {
+    case 'env': {
+      const key = finding.position.split(':')[0] ?? ''
+      const env = { ...rec.call.env, [key]: replacement }
+      return { ...rec, call: { ...rec.call, env } }
+    }
+    case 'args': {
+      const argIdx = Number.parseInt(finding.position.split(':')[0] ?? '0', 10)
+      const col = Number.parseInt(finding.position.split(':')[1] ?? '0', 10)
+      const args = [...rec.call.args]
+      // biome-ignore lint/style/noNonNullAssertion: argIdx in range when reached
+      const arg = args[argIdx]!
+      args[argIdx] = arg.slice(0, col) + replacement + arg.slice(col + finding.matchLength)
+      return { ...rec, call: { ...rec.call, args } }
+    }
+    case 'stdin':
+      // Whole-value replacement; stdin is a single string. Defensive parallel
+      // to env's branch. Should not be reached in normal flow because
+      // readNextAction gates 'r' for stdin findings.
+      return { ...rec, call: { ...rec.call, stdin: replacement } }
+    case 'stdout':
+      return {
+        ...rec,
+        result: { ...rec.result, stdoutLines: replaceInLines(rec.result.stdoutLines) },
+      }
+    case 'stderr':
+      return {
+        ...rec,
+        result: { ...rec.result, stderrLines: replaceInLines(rec.result.stderrLines) },
+      }
+    case 'allLines':
+      if (rec.result.allLines === null) return rec
+      return { ...rec, result: { ...rec.result, allLines: replaceInLines(rec.result.allLines) } }
+    default: {
+      const _exhaustive: never = source
+      throw new CassetteInternalError(`unhandled redact source: ${String(_exhaustive)}`)
     }
   }
-  if (source === 'stderr') {
-    return {
-      ...rec,
-      result: { ...rec.result, stderrLines: replaceInLines(rec.result.stderrLines) },
-    }
-  }
-  if (rec.result.allLines === null) return rec
-  return { ...rec, result: { ...rec.result, allLines: replaceInLines(rec.result.allLines) } }
 }
 
 const REVIEW_VERSION = 1

--- a/src/cli-scan.ts
+++ b/src/cli-scan.ts
@@ -247,6 +247,13 @@ function findingsForRecording(
   config: Readonly<RedactConfig>,
   includeMatch: boolean,
 ): Finding[] {
+  // Compile-time exhaustiveness: each source is scanned explicitly below.
+  // The type-level assertion fails compilation if a new RedactSource variant
+  // is added without a corresponding scan block here.
+  type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+  const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+  void _exhaustive
+
   const findings: Finding[] = []
 
   // env: env-key-match check first, then pattern scan on non-matching keys

--- a/src/cli-show.ts
+++ b/src/cli-show.ts
@@ -18,7 +18,7 @@ import { applyTruncation, color, formatBytes, setupCliColor, stderr, stdout } fr
 import { CassetteConfigError, CassetteNotFoundError } from './errors.js'
 import { loadCassette } from './loader.js'
 import { REDACTION_PLACEHOLDER_PATTERN } from './redact-pipeline.js'
-import type { CassetteFile, Recording } from './types.js'
+import type { CassetteFile, Recording, RedactSource } from './types.js'
 
 const SHOW_VERSION = 1
 
@@ -205,6 +205,15 @@ function printTerminal(cassette: CassetteFile, summary: ShowSummary, flags: Show
 }
 
 function printRecording(rec: Recording, index: number, total: number, flags: ShowFlags): void {
+  // Compile-time exhaustiveness: every RedactSource has a printer site below
+  // ('args' is printed in the header line; 'env' / 'stdin' / 'stdout' /
+  // 'stderr' / 'allLines' have their own sections). The type-level assertion
+  // fails compilation if a new RedactSource variant is added without a
+  // corresponding printer site here.
+  type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+  const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+  void _exhaustive
+
   stdout(color.bold(`[${index + 1}/${total}] ${rec.call.command} ${rec.call.args.join(' ')}`))
   stdout(`  cwd: ${rec.call.cwd ?? '(null)'}`)
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -5,6 +5,14 @@ import { aggregateEntries, ENV_KEY_MATCH_RULE, formatPlaceholder } from './redac
 import type { Call, CassetteSession, Recording, RedactSource, Result } from './types.js'
 
 export function record(call: Call, result: Result, session: CassetteSession): void {
+  // Compile-time exhaustiveness: redactCall covers env+args+stdin and
+  // redactResult covers stdout+stderr+allLines. Adding a new RedactSource
+  // variant must extend one of those two. This assertion fires in both
+  // subfunctions if a variant goes unhandled here.
+  type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+  const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+  void _exhaustive
+
   if (!session.redactEnabled) {
     // Per-cassette override: bypass the redact pipeline entirely.
     session.newRecordings.push({ call, result, redactions: [], suppressed: [] })

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -294,6 +294,14 @@ function walkStringsForPlaceholders(
   rec: CassetteFile['recordings'][number],
   visit: (source: string, rule: string, n: number) => void,
 ): void {
+  // Compile-time exhaustiveness: the values array below must spread every
+  // RedactSource field on the recording. Counter seeding from existing
+  // placeholders depends on it; missing a source means the per-(source,rule)
+  // ceiling for that source resets to 0 on auto-additive append.
+  type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
+  const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
+  void _exhaustive
+
   // Construct the regex once per function call. String.prototype.matchAll
   // does not mutate the pattern's lastIndex, so reusing re across multiple
   // matchAll calls is safe.


### PR DESCRIPTION
Combined PR for issues #101 and #113. (Replaces #120, which got into a stuck-closed state during a force-push reopen.)

Adds compile-time exhaustiveness over the \`RedactSource\` union at every source-aware site so future variants can't silently miss a site. Two patterns landed across 8 sites (6 CLI + recorder + redact-pipeline):

## Pattern A: switch+\`never\` (one site)

**\`cli-review.applyReplace\`** (#101) — the cascade-with-fallthrough is converted to a real \`switch (source)\` with a \`default\` arm that throws \`CassetteInternalError\` after binding \`source\` to a \`never\` type. A new \`replaceInLines\` helper hoisted to function scope flattens the line-stream cases.

## Pattern B: type-level assertion (seven iteration sites)

**\`cli-review.scanRecording\`**, **\`cli-review.applyDecisions\`**, **\`cli-scan.findingsForRecording\`**, **\`cli-re-redact.reRedactRecording\`**, **\`cli-show.printRecording\`**, **\`recorder.record()\`**, and **\`redact-pipeline.walkStringsForPlaceholders()\`** each gain a 4-line block at function scope:

\`\`\`ts
type _CoveredSources = 'env' | 'args' | 'stdin' | 'stdout' | 'stderr' | 'allLines'
const _exhaustive: Exclude<RedactSource, _CoveredSources> extends never ? true : never = true
void _exhaustive
\`\`\`

Adding a variant to \`RedactSource\` fails compilation at every site simultaneously.

## Why two patterns, not one

Each iteration site has a distinct shape: env per-key, args per-index, stdin nullable single-string, line streams per-line with context, plus recorder splits coverage between \`redactCall\` and \`redactResult\`. Forcing all seven through a uniform \`switch (source)\` dispatcher would add tagged-union plumbing for marginal gain over the type-level assertion. \`applyReplace\`'s real switch carries the strongest gate.

\`matcher.defaultCanonicalize\` is intentionally opinionated about which sources participate in the canonical match-tuple (cwd/env/result fields deliberately omitted for portability), so it does not get the assertion.

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` (count unchanged)
- [x] \`npm run build\`

Verified the exhaustiveness check works by temporarily adding \`'fakeNewSource'\` to \`RedactSource\` and running \`tsc --noEmit\`. All 8 sites failed compilation as expected.

Closes #101.
Closes #113.
Closes #119.