### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-cassette",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-cassette",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-cassette",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Polly.js, but for shell commands. Record subprocess calls once, replay them deterministically forever.",
   "keywords": [
     "subprocess",


### PR DESCRIPTION
Release commit for v0.6.0. CHANGELOG entry was added in #112 and is already in place with today's date (2026-04-30).

## What landed in v0.6 (per CHANGELOG.md \`[0.6.0]\`)

**Added**
- \`input: 'string'\` and \`inputFile\` accepted on execa
- \`stdin: 'string'\` stored in cassettes and matched on tinyexec
- \`node: true\` and \`execaNode\` named export accepted on execa
- \`lines\` object form (\`{ stdout, stderr, all, fd1, fd2 }\`) supported in execa synthesize
- \`BinaryInputError\` class for non-UTF-8 \`inputFile\`
- stdin included in \`defaultCanonicalize\` (with redaction round-trip)
- stdin redaction via the same pipeline as args/stdout/stderr (\`RedactSource\` extended)
- ReplayMissError hint when the failing call passed \`node: true\`
- Compile-time exhaustiveness over \`RedactSource\` at every parallel-arm site
- \`useRecordingEnv()\` test helper

**Changed**
- \`REVIEW_WARNING\` text drops \`stdin\` from the not-redacted list
- \`defaultCanonicalize\` includes stdin
- \`RunnerHooks.buildCall\` is now async (internal API; users importing only the high-level entries are unaffected)
- \`wrapFsError\` extracted in \`src/io.ts\`
- \"Tracked in backlog\" phrases dropped from validator and runtime error messages

**Notes**
- Cassette schema stays at version 2; v0.5 cassettes load with \`stdin: null\` and continue to match calls without an input option
- Double-read of \`inputFile\` (us + real execa) is documented and tracked for v0.7 optimization

## Test Plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test\`
- [x] \`npm run build\`