### PR TITLE
docs: full audit pass for stdin redaction and v0.6 surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ shell-cassette refuses to record without `SHELL_CASSETTE_ACK_REDACTION=true`. Th
 
 ### Redacted by default
 
-shell-cassette provides **25 bundled credential patterns**, applied to env values, args, stdout lines, stderr lines, and `allLines`. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format:
+shell-cassette provides **25 bundled credential patterns**, applied to env values, args, stdin, stdout lines, stderr lines, and `allLines`. Each pattern is anchored, character-class-locked, and length-bounded by the issuer's published format:
 
 - **GitHub** (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `github_pat_`)
 - **AWS access key IDs** (`AKIA`, `ASIA`, `AROA`, `AIDA`, `AGPA`, `ANPA`, `ANVA`, `APKA`, `ABIA`, `ACCA`)
@@ -383,10 +383,9 @@ npm test  # CI=true is set by your CI provider
 
 Run `shell-cassette --help` for the full subcommand list, or `shell-cassette <command> --help` for per-subcommand flags.
 
-## Adapter quirks
+## Adapter specifics
 
-A few v0.4 specifics:
-
+- **`shell-cassette/execa` exports `execa` and `execaNode`.** Both mirror real execa's named exports and accept the same options. `execaNode(file, args)` is equivalent to `execa(file, args, { node: true })`; recordings made via either form are interchangeable on replay (the `node` flag is not stored in the cassette).
 - **`shell-cassette/tinyexec` exports `exec` as an alias for `x`.** Mirrors tinyexec's own dual export so `import { exec } from 'tinyexec'` redirects to `import { exec } from 'shell-cassette/tinyexec'` without renaming.
 - **`shell-cassette/tinyexec.xSync` throws.** Sync subprocess wrapping is not supported. Use async `x` (recommended), or import `xSync` directly from `tinyexec` (those calls bypass shell-cassette).
 - **`result.process` on tinyexec replay throws** a clear `ShellCassetteError`. Tests reading `result.process.stdout` / `.stderr` / `.stdin` should switch to the buffered `result.stdout` / `result.stderr` fields, or run with `SHELL_CASSETTE_MODE=passthrough`.
@@ -533,6 +532,8 @@ If you hit one of these, see [docs/troubleshooting.md](docs/troubleshooting.md):
 - `NoActiveSessionError` -> in CI=true replay mode without a session bound; wrap with `useCassette` or import the vitest plugin
 - `NoActiveSessionError` from `beforeAll` / `beforeEach` -> setup runs outside the per-test session; use real `tinyexec` / `execa` in setup, or `SHELL_CASSETTE_MODE=passthrough` for setup-only flows
 - `AckRequiredError` with "auto mode: no recording matched..." -> matcher missed; check cassette
+- `BinaryInputError` -> `inputFile` points at a non-UTF-8 file. shell-cassette stores stdin as UTF-8; for binary stdin tests, use `SHELL_CASSETTE_MODE=passthrough`
+- `UnsupportedOptionError: input and inputFile cannot be combined` -> pass exactly one. Any non-undefined `input` (including `null` and `''`) combined with `inputFile` triggers this
 - `__cassettes__/` showing up as a test fixture -> exclude alongside `__snapshots__/`
 - `vi.mock('tinyexec')` infinite loop -> redirect at the import level, or use `shellCassetteAlias` from `shell-cassette/vite-plugin`
 - Naive `resolve.alias: { tinyexec: 'shell-cassette/tinyexec' }` self-loops -> use `shellCassetteAlias` instead (importer guard included)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -281,7 +281,7 @@ Pre-scans the cassette for un-redacted findings using the same regex rules as `s
 | ----- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `(a)` | accept  | Apply default redaction. The match becomes `<redacted:source:rule:N>` (counter-tagged).                                                                  |
 | `(s)` | skip    | Leave the match in body. Persists a `SuppressedEntry` so the match is not re-flagged on subsequent runs of `review` or `re-redact`.                     |
-| `(r)` | replace | Substitute a user-provided string. Not available for `args` (canonicalize-incompatible). Recorded as `rule: 'custom'` in the redaction summary.          |
+| `(r)` | replace | Substitute a user-provided string. Not available for `args` or `stdin` (both participate in the canonicalize-then-match path; replacing them would invalidate the recording). Recorded as `rule: 'custom'` in the redaction summary. |
 | `(d)` | delete  | Remove the entire recording from the cassette. Confirms before adding the decision.                                                                      |
 | `(b)` | back    | Revisit the previous finding. Removes the prior decision (the user must re-decide). Unwinds multi-step jumps from `(d)elete`.                            |
 | `(q)` | quit    | Discard all decisions and exit without writing.                                                                                                          |
@@ -354,6 +354,7 @@ With `--include-match`, each finding gains a `match` field with the raw matched 
 - `<line>:<col>` for stdout, stderr, allLines.
 - `<argIndex>:<col>` for args.
 - `<KEY>:0` for env values (env-key-match findings) or `<KEY>:<col>` for env values matched by regex.
+- `0:<col>` for stdin (single-value source; the `0` segment exists for shape symmetry with the others).
 
 ### Skip semantics
 

--- a/docs/execa.md
+++ b/docs/execa.md
@@ -127,6 +127,12 @@ When the wrapper synthesizes a result on replay, it produces the same shape exec
 
 `isCanceled` is preserved through record/replay (captured from execa's field, stored as `aborted` in the cassette schema, synthesized back to `isCanceled` on replay). `durationMs` is wall-clock measured by shell-cassette's wrapper around the real subprocess.
 
-## What's NOT redacted
+## Redaction
 
-shell-cassette only redacts curated env-key values by default. **stdout, stderr, args, and non-curated env vars are not scrubbed.** See [troubleshooting → What shell-cassette does NOT redact](troubleshooting.md#what-shell-cassette-does-not-redact). Always review cassettes before committing.
+By default, shell-cassette redacts:
+
+- **Bundled credential patterns.** 25 prefix-anchored shapes (GitHub, AWS access key IDs, Stripe, OpenAI, Anthropic, Slack, npm, etc.) applied to env values, args, stdin, stdout, stderr, and `allLines`. Reference: [docs/redact-patterns.md](redact-patterns.md).
+- **Curated env-key values.** Whole-value redacted when the env-var KEY contains `TOKEN`, `SECRET`, `PASSWORD`, `APIKEY`, etc. (substring match, case-insensitive).
+- **User-supplied custom rules** (`config.redact.customPatterns`) applied to the same six sources.
+
+What is NOT redacted by default: AWS Secret Access Keys (no documented prefix), JWTs (opt-in via custom rule), encoded credentials (`Authorization: Basic ...`), `cwd` values, binary output (blocked by `BinaryOutputError`). See [troubleshooting → Residual risks](troubleshooting.md#residual-risks-and-gaps-in-redaction). Always review cassettes before committing. `npx shell-cassette scan` reports what would be flagged.

--- a/docs/redact-patterns.md
+++ b/docs/redact-patterns.md
@@ -34,7 +34,7 @@ For ambiguous credential shapes (AWS Secret Access Keys, JWTs, generic 32-hex to
 | `discord-bot-token` | Discord | `[MN]` | 23 + `.` + 6 + `.` + 27+ | https://docs.discord.com/developers/reference |
 | `square-production-token` | Square | `EAAA` | 60+ | https://developer.squareup.com/docs/build-basics/access-tokens |
 
-Patterns apply to env values, args, stdout lines, stderr lines, and `allLines`. The same pattern is shared across all five sources; the placeholder records which source it fired in: `<redacted:source:rule-name:N>`.
+Patterns apply to env values, args, stdin, stdout lines, stderr lines, and `allLines`. The same pattern is shared across all six sources; the placeholder records which source it fired in: `<redacted:source:rule-name:N>`.
 
 ## Adding a custom rule
 
@@ -60,7 +60,7 @@ Notes:
 - The `g` flag is normalized internally; supplying a regex with or without `g` works the same.
 - `name` must be lowercase kebab-case (`/^[a-z][a-z0-9-]*$/`). It appears in placeholder strings: `<redacted:source:my-internal-token:N>`.
 - `pattern` may also be a function `(s: string) => string` for advanced cases (e.g., conditional replacement). Function-typed patterns can NOT be position-scanned by `shell-cassette scan`; prefer regex when possible.
-- Custom rules apply to the same five sources as bundled rules.
+- Custom rules apply to the same six sources as bundled rules.
 
 ## Suppressing false positives
 

--- a/docs/tinyexec.md
+++ b/docs/tinyexec.md
@@ -67,7 +67,7 @@ tinyexec returns a richer object than `Promise<Result>` - it's structurally `Pro
 
 | Interaction | Replay behavior | Reason |
 |---|---|---|
-| `result.process` | `null` | No live `ChildProcess` to expose |
+| `result.process` | Throws `ShellCassetteError` on read | No live `ChildProcess` to expose; the throwing getter surfaces a clear error rather than letting downstream `.stdout`/`.stderr`/`.stdin` accesses fail with confusing TypeErrors |
 | `result.pipe(...)` | Throws `UnsupportedOptionError` | Pipe chaining requires a live subprocess to receive stdin |
 | `result.kill()` | No-op | The subprocess never spawned; nothing to kill |
 | `for await (line of result)` | Throws `UnsupportedOptionError` | Interleaving order between stdout and stderr is lost in storage |
@@ -97,6 +97,18 @@ The cassette schema is narrower than tinyexec's runtime result. One mapping stil
 
 Rejected options throw `UnsupportedOptionError` at the wrapper entry.
 
-## What's NOT redacted
+## Named exports
 
-shell-cassette only redacts curated env-key values. stdout, stderr, args, and non-curated env vars are not scrubbed. See [troubleshooting → What shell-cassette does NOT redact](troubleshooting.md#what-shell-cassette-does-not-redact). Always review cassettes before committing.
+- **`x`** is the canonical entry point.
+- **`exec`** is an alias for `x`. tinyexec exports both names; shell-cassette mirrors that so `import { exec } from 'tinyexec'` redirects to `import { exec } from 'shell-cassette/tinyexec'` without renaming at every call site.
+- **`xSync`** is a stub that throws a clear error pointing to async `x`. Sync subprocess wrapping requires synchronous lazy-load support, which shell-cassette does not currently provide. Either refactor to async `x` (gets cassette coverage), or import `xSync` directly from `tinyexec` (those calls bypass shell-cassette).
+
+## Redaction
+
+By default, shell-cassette redacts:
+
+- **Bundled credential patterns.** 25 prefix-anchored shapes applied to env values, args, stdin, stdout, stderr, and `allLines`. Reference: [docs/redact-patterns.md](redact-patterns.md).
+- **Curated env-key values.** Whole-value redacted when the env-var KEY contains `TOKEN`, `SECRET`, `PASSWORD`, `APIKEY`, etc.
+- **User-supplied custom rules** (`config.redact.customPatterns`) applied to the same six sources.
+
+What is NOT redacted by default: AWS Secret Access Keys (no documented prefix), JWTs (opt-in), encoded credentials, `cwd` values, binary output. See [troubleshooting → Residual risks](troubleshooting.md#residual-risks-and-gaps-in-redaction). Always review cassettes before committing. `npx shell-cassette scan` reports what would be flagged.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -64,7 +64,7 @@ The test expected to replay from a cassette but shell-cassette tried to record i
 
 > auto mode: no recording matched `git status --porcelain`, attempted to record but ack gate not set.
 
-**Most common cause:** the matcher missed. shell-cassette's default matcher is `command + deep-equal args`. If a recording captured `git status --porcelain` and the test now calls `git status -uall`, the matcher fails. In auto mode (default), failure falls through to the record path. The record path requires the ack gate.
+**Most common cause:** the matcher missed. shell-cassette's default matcher is `command + deep-equal args + stdin`. If a recording captured `git status --porcelain` and the test now calls `git status -uall`, the matcher fails. Same applies if the recorded call had `input: 'foo'` and the replay call has `input: 'bar'`. In auto mode (default), failure falls through to the record path. The record path requires the ack gate.
 
 **Fix paths:**
 
@@ -151,6 +151,24 @@ await x('ffmpeg', ['-i', 'input.mp4', '-y', 'output.mp4'])
 
 If you need binary stdout/stderr support, [open an issue](https://github.com/slgoodrich/shell-cassette/issues/new).
 
+## `BinaryInputError`
+
+Thrown when `inputFile` (execa) points at a file with non-UTF-8 bytes. shell-cassette stores stdin as UTF-8 in the cassette so the bytes can flow through redaction alongside args, stdout, and stderr; binary stdin can't round-trip.
+
+The check fires inside `buildCall` BEFORE the matcher runs, so a fixture-swap that turns a previously-UTF-8 file into a binary one throws here even on replay (rather than producing a confusing `ReplayMissError`).
+
+**Options:**
+
+- **Use `SHELL_CASSETTE_MODE=passthrough` for that test.** Bypasses cassette mode; the real subprocess receives the binary file directly.
+- **Read the file yourself and pass `input: 'string'`** if the content is actually text. The validator accepts `input: 'string'`; the bytes go through redaction normally.
+- **Refactor the test** to feed binary input via a different route (write to a temp file the subprocess reads on its own, rather than via stdin).
+
+## `UnsupportedOptionError`: `input` and `inputFile` cannot be combined
+
+Thrown when both `input` and `inputFile` are passed to execa. The check fires for any non-undefined `input` value (including `null` and `''`) combined with a set `inputFile`; this is intentional, since user code passing both is ambiguous about which is the source of truth.
+
+**Fix:** pass exactly one. Use `input: 'string'` for inline content; use `inputFile: '/path'` for file-backed content. If your call site conditionally picks one, build the options object with only the chosen field present (omit the other entirely rather than setting it to `undefined`).
+
 ## "How do I redact a secret that isn't in the curated list?"
 
 Add the env var name to your `shell-cassette.config.js`:
@@ -206,7 +224,7 @@ Exit codes:
 - `1` - at least one cassette has findings (commit should be blocked)
 - `2` - error (missing path, malformed cassette, conflicting flags)
 
-The scanner reports what `record` mode would have redacted. A clean exit means: every env value with a curated key name is already a placeholder, every bundled pattern that fires on a value in env/args/stdout/stderr/allLines is already a placeholder, and every custom rule you've configured is already applied.
+The scanner reports what `record` mode would have redacted. A clean exit means: every env value with a curated key name is already a placeholder, every bundled pattern that fires on a value in env/args/stdin/stdout/stderr/allLines is already a placeholder, and every custom rule you've configured is already applied.
 
 Useful flags:
 


### PR DESCRIPTION
Pre-release docs cleanup. Targets main directly so the published v0.6.0 docs are current.

Per a full audit of README, CHANGELOG, and the six \`docs/\*.md\` files against the v0.6 changeset, this PR fixes:

## Critical staleness (factual errors a v0.6 user would hit)

**README.md**
- Bundled-pattern source list adds stdin (was \`env/args/stdout/stderr/allLines\`).
- Common gotchas gains \`BinaryInputError\` and the \`input + inputFile\` conflict.
- Adapter section opens with execa's named exports (\`execa\` + \`execaNode\`); drops the dated \"v0.4 specifics\" header.

**docs/execa.md**
- Replaces the stale \"shell-cassette only redacts curated env-key values\" claim (wrong since v0.4: bundled patterns scrub all sources) with a Redaction section that accurately describes the six-source bundled coverage, curated env-key handling, and custom rules.

**docs/tinyexec.md**
- \`result.process\` row updated from \"null\" to \"Throws ShellCassetteError on read\". The previous text contradicted both the README and the actual code (the field is a throwing getter).
- Same Redaction-section rewrite as execa.md.
- Adds a Named exports section covering \`exec\` alias and \`xSync\` stub (previously only in the README).

**docs/troubleshooting.md**
- Default matcher description: \`command + deep-equal args\` -> \`command + deep-equal args + stdin\`.
- Scan-clean explanation: bundled-pattern source list adds stdin.
- New \`BinaryInputError\` section: when it fires, fix paths.
- New \`UnsupportedOptionError: input and inputFile cannot be combined\` section: the \`!== undefined\` trigger semantics and the fix.

**docs/cli.md**
- \`(r)eplace\` gating: \"Not available for \`args\`\" -> \"Not available for \`args\` or \`stdin\`\".
- Position-format reference adds stdin's \`0:<col>\` shape.

**docs/redact-patterns.md**
- \"five sources\" -> \"six sources\" (x2).

## What's clean (no changes)

- \`CHANGELOG.md\` [0.6.0] entry: accurate.
- \`docs/vitest-plugin.md\`: unaffected by v0.6 surface changes.
- README \"What's in the match-tuple\" section: accurate.
- README stdin residual-risk bullet: accurate.
- \`docs/execa.md\` and \`docs/tinyexec.md\` option compatibility tables: already correct.
- Historical CHANGELOG entries for v0.4 / v0.5: left as-is. Accurate at the time they were written; rewriting historical changelog entries would falsify the record.

## Test Plan

- [x] \`npm run lint\` (docs only, no source changes; biome confirms no fixes needed)
- [x] \`npm run typecheck\` (no source changes)
- Tests not run; no source changes.

## Notes

- The \`result.process\` and \"only redacts curated env-key values\" inaccuracies pre-date v0.6 (the throwing-getter dates back to when result.process was reshaped; the curated-only redaction claim has been wrong since bundled patterns went into the bundle in v0.4). Fixed in this sweep rather than carrying them into v0.6.0.
- Once this PR merges to main, #124 (\`chore(release): v0.6.0\`) will need a rebase. No conflicts expected (this PR doesn't touch \`package.json\` / \`package-lock.json\`).