### PR TITLE
fix: shape fidelity for replay (timedOut, failed derivation, subprocess-API stubs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
+Replay shape now matches real execa/tinyexec behavior on failure paths. Three bug fixes plus subprocess-API stubs on execa replay. Cassette schema stays at version 2; the new `Result` fields are JSON-additive.
+
+### Added
+
+- **Optional flag fields on `Result`.** `failed`, `timedOut`, `isMaxBuffer`, `isForcefullyTerminated`, `isGracefullyCanceled` are stored on capture (execa) and derived where the runner does not expose them (tinyexec derives `failed` from exit code, kill, abort).
+- **Full execa flag completeness on synth.** Replay populates every documented execa `Result` boolean: `isTerminated`, `isMaxBuffer`, `isForcefullyTerminated`, `isGracefullyCanceled`, plus the empty `pipedFrom` and `ipcOutput` arrays. Tests asserting on these now reach reachable values instead of `undefined`.
+- **Subprocess-API stubs on execa replay.** The synth result attaches `kill()` (no-op returning `false`), `pipe()` (throws `UnsupportedOptionError`), and `Symbol.asyncIterator` (throws `UnsupportedOptionError`). Mirrors tinyexec's existing pattern.
+
+### Fixed
+
+- **Replay no longer drops `timedOut`.** Recordings capture the flag; synth surfaces it. Tests asserting on `result.timedOut === true` after a recorded timeout now pass.
+- **Aborted, signal-killed, and maxBuffer-exceeded calls no longer replay as success.** Synth resolves `failed` via fallback derivation (`exitCode !== 0 || signal !== null || aborted`) and the reject branch keys on the resolved value. Cassettes recorded before the `failed` field was added auto-upgrade their replay correctness without re-recording.
+- **`result.kill()`, `result.pipe()`, and `for await (line of result)` on execa replay no longer raise `TypeError`.** They now have stub implementations consistent with tinyexec's existing behavior.
+
+### Changed
+
+- **Cassette schema stays at version 2.** The five new `Result` fields are JSON-additive. Older cassettes parse with them absent and synth resolves missing values via fallback derivation.
+
+### Notes
+
+- Tinyexec does not expose `timedOut`, `isMaxBuffer`, `isForcefullyTerminated`, or `isGracefullyCanceled`; synth defaults each to `false` on tinyexec replay.
+- Stream methods (`iterable()`, `readable()`, `writable()`, `duplex()`) and stream-property getters on execa replay are not stubbed; calls produce `TypeError`. Tests using these patterns must run with `SHELL_CASSETTE_MODE=passthrough`.
+- Tinyexec's record path drops `aborted`/`killed` from the awaited `Output` (those getters live on the pre-await `ExecProcess`). Cassettes recorded by tinyexec currently store `aborted: false` regardless of whether the call was canceled. Replay-side handling is correct. Tracked in [#126](https://github.com/slgoodrich/shell-cassette/issues/126).
+
 ## [0.6.0] - 2026-04-30
 
 Surface coverage for stdin and the previously-rejected execa input options. The cassette schema stays at version 2; v0.5 cassettes load and replay unchanged. v0.5 cassettes have `stdin: null` and continue to match calls that pass no input option.

--- a/docs/execa.md
+++ b/docs/execa.md
@@ -119,13 +119,36 @@ Rejected options throw `UnsupportedOptionError` at the record-mode wrapper entry
 
 ## Replay fidelity
 
-When the wrapper synthesizes a result on replay, it produces the same shape execa returns:
+When the wrapper synthesizes a result on replay, it populates every documented `Result` boolean flag so user assertions reach reachable values:
 
-- `stdout`, `stderr`, `exitCode`, `signal`, `command`, `escapedCommand`, `failed`, `timedOut`, `isCanceled`, `killed`, `durationMs`
-- `all` (when `all: true` was passed)
-- Throws synthesized `ExecaError` when exit code is non-zero AND `reject: false` not set (matching execa's default)
+| Field | Replay value |
+|---|---|
+| `failed` | Stored on capture; if absent (older cassettes), derived from `exitCode !== 0 \|\| signal !== null \|\| aborted` |
+| `timedOut` | Stored on capture; defaults to `false` when absent |
+| `isCanceled` | Mirrors the cassette's `aborted` field |
+| `isMaxBuffer` | Stored on capture; defaults to `false` when absent |
+| `isTerminated` | Derived: `signal !== null` |
+| `isForcefullyTerminated` | Stored on capture; defaults to `false` when absent |
+| `isGracefullyCanceled` | Stored on capture; defaults to `false` when absent |
+| `killed` | Derived: `signal !== null` |
+| `pipedFrom` | Always `[]` (`.pipe()` is stubbed; see below) |
+| `ipcOutput` | Always `[]` (`ipc: true` is rejected at validation) |
 
-`isCanceled` is preserved through record/replay (captured from execa's field, stored as `aborted` in the cassette schema, synthesized back to `isCanceled` on replay). `durationMs` is wall-clock measured by shell-cassette's wrapper around the real subprocess.
+Other fields (`stdout`, `stderr`, `exitCode`, `signal`, `command`, `escapedCommand`, `durationMs`, optional `all`) round-trip as before. The reject branch throws synthesized `ExecaError` when the resolved `failed` is `true` and `reject !== false` (matching execa's default). The fallback derivation lets cassettes recorded before the `failed` field was added auto-upgrade their replay correctness — aborted and signal-killed calls now throw on replay even when the cassette was recorded before the flag existed.
+
+`durationMs` is wall-clock measured by shell-cassette's wrapper around the real subprocess.
+
+### Subprocess-API methods on replay
+
+The synth result attaches a minimal subprocess API:
+
+| Method | Replay behavior |
+|---|---|
+| `kill(signal?)` | No-op; returns `false` (real execa returns `false` when no signal was sent) |
+| `pipe(...)` | Throws `UnsupportedOptionError`; use `SHELL_CASSETTE_MODE=passthrough` for tests that pipe |
+| `for await (line of subprocess)` | Throws `UnsupportedOptionError`; read `result.stdout` (string or `lines: true` array) |
+
+Stream methods (`iterable()`, `readable()`, `writable()`, `duplex()`) and stream-property getters (`stdin`, `stdout`, `stderr` as Node streams) are not stubbed; calls produce `TypeError`. Tests using these patterns must run with `SHELL_CASSETTE_MODE=passthrough`.
 
 ## Redaction
 

--- a/docs/tinyexec.md
+++ b/docs/tinyexec.md
@@ -83,6 +83,12 @@ The cassette schema is narrower than tinyexec's runtime result. One mapping stil
 
 `aborted` is preserved through record/replay (captured from tinyexec's `aborted: true` when AbortSignal triggered, synthesized back to `aborted` on replay).
 
+## Failed flag
+
+Tinyexec's `Output` does not expose a `failed` boolean. shell-cassette derives `failed` on capture from `exitCode !== 0 || killed || aborted` and stores it in the cassette. Replay surfaces the stored value; older cassettes recorded before the field was stored re-derive at replay time via the same formula. The `throwOnError` reject branch keys on the resolved value, so signal-killed and aborted replays throw under `throwOnError: true` even when the cassette predates the field.
+
+Tinyexec's awaited `Output` also drops the `aborted` and `killed` getters that live on the pre-await `ExecProcess`. As a result, tinyexec cassettes currently record `aborted: false` regardless of whether the original call was canceled. Tracked in [#126](https://github.com/slgoodrich/shell-cassette/issues/126); replay-side handling is correct.
+
 ## Supported tinyexec options
 
 | Option | Status |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -390,6 +390,23 @@ shell-cassette/tinyexec's `xSync` is a stub that throws a clear error pointing t
 - **Use async `x`** (recommended). Refactor sync call sites to async; you get cassette coverage.
 - **Import `xSync` directly from `tinyexec`.** Those calls bypass shell-cassette and run real subprocess. Acceptable for pre-flight version checks and similar non-determinism-sensitive paths.
 
+## `result.pipe()` or `for await (line of subprocess)` throws on execa replay
+
+shell-cassette synthesizes the execa result from the cassette; there is no live subprocess to pipe or stream. The synth result includes stub methods that throw `UnsupportedOptionError`:
+
+```ts
+// On replay, this throws:
+const result = await execa('node', ['-v'])
+result.pipe(otherProcess) // UnsupportedOptionError
+
+// Same for async iteration:
+for await (const line of execa('node', ['script.js'])) { ... } // UnsupportedOptionError
+```
+
+For tests that genuinely need to pipe subprocesses or stream output line-by-line as it arrives, run that test (or its describe block) with `SHELL_CASSETTE_MODE=passthrough`. The wrapper then calls real execa with no recording involvement and the live subprocess API works as expected.
+
+`result.kill()` on replay returns `false` (no-op) rather than throwing, mirroring real execa's "did not signal" return value.
+
 ## `result.process` throws on tinyexec replay
 
 Tests that read `result.process.stdout` (streaming) or `result.process.stderr` (sync inspection) on replay get a clear error:

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -194,9 +194,10 @@ function synthesize(rec: Recording, options: Options): unknown {
     isGracefullyCanceled: rec.result.isGracefullyCanceled ?? false,
     killed: rec.result.signal !== null,
 
-    // Empty arrays for unsupported features. pipedFrom only meaningful
-    // with .pipe() (stubbed as throw in the next change); ipcOutput only
-    // with ipc: true (rejected at validation).
+    // Always empty arrays. `pipedFrom` records the upstream
+    // subprocesses of a piped chain; replay synthesizes single results
+    // and never chains. `ipcOutput` collects IPC messages; `ipc: true`
+    // is rejected at validation.
     pipedFrom: [],
     ipcOutput: [],
 

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -164,13 +164,22 @@ function synthesize(rec: Recording, options: Options): unknown {
           : []
         : (rec.result.allLines?.join('\n') ?? stdoutAsString + stderrAsString)
       : undefined
+  // Resolve failed: stored value when present; otherwise derive from
+  // exit/signal/abort state. The fallback covers signal kill and aborted
+  // cases the old `exitCode !== 0` check missed and lets cassettes
+  // recorded before the field was added auto-upgrade their replay
+  // correctness without re-recording.
+  const failed =
+    rec.result.failed ??
+    (rec.result.exitCode !== 0 || rec.result.signal !== null || rec.result.aborted)
+
   const result = {
     stdout,
     stderr,
     exitCode: rec.result.exitCode,
     signal: rec.result.signal,
     durationMs: rec.result.durationMs,
-    failed: rec.result.exitCode !== 0,
+    failed,
     timedOut: false,
     isCanceled: rec.result.aborted,
     killed: rec.result.signal !== null,
@@ -179,7 +188,7 @@ function synthesize(rec: Recording, options: Options): unknown {
     ...(all !== undefined && { all }),
   }
 
-  if (options.reject !== false && rec.result.exitCode !== 0) {
+  if (options.reject !== false && failed) {
     const err = Object.assign(
       new Error(`Command failed with exit code ${rec.result.exitCode}: ${result.command}`),
       result,

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -1,5 +1,5 @@
 import type { Options, ResultPromise } from 'execa'
-import { MissingPeerDependencyError } from './errors.js'
+import { MissingPeerDependencyError, ShellCassetteError } from './errors.js'
 import { readInputFile } from './io.js'
 import { validateOptions } from './options-execa.js'
 import type { Call, Recording, Result } from './types.js'
@@ -202,6 +202,25 @@ function synthesize(rec: Recording, options: Options): unknown {
     ipcOutput: [],
 
     ...(all !== undefined && { all }),
+
+    // Subprocess-API stubs. kill() returns false to mirror real execa's
+    // "did not signal" return (no live subprocess). pipe() and async
+    // iteration throw ShellCassetteError with actionable messages.
+    // Stream methods (iterable/readable/writable/duplex) are not
+    // stubbed; calls produce TypeError.
+    kill: (): boolean => false,
+    pipe: (): never => {
+      throw new ShellCassetteError(
+        'execa result.pipe() not supported on replay (no live subprocess). ' +
+          'Use SHELL_CASSETTE_MODE=passthrough for tests that pipe subprocesses.',
+      )
+    },
+    [Symbol.asyncIterator]: (): never => {
+      throw new ShellCassetteError(
+        'execa async iteration `for await (line of subprocess)` not supported on replay. ' +
+          'Read result.stdout (string or array form via lines option) instead.',
+      )
+    },
   }
 
   if (options.reject !== false && failed) {

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -179,12 +179,27 @@ function synthesize(rec: Recording, options: Options): unknown {
     exitCode: rec.result.exitCode,
     signal: rec.result.signal,
     durationMs: rec.result.durationMs,
-    failed,
-    timedOut: false,
-    isCanceled: rec.result.aborted,
-    killed: rec.result.signal !== null,
     command: `${rec.call.command} ${rec.call.args.join(' ')}`,
     escapedCommand: rec.call.command,
+
+    // All execa Result boolean flags. Stored values when available;
+    // sane defaults when absent (legacy cassettes or runner did not
+    // expose them).
+    failed,
+    timedOut: rec.result.timedOut ?? false,
+    isCanceled: rec.result.aborted,
+    isMaxBuffer: rec.result.isMaxBuffer ?? false,
+    isTerminated: rec.result.signal !== null,
+    isForcefullyTerminated: rec.result.isForcefullyTerminated ?? false,
+    isGracefullyCanceled: rec.result.isGracefullyCanceled ?? false,
+    killed: rec.result.signal !== null,
+
+    // Empty arrays for unsupported features. pipedFrom only meaningful
+    // with .pipe() (stubbed as throw in the next change); ipcOutput only
+    // with ipc: true (rejected at validation).
+    pipedFrom: [],
+    ipcOutput: [],
+
     ...(all !== undefined && { all }),
   }
 

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -83,6 +83,11 @@ function captureResult(raw: unknown, durationMs: number): Result {
     exitCode?: number
     signal?: string | null
     isCanceled?: boolean
+    failed?: boolean
+    timedOut?: boolean
+    isMaxBuffer?: boolean
+    isForcefullyTerminated?: boolean
+    isGracefullyCanceled?: boolean
   }
   return {
     stdoutLines: toLines(r.stdout),
@@ -92,8 +97,17 @@ function captureResult(raw: unknown, durationMs: number): Result {
     signal: r.signal ?? null,
     durationMs,
     aborted: r.isCanceled === true,
+    failed: r.failed === true,
+    timedOut: r.timedOut === true,
+    isMaxBuffer: r.isMaxBuffer === true,
+    isForcefullyTerminated: r.isForcefullyTerminated === true,
+    isGracefullyCanceled: r.isGracefullyCanceled === true,
   }
 }
+
+// Test-only export so unit tests can drive captureResult without spawning
+// a real subprocess. Underscore prefix marks it as non-public API.
+export const _captureResultForTesting = captureResult
 
 function toLines(input: string | string[] | undefined): string[] {
   if (input === undefined) return ['']

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -1,5 +1,5 @@
 import type { Options, ResultPromise } from 'execa'
-import { MissingPeerDependencyError, ShellCassetteError } from './errors.js'
+import { MissingPeerDependencyError, UnsupportedOptionError } from './errors.js'
 import { readInputFile } from './io.js'
 import { validateOptions } from './options-execa.js'
 import type { Call, Recording, Result } from './types.js'
@@ -205,18 +205,18 @@ function synthesize(rec: Recording, options: Options): unknown {
 
     // Subprocess-API stubs. kill() returns false to mirror real execa's
     // "did not signal" return (no live subprocess). pipe() and async
-    // iteration throw ShellCassetteError with actionable messages.
+    // iteration throw UnsupportedOptionError with actionable messages.
     // Stream methods (iterable/readable/writable/duplex) are not
     // stubbed; calls produce TypeError.
     kill: (): boolean => false,
     pipe: (): never => {
-      throw new ShellCassetteError(
+      throw new UnsupportedOptionError(
         'execa result.pipe() not supported on replay (no live subprocess). ' +
           'Use SHELL_CASSETTE_MODE=passthrough for tests that pipe subprocesses.',
       )
     },
     [Symbol.asyncIterator]: (): never => {
-      throw new ShellCassetteError(
+      throw new UnsupportedOptionError(
         'execa async iteration `for await (line of subprocess)` not supported on replay. ' +
           'Read result.stdout (string or array form via lines option) instead.',
       )

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -5,6 +5,27 @@ import { validateOptions } from './options-execa.js'
 import type { Call, Recording, Result } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
 
+// Reused across every synth call. `pipe` and async iteration always
+// throw the same error; `kill` always returns false; the empty arrays
+// are frozen so callers can't mutate them between replays.
+const FROZEN_EMPTY_ARRAY: readonly never[] = Object.freeze([])
+
+const REPLAY_KILL_STUB = (): boolean => false
+
+const REPLAY_PIPE_STUB = (): never => {
+  throw new UnsupportedOptionError(
+    'execa result.pipe() not supported on replay (no live subprocess). ' +
+      'Use SHELL_CASSETTE_MODE=passthrough for tests that pipe subprocesses.',
+  )
+}
+
+const REPLAY_ASYNC_ITER_STUB = (): never => {
+  throw new UnsupportedOptionError(
+    'execa async iteration `for await (line of subprocess)` not supported on replay. ' +
+      'Read result.stdout (string or array form via lines option) instead.',
+  )
+}
+
 // Resolve execa via dynamic import so we can wrap "Cannot find module" with
 // an actionable error. Top-level await here means consumers importing
 // shell-cassette/execa wait for this resolution. If execa isn't installed,
@@ -173,6 +194,8 @@ function synthesize(rec: Recording, options: Options): unknown {
     rec.result.failed ??
     (rec.result.exitCode !== 0 || rec.result.signal !== null || rec.result.aborted)
 
+  const isTerminated = rec.result.signal !== null
+
   const result = {
     stdout,
     stderr,
@@ -181,46 +204,29 @@ function synthesize(rec: Recording, options: Options): unknown {
     durationMs: rec.result.durationMs,
     command: `${rec.call.command} ${rec.call.args.join(' ')}`,
     escapedCommand: rec.call.command,
-
-    // All execa Result boolean flags. Stored values when available;
-    // sane defaults when absent (legacy cassettes or runner did not
-    // expose them).
     failed,
     timedOut: rec.result.timedOut ?? false,
     isCanceled: rec.result.aborted,
     isMaxBuffer: rec.result.isMaxBuffer ?? false,
-    isTerminated: rec.result.signal !== null,
+    isTerminated,
     isForcefullyTerminated: rec.result.isForcefullyTerminated ?? false,
     isGracefullyCanceled: rec.result.isGracefullyCanceled ?? false,
-    killed: rec.result.signal !== null,
+    killed: isTerminated, // NOTE: tracked as semantic bug in #129 — preserves current behavior
 
-    // Always empty arrays. `pipedFrom` records the upstream
-    // subprocesses of a piped chain; replay synthesizes single results
-    // and never chains. `ipcOutput` collects IPC messages; `ipc: true`
+    // pipedFrom: no chained subprocess on replay. ipcOutput: ipc: true
     // is rejected at validation.
-    pipedFrom: [],
-    ipcOutput: [],
+    pipedFrom: FROZEN_EMPTY_ARRAY,
+    ipcOutput: FROZEN_EMPTY_ARRAY,
 
     ...(all !== undefined && { all }),
 
-    // Subprocess-API stubs. kill() returns false to mirror real execa's
-    // "did not signal" return (no live subprocess). pipe() and async
-    // iteration throw UnsupportedOptionError with actionable messages.
-    // Stream methods (iterable/readable/writable/duplex) are not
-    // stubbed; calls produce TypeError.
-    kill: (): boolean => false,
-    pipe: (): never => {
-      throw new UnsupportedOptionError(
-        'execa result.pipe() not supported on replay (no live subprocess). ' +
-          'Use SHELL_CASSETTE_MODE=passthrough for tests that pipe subprocesses.',
-      )
-    },
-    [Symbol.asyncIterator]: (): never => {
-      throw new UnsupportedOptionError(
-        'execa async iteration `for await (line of subprocess)` not supported on replay. ' +
-          'Read result.stdout (string or array form via lines option) instead.',
-      )
-    },
+    // No live subprocess on replay. kill() returns false (mirrors
+    // execa's "did not signal" return); pipe() and async iteration
+    // throw with actionable messages. Stream methods (iterable,
+    // readable, writable, duplex) are not stubbed.
+    kill: REPLAY_KILL_STUB,
+    pipe: REPLAY_PIPE_STUB,
+    [Symbol.asyncIterator]: REPLAY_ASYNC_ITER_STUB,
   }
 
   if (options.reject !== false && failed) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -53,8 +53,8 @@ function orderRecording(rec: Recording) {
       signal: rec.result.signal,
       durationMs: rec.result.durationMs,
       aborted: rec.result.aborted,
-      // Optional v0.7 flag fields. Each emitted only when defined so legacy
-      // in-memory recordings produce the same JSON shape as before.
+      // Optional flag fields. Each emitted only when defined so recordings
+      // that predate this schema produce the same JSON shape as before.
       ...(rec.result.failed !== undefined && { failed: rec.result.failed }),
       ...(rec.result.timedOut !== undefined && { timedOut: rec.result.timedOut }),
       ...(rec.result.isMaxBuffer !== undefined && { isMaxBuffer: rec.result.isMaxBuffer }),
@@ -160,6 +160,9 @@ function normalizeRecording(rec: LegacyRecording): Recording {
   return {
     call: rec.call,
     result: {
+      // Spread first so fields added after LegacyRecording was defined
+      // (allLines, aborted, and the optional flag fields) pass through
+      // from disk. Explicit assignments below fill defaults.
       ...rec.result,
       allLines: rec.result.allLines ?? null,
       aborted: rec.result.aborted ?? false,

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -53,6 +53,17 @@ function orderRecording(rec: Recording) {
       signal: rec.result.signal,
       durationMs: rec.result.durationMs,
       aborted: rec.result.aborted,
+      // Optional v0.7 flag fields. Each emitted only when defined so legacy
+      // in-memory recordings produce the same JSON shape as before.
+      ...(rec.result.failed !== undefined && { failed: rec.result.failed }),
+      ...(rec.result.timedOut !== undefined && { timedOut: rec.result.timedOut }),
+      ...(rec.result.isMaxBuffer !== undefined && { isMaxBuffer: rec.result.isMaxBuffer }),
+      ...(rec.result.isForcefullyTerminated !== undefined && {
+        isForcefullyTerminated: rec.result.isForcefullyTerminated,
+      }),
+      ...(rec.result.isGracefullyCanceled !== undefined && {
+        isGracefullyCanceled: rec.result.isGracefullyCanceled,
+      }),
     },
     _redactions: rec.redactions,
     ...(rec.suppressed.length > 0 ? { _suppressed: rec.suppressed } : {}),

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -125,7 +125,16 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
     },
   }
 
-  if ((options as { throwOnError?: boolean }).throwOnError === true && rec.result.exitCode !== 0) {
+  // Resolve failed via fallback derivation: stored value when present;
+  // otherwise derived from exit/signal/abort state. The fallback covers
+  // signal kill and aborted cases the old `exitCode !== 0` check missed
+  // and lets cassettes recorded before the field was added auto-upgrade
+  // their replay correctness without re-recording.
+  const failed =
+    rec.result.failed ??
+    (rec.result.exitCode !== 0 || rec.result.signal !== null || rec.result.aborted)
+
+  if ((options as { throwOnError?: boolean }).throwOnError === true && failed) {
     throw Object.assign(
       new Error(
         `Process exited with non-zero code: ${rec.result.exitCode} (command: ${rec.call.command})`,

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -76,16 +76,27 @@ function captureResult(raw: unknown, durationMs: number): CassetteResult {
   // tinyexec exposes only `killed: boolean`, not the actual signal name (SIGINT,
   // SIGKILL, etc.). We unconditionally record SIGTERM on kill; the real signal is
   // lost. Known limitation; tinyexec does not expose the signal name.
+  const exitCode = r.exitCode ?? 0
+  const killed = r.killed === true
+  const aborted = r.aborted === true
   return {
     stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
     stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],
     allLines: null,
-    exitCode: r.exitCode ?? 0,
-    signal: r.killed === true ? 'SIGTERM' : null,
+    exitCode,
+    signal: killed ? 'SIGTERM' : null,
     durationMs,
-    aborted: r.aborted === true,
+    aborted,
+    // Derived because tinyexec does not expose a `failed` boolean. Covers
+    // the three known failure shapes (non-zero exit, signal kill, abort).
+    // timedOut and isMaxBuffer are intentionally not stored: tinyexec
+    // exposes neither; synth defaults each to false on replay.
+    failed: exitCode !== 0 || killed || aborted,
   }
 }
+
+// Test-only export. See execa.ts for the same pattern.
+export const _captureResultForTesting = captureResult
 
 function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
   const stdout = rec.result.stdoutLines.join('\n')

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export type Result = {
   // tinyexec: r.aborted). Defaults to false on legacy cassettes that
   // predate the field; deserializer normalizes.
   aborted: boolean
+  // Optional flag fields added in v0.7. Legacy cassettes parse with these
+  // absent; synth resolves via fallback derivation so older cassettes still
+  // throw correctly on replay for aborted/signal-killed calls.
+  failed?: boolean
+  timedOut?: boolean
+  isMaxBuffer?: boolean
+  isForcefullyTerminated?: boolean
+  isGracefullyCanceled?: boolean
 }
 
 export type Recording = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,9 +22,10 @@ export type Result = {
   // tinyexec: r.aborted). Defaults to false on legacy cassettes that
   // predate the field; deserializer normalizes.
   aborted: boolean
-  // Optional flag fields added in v0.7. Legacy cassettes parse with these
-  // absent; synth resolves via fallback derivation so older cassettes still
-  // throw correctly on replay for aborted/signal-killed calls.
+  // Optional flag fields. Legacy cassettes parse with these absent
+  // (the type permits `undefined`); synth resolves missing values via
+  // fallback derivation so older cassettes still throw correctly on
+  // replay for aborted/signal-killed calls.
   failed?: boolean
   timedOut?: boolean
   isMaxBuffer?: boolean

--- a/tests/e2e/e2e-cancel-signal.test.ts
+++ b/tests/e2e/e2e-cancel-signal.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
+
+describe('e2e: cancelSignal round-trip', () => {
+  const tmp = useTmpDir('sc-e2e-cancel-')
+
+  test('real subprocess aborted via cancelSignal records aborted, replays as throw', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    await useCassette(cp, async () => {
+      const ac = new AbortController()
+      setTimeout(() => ac.abort(), 100)
+      const r = await execa('node', SLEEP_5S, { cancelSignal: ac.signal, reject: false })
+      // Real execa exposes isCanceled (the cassette stores it as aborted).
+      expect((r as { isCanceled: boolean }).isCanceled).toBe(true)
+      expect((r as { failed: boolean }).failed).toBe(true)
+    })
+
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings[0].result.aborted).toBe(true)
+    expect(cassette.recordings[0].result.failed).toBe(true)
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const ac = new AbortController()
+        await expect(execa('node', SLEEP_5S, { cancelSignal: ac.signal })).rejects.toThrow(
+          /Command failed/,
+        )
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  }, 10_000)
+})

--- a/tests/e2e/e2e-cancel-signal.test.ts
+++ b/tests/e2e/e2e-cancel-signal.test.ts
@@ -5,11 +5,10 @@ import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
+import { SLEEP_5S } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 useRecordingEnv()
-
-const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
 
 describe('e2e: cancelSignal round-trip', () => {
   const tmp = useTmpDir('sc-e2e-cancel-')

--- a/tests/e2e/e2e-timeout.test.ts
+++ b/tests/e2e/e2e-timeout.test.ts
@@ -1,0 +1,41 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
+
+describe('e2e: timeout round-trip', () => {
+  const tmp = useTmpDir('sc-e2e-timeout-')
+
+  test('real subprocess timeout records and replays with matching shape', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    await useCassette(cp, async () => {
+      const r = await execa('node', SLEEP_5S, { timeout: 200, reject: false })
+      expect((r as { timedOut: boolean }).timedOut).toBe(true)
+    })
+
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings[0].result.timedOut).toBe(true)
+    expect(cassette.recordings[0].result.failed).toBe(true)
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const r = await execa('node', SLEEP_5S, { timeout: 200, reject: false })
+        expect((r as { timedOut: boolean }).timedOut).toBe(true)
+        expect((r as { failed: boolean }).failed).toBe(true)
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  }, 10_000)
+})

--- a/tests/e2e/e2e-timeout.test.ts
+++ b/tests/e2e/e2e-timeout.test.ts
@@ -5,11 +5,10 @@ import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
+import { SLEEP_5S } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 useRecordingEnv()
-
-const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
 
 describe('e2e: timeout round-trip', () => {
   const tmp = useTmpDir('sc-e2e-timeout-')

--- a/tests/error-path/aborted-call-replays-as-throw.test.ts
+++ b/tests/error-path/aborted-call-replays-as-throw.test.ts
@@ -1,0 +1,84 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv({ mode: 'replay' })
+
+describe('error path: legacy cassette aborted call replays as throw', () => {
+  const tmp = useTmpDir('sc-legacy-aborted-')
+
+  test('legacy cassette with aborted: true (no failed field) throws on default reject', async () => {
+    const cp = path.join(tmp.ref(), 'legacy.json')
+
+    // Hand-crafted legacy cassette: no failed/timedOut/* flags.
+    // exitCode 0, no signal, aborted: true. Pre-fix code would replay as
+    // success (exitCode 0); fallback derivation throws.
+    const legacy = {
+      version: 2,
+      _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+      recordings: [
+        {
+          call: { command: 'node', args: ['-v'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['', ''],
+            stderrLines: [''],
+            allLines: null,
+            exitCode: 0,
+            signal: null,
+            durationMs: 50,
+            aborted: true,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    await writeFile(cp, JSON.stringify(legacy, null, 2), 'utf8')
+
+    await useCassette(cp, async () => {
+      let caught: unknown
+      try {
+        await execa('node', ['-v'])
+        throw new Error('should not reach')
+      } catch (e) {
+        caught = e
+      }
+      const err = caught as { name: string; failed: boolean; isCanceled: boolean }
+      expect(err.name).toBe('ExecaError')
+      expect(err.failed).toBe(true)
+      expect(err.isCanceled).toBe(true)
+    })
+  })
+
+  test('legacy cassette with signal kill (no failed field) throws on default reject', async () => {
+    const cp = path.join(tmp.ref(), 'legacy-killed.json')
+
+    const legacy = {
+      version: 2,
+      _recorded_by: { name: 'shell-cassette', version: '0.6.0' },
+      recordings: [
+        {
+          call: { command: 'node', args: ['-v'], cwd: null, env: {}, stdin: null },
+          result: {
+            stdoutLines: ['', ''],
+            stderrLines: [''],
+            allLines: null,
+            exitCode: 0,
+            signal: 'SIGTERM',
+            durationMs: 50,
+            aborted: false,
+          },
+          _redactions: [],
+        },
+      ],
+    }
+    await writeFile(cp, JSON.stringify(legacy, null, 2), 'utf8')
+
+    await useCassette(cp, async () => {
+      await expect(execa('node', ['-v'])).rejects.toThrow(/Command failed/)
+    })
+  })
+})

--- a/tests/error-path/pipe-on-replay-throws.test.ts
+++ b/tests/error-path/pipe-on-replay-throws.test.ts
@@ -1,0 +1,78 @@
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { UnsupportedOptionError } from '../../src/errors.js'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+describe('error path: subprocess-API stubs on replay (execa)', () => {
+  const tmp = useTmpDir('sc-execa-stubs-')
+
+  test('result.pipe() throws UnsupportedOptionError', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    await useCassette(cp, async () => {
+      await execa('node', ['-v'])
+    })
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const r = (await execa('node', ['-v'])) as unknown as {
+          pipe: () => unknown
+        }
+        expect(typeof r.pipe).toBe('function')
+        expect(() => r.pipe()).toThrow(UnsupportedOptionError)
+        expect(() => r.pipe()).toThrow(/passthrough/i)
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  })
+
+  test('result[Symbol.asyncIterator]() throws UnsupportedOptionError', async () => {
+    const cp = path.join(tmp.ref(), 'cassette-iter.json')
+
+    await useCassette(cp, async () => {
+      await execa('node', ['-v'])
+    })
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const r = (await execa('node', ['-v'])) as unknown as {
+          [Symbol.asyncIterator]: () => unknown
+        }
+        expect(() => r[Symbol.asyncIterator]()).toThrow(UnsupportedOptionError)
+        expect(() => r[Symbol.asyncIterator]()).toThrow(/result\.stdout/i)
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  })
+
+  test('result.kill() returns false (no-op)', async () => {
+    const cp = path.join(tmp.ref(), 'cassette-kill.json')
+
+    await useCassette(cp, async () => {
+      await execa('node', ['-v'])
+    })
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const r = (await execa('node', ['-v'])) as unknown as { kill: () => boolean }
+        expect(r.kill()).toBe(false)
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  })
+})

--- a/tests/helpers/execa-replay.ts
+++ b/tests/helpers/execa-replay.ts
@@ -1,0 +1,33 @@
+import type { Options } from 'execa'
+import { setActiveCassette } from '../../src/state.js'
+import type { Result } from '../../src/types.js'
+import { makeRecording } from './recording.js'
+import { makeSession } from './session.js'
+
+/**
+ * Build a one-recording session, set it active, force replay mode, and
+ * call execa. Caller must mock 'execa' before importing the wrapper and
+ * call this helper inside `useRecordingEnv` test scaffolding so env
+ * teardown happens at afterEach.
+ *
+ * The third arg, `defaultOptions`, lets call-sites pre-set common
+ * defaults (e.g. `{ reject: false }`) which the per-call `options`
+ * spreads over.
+ */
+export async function replayExeca(
+  options: Options,
+  resultOverrides: Partial<Result>,
+  defaultOptions: Options = {},
+): Promise<unknown> {
+  const { execa } = await import('../../src/execa.js')
+  const recording = makeRecording({
+    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
+    result: resultOverrides,
+  })
+  const session = makeSession({
+    loadedFile: { version: 2, recordedBy: null, recordings: [recording] },
+  })
+  setActiveCassette(session)
+  process.env.SHELL_CASSETTE_MODE = 'replay'
+  return execa('cmd', [], { ...defaultOptions, ...options })
+}

--- a/tests/helpers/subprocess-targets.ts
+++ b/tests/helpers/subprocess-targets.ts
@@ -1,3 +1,7 @@
 // `node -e 'process.stdin.pipe(process.stdout)'` is portable across Linux,
 // macOS, and Windows where `cat` is not stock-available.
 export const NODE_ECHO_STDIN: readonly string[] = ['-e', 'process.stdin.pipe(process.stdout)']
+
+// Long-running subprocess (5s sleep). Tests pair this with `timeout` or
+// `cancelSignal` to exercise the abort/timeout paths without flaky timing.
+export const SLEEP_5S: readonly string[] = ['-e', 'setTimeout(() => {}, 5000)']

--- a/tests/integration/record-replay-aborted.test.ts
+++ b/tests/integration/record-replay-aborted.test.ts
@@ -5,11 +5,10 @@ import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
+import { SLEEP_5S } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 useRecordingEnv()
-
-const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
 
 // Tinyexec coverage for aborted-call record/replay is tracked in #126.
 // tinyexec's awaited Output drops the OutputApi getters (aborted, killed)

--- a/tests/integration/record-replay-aborted.test.ts
+++ b/tests/integration/record-replay-aborted.test.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
+
+// Tinyexec coverage for aborted-call record/replay is tracked in #126.
+// tinyexec's awaited Output drops the OutputApi getters (aborted, killed)
+// that live on the pre-await ExecProcess, so the wrapper currently records
+// `aborted: false` even on cancelled tinyexec calls. Replay synth handles
+// the cassette field correctly; the gap is purely on the record path.
+
+describe('record + replay: aborted (execa)', () => {
+  const tmp = useTmpDir('sc-aborted-execa-')
+
+  test('cancelSignal abort records aborted/failed, replays as throw', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    // Record: real execa cancellation. The live result exposes
+    // `isCanceled` (execa's field name); the cassette stores it as
+    // `aborted` (our internal schema). Both should be true.
+    await useCassette(cp, async () => {
+      const ac = new AbortController()
+      setTimeout(() => ac.abort(), 100)
+      const r = await execa('node', SLEEP_5S, { cancelSignal: ac.signal, reject: false })
+      expect((r as { isCanceled: boolean }).isCanceled).toBe(true)
+      expect((r as { failed: boolean }).failed).toBe(true)
+    })
+
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings[0].result.aborted).toBe(true)
+    expect(cassette.recordings[0].result.failed).toBe(true)
+
+    // Replay: synth surfaces `isCanceled` from the cassette's `aborted`.
+    // Default reject behavior throws.
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const ac = new AbortController()
+        await expect(execa('node', SLEEP_5S, { cancelSignal: ac.signal })).rejects.toThrow(
+          /Command failed/,
+        )
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  })
+})

--- a/tests/integration/record-replay-forceful-kill.test.ts
+++ b/tests/integration/record-replay-forceful-kill.test.ts
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+// POSIX-only: forceKillAfterDelay relies on a SIGTERM-ignoring child.
+// Windows has no SIGTERM semantics; the equivalent escalation does not
+// exist, so there is no Windows counter-test (nothing to assert).
+const isWindows = process.platform === 'win32'
+
+// Ignore SIGTERM and idle. The wrapper's timeout fires SIGTERM, then
+// forceKillAfterDelay escalates to SIGKILL. The captured result has
+// isForcefullyTerminated: true.
+const IGNORE_SIGTERM_THEN_IDLE = [
+  '-e',
+  "process.on('SIGTERM', () => {}); setTimeout(() => {}, 5000)",
+]
+
+describe('record + replay: forceful kill (execa, POSIX-only)', () => {
+  const tmp = useTmpDir('sc-forceful-')
+
+  test.skipIf(isWindows)(
+    'isForcefullyTerminated captured, replays with matching shape',
+    async () => {
+      const cp = path.join(tmp.ref(), 'cassette.json')
+
+      await useCassette(cp, async () => {
+        const r = await execa('node', IGNORE_SIGTERM_THEN_IDLE, {
+          timeout: 100,
+          forceKillAfterDelay: 50,
+          reject: false,
+        })
+        expect((r as { isForcefullyTerminated: boolean }).isForcefullyTerminated).toBe(true)
+      })
+
+      const cassette = JSON.parse(await readFile(cp, 'utf8'))
+      expect(cassette.recordings[0].result.isForcefullyTerminated).toBe(true)
+
+      const prevMode = process.env.SHELL_CASSETTE_MODE
+      process.env.SHELL_CASSETTE_MODE = 'replay'
+      try {
+        await useCassette(cp, async () => {
+          const r = await execa('node', IGNORE_SIGTERM_THEN_IDLE, {
+            timeout: 100,
+            forceKillAfterDelay: 50,
+            reject: false,
+          })
+          expect((r as { isForcefullyTerminated: boolean }).isForcefullyTerminated).toBe(true)
+        })
+      } finally {
+        restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+      }
+    },
+  )
+})

--- a/tests/integration/record-replay-max-buffer.test.ts
+++ b/tests/integration/record-replay-max-buffer.test.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+// Print 10 KiB to stdout. With maxBuffer=1024 the call exceeds the limit.
+const PRINT_10K = ['-e', "process.stdout.write('x'.repeat(10000))"]
+
+describe('record + replay: maxBuffer (execa)', () => {
+  const tmp = useTmpDir('sc-maxbuf-')
+
+  test('isMaxBuffer + failed captured, replays with matching shape', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    await useCassette(cp, async () => {
+      // First call: record the failing result (consumed by replay's reject:false call).
+      const r = await execa('node', PRINT_10K, { maxBuffer: 1024, reject: false })
+      expect((r as { isMaxBuffer: boolean }).isMaxBuffer).toBe(true)
+      expect((r as { failed: boolean }).failed).toBe(true)
+      // Second call: record again for the replay's default-reject throw assertion.
+      await execa('node', PRINT_10K, { maxBuffer: 1024, reject: false })
+    })
+
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings[0].result.isMaxBuffer).toBe(true)
+    expect(cassette.recordings[0].result.failed).toBe(true)
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const r = await execa('node', PRINT_10K, { maxBuffer: 1024, reject: false })
+        expect((r as { isMaxBuffer: boolean }).isMaxBuffer).toBe(true)
+
+        await expect(execa('node', PRINT_10K, { maxBuffer: 1024 })).rejects.toThrow(
+          /Command failed/,
+        )
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  })
+})

--- a/tests/integration/record-replay-timeout.test.ts
+++ b/tests/integration/record-replay-timeout.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
+import { restoreEnv } from '../helpers/env.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
@@ -21,11 +22,7 @@ describe('record + replay: timeout (execa)', () => {
     let recordedTimedOut: boolean | undefined
     let recordedFailed: boolean | undefined
     await useCassette(cp, async () => {
-      try {
-        await execa('node', SLEEP_5S, { timeout: 200, reject: false })
-      } catch {
-        // reject:false: synth path returns the error-shaped result; no throw
-      }
+      await execa('node', SLEEP_5S, { timeout: 200, reject: false })
       const r = await execa('node', SLEEP_5S, { timeout: 200, reject: false })
       recordedTimedOut = (r as { timedOut: boolean }).timedOut
       recordedFailed = (r as { failed: boolean }).failed
@@ -41,6 +38,7 @@ describe('record + replay: timeout (execa)', () => {
     expect(recResult.failed).toBe(true)
 
     // Replay: same shape, throws on default reject
+    const prevMode = process.env.SHELL_CASSETTE_MODE
     process.env.SHELL_CASSETTE_MODE = 'replay'
     try {
       await useCassette(cp, async () => {
@@ -51,7 +49,7 @@ describe('record + replay: timeout (execa)', () => {
         await expect(execa('node', SLEEP_5S, { timeout: 200 })).rejects.toThrow(/Command failed/)
       })
     } finally {
-      process.env.SHELL_CASSETTE_MODE = 'auto'
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
     }
   })
 })

--- a/tests/integration/record-replay-timeout.test.ts
+++ b/tests/integration/record-replay-timeout.test.ts
@@ -5,12 +5,10 @@ import { execa } from '../../src/execa.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
+import { SLEEP_5S } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 useRecordingEnv()
-
-// Long-running script: sleeps 5s. The wrapper's timeout=200ms fires first.
-const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
 
 describe('record + replay: timeout (execa)', () => {
   const tmp = useTmpDir('sc-timeout-')

--- a/tests/integration/record-replay-timeout.test.ts
+++ b/tests/integration/record-replay-timeout.test.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { execa } from '../../src/execa.js'
+import { useCassette } from '../../src/use-cassette.js'
+import { useRecordingEnv } from '../helpers/recording-env.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+useRecordingEnv()
+
+// Long-running script: sleeps 5s. The wrapper's timeout=200ms fires first.
+const SLEEP_5S = ['-e', 'setTimeout(() => {}, 5000)']
+
+describe('record + replay: timeout (execa)', () => {
+  const tmp = useTmpDir('sc-timeout-')
+
+  test('records timedOut + failed, replays with matching shape, throws on default reject', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    // Record: real subprocess hits timeout, throws ExecaError-shaped
+    let recordedTimedOut: boolean | undefined
+    let recordedFailed: boolean | undefined
+    await useCassette(cp, async () => {
+      try {
+        await execa('node', SLEEP_5S, { timeout: 200, reject: false })
+      } catch {
+        // reject:false: synth path returns the error-shaped result; no throw
+      }
+      const r = await execa('node', SLEEP_5S, { timeout: 200, reject: false })
+      recordedTimedOut = (r as { timedOut: boolean }).timedOut
+      recordedFailed = (r as { failed: boolean }).failed
+    })
+
+    expect(recordedTimedOut).toBe(true)
+    expect(recordedFailed).toBe(true)
+
+    // Cassette stores the new fields
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    const recResult = cassette.recordings[0].result
+    expect(recResult.timedOut).toBe(true)
+    expect(recResult.failed).toBe(true)
+
+    // Replay: same shape, throws on default reject
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const r = await execa('node', SLEEP_5S, { timeout: 200, reject: false })
+        expect((r as { timedOut: boolean }).timedOut).toBe(true)
+        expect((r as { failed: boolean }).failed).toBe(true)
+
+        await expect(execa('node', SLEEP_5S, { timeout: 200 })).rejects.toThrow(/Command failed/)
+      })
+    } finally {
+      process.env.SHELL_CASSETTE_MODE = 'auto'
+    }
+  })
+})

--- a/tests/unit/execa-capture-result.test.ts
+++ b/tests/unit/execa-capture-result.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+
+// captureResult is internal; expose a thin re-export by importing the
+// adapter and using a known shape. Pure-function unit test bypasses
+// the wrapper layer entirely.
+import { _captureResultForTesting } from '../../src/execa.js'
+
+describe('execa captureResult: optional flag fields', () => {
+  test('reads all five flags when present and true', () => {
+    const r = _captureResultForTesting(
+      {
+        stdout: 'ok',
+        stderr: '',
+        exitCode: 0,
+        signal: null,
+        isCanceled: false,
+        failed: true,
+        timedOut: true,
+        isMaxBuffer: true,
+        isForcefullyTerminated: true,
+        isGracefullyCanceled: true,
+      },
+      42,
+    )
+    expect(r.failed).toBe(true)
+    expect(r.timedOut).toBe(true)
+    expect(r.isMaxBuffer).toBe(true)
+    expect(r.isForcefullyTerminated).toBe(true)
+    expect(r.isGracefullyCanceled).toBe(true)
+    expect(r.durationMs).toBe(42)
+  })
+
+  test('absent flags default to false (not undefined)', () => {
+    const r = _captureResultForTesting({ stdout: '', stderr: '', exitCode: 0 }, 1)
+    expect(r.failed).toBe(false)
+    expect(r.timedOut).toBe(false)
+    expect(r.isMaxBuffer).toBe(false)
+    expect(r.isForcefullyTerminated).toBe(false)
+    expect(r.isGracefullyCanceled).toBe(false)
+  })
+
+  test('non-true truthy values (e.g. truthy strings) coerce to false', () => {
+    // execa types these as boolean. The === true idiom guards against any
+    // accidental string-leaks from real execa shape changes.
+    const r = _captureResultForTesting(
+      {
+        stdout: '',
+        stderr: '',
+        exitCode: 1,
+        failed: 1 as unknown as boolean,
+        timedOut: 'yes' as unknown as boolean,
+      },
+      1,
+    )
+    expect(r.failed).toBe(false)
+    expect(r.timedOut).toBe(false)
+  })
+})

--- a/tests/unit/execa-synthesize-failed.test.ts
+++ b/tests/unit/execa-synthesize-failed.test.ts
@@ -1,6 +1,8 @@
 import type { Options } from 'execa'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { Result } from '../../src/types.js'
+import { restoreEnv } from '../helpers/env.js'
 import { makeRecording } from '../helpers/recording.js'
 import { makeSession } from '../helpers/session.js'
 
@@ -9,10 +11,9 @@ vi.mock('execa', () => ({ execa: vi.fn() }))
 const { execa: realExecaMock } = await import('execa')
 const { execa } = await import('../../src/execa.js')
 
-async function replayWith(
-  options: Options,
-  resultOverrides: Parameters<typeof makeRecording>[0] extends { result?: infer R } ? R : never,
-): Promise<unknown> {
+const originalMode = process.env.SHELL_CASSETTE_MODE
+
+async function replayWith(options: Options, resultOverrides: Partial<Result>): Promise<unknown> {
   const recording = makeRecording({
     call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
     result: resultOverrides,
@@ -37,6 +38,7 @@ describe('execa synthesize: failed resolution', () => {
   afterEach(() => {
     _resetForTesting()
     clearActiveCassette()
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
   })
 
   test('explicit failed: true throws when reject not false', async () => {

--- a/tests/unit/execa-synthesize-failed.test.ts
+++ b/tests/unit/execa-synthesize-failed.test.ts
@@ -1,0 +1,91 @@
+import type { Options } from 'execa'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import { makeRecording } from '../helpers/recording.js'
+import { makeSession } from '../helpers/session.js'
+
+vi.mock('execa', () => ({ execa: vi.fn() }))
+
+const { execa: realExecaMock } = await import('execa')
+const { execa } = await import('../../src/execa.js')
+
+async function replayWith(
+  options: Options,
+  resultOverrides: Parameters<typeof makeRecording>[0] extends { result?: infer R } ? R : never,
+): Promise<unknown> {
+  const recording = makeRecording({
+    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
+    result: resultOverrides,
+  })
+  const session = makeSession({
+    loadedFile: { version: 2, recordedBy: null, recordings: [recording] },
+  })
+  setActiveCassette(session)
+  process.env.SHELL_CASSETTE_MODE = 'replay'
+  return await execa('cmd', [], options)
+}
+
+describe('execa synthesize: failed resolution', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    vi.mocked(realExecaMock).mockReset()
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+  })
+
+  test('explicit failed: true throws when reject not false', async () => {
+    await expect(
+      replayWith({}, { exitCode: 0, signal: null, aborted: false, failed: true }),
+    ).rejects.toThrow(/Command failed/)
+  })
+
+  test('explicit failed: false succeeds even when exitCode is non-zero', async () => {
+    const r = (await replayWith(
+      {},
+      { exitCode: 1, signal: null, aborted: false, failed: false },
+    )) as {
+      failed: boolean
+    }
+    expect(r.failed).toBe(false)
+  })
+
+  test('legacy cassette (no failed field), exitCode !== 0: derives failed → throws', async () => {
+    await expect(replayWith({}, { exitCode: 1, signal: null, aborted: false })).rejects.toThrow(
+      /Command failed/,
+    )
+  })
+
+  test('legacy cassette, signal kill (exitCode 0, signal SIGTERM): derives failed → throws', async () => {
+    await expect(
+      replayWith({}, { exitCode: 0, signal: 'SIGTERM', aborted: false }),
+    ).rejects.toThrow(/Command failed/)
+  })
+
+  test('legacy cassette, aborted (exitCode 0, no signal, aborted true): derives failed → throws', async () => {
+    await expect(replayWith({}, { exitCode: 0, signal: null, aborted: true })).rejects.toThrow(
+      /Command failed/,
+    )
+  })
+
+  test('legacy cassette, plain success (exitCode 0, no signal, not aborted): does not throw', async () => {
+    const r = (await replayWith({}, { exitCode: 0, signal: null, aborted: false })) as {
+      failed: boolean
+    }
+    expect(r.failed).toBe(false)
+  })
+
+  test('reject: false suppresses throw even when failed resolves true', async () => {
+    const r = (await replayWith(
+      { reject: false },
+      { exitCode: 1, signal: null, aborted: false, failed: true },
+    )) as { failed: boolean; exitCode: number }
+    expect(r.failed).toBe(true)
+    expect(r.exitCode).toBe(1)
+  })
+})

--- a/tests/unit/execa-synthesize-failed.test.ts
+++ b/tests/unit/execa-synthesize-failed.test.ts
@@ -1,30 +1,13 @@
-import type { Options } from 'execa'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { Result } from '../../src/types.js'
+import { _resetForTesting, clearActiveCassette } from '../../src/state.js'
 import { restoreEnv } from '../helpers/env.js'
-import { makeRecording } from '../helpers/recording.js'
-import { makeSession } from '../helpers/session.js'
+import { replayExeca } from '../helpers/execa-replay.js'
 
 vi.mock('execa', () => ({ execa: vi.fn() }))
 
 const { execa: realExecaMock } = await import('execa')
-const { execa } = await import('../../src/execa.js')
 
 const originalMode = process.env.SHELL_CASSETTE_MODE
-
-async function replayWith(options: Options, resultOverrides: Partial<Result>): Promise<unknown> {
-  const recording = makeRecording({
-    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
-    result: resultOverrides,
-  })
-  const session = makeSession({
-    loadedFile: { version: 2, recordedBy: null, recordings: [recording] },
-  })
-  setActiveCassette(session)
-  process.env.SHELL_CASSETTE_MODE = 'replay'
-  return await execa('cmd', [], options)
-}
 
 describe('execa synthesize: failed resolution', () => {
   beforeEach(() => {
@@ -43,12 +26,12 @@ describe('execa synthesize: failed resolution', () => {
 
   test('explicit failed: true throws when reject not false', async () => {
     await expect(
-      replayWith({}, { exitCode: 0, signal: null, aborted: false, failed: true }),
+      replayExeca({}, { exitCode: 0, signal: null, aborted: false, failed: true }),
     ).rejects.toThrow(/Command failed/)
   })
 
   test('explicit failed: false succeeds even when exitCode is non-zero', async () => {
-    const r = (await replayWith(
+    const r = (await replayExeca(
       {},
       { exitCode: 1, signal: null, aborted: false, failed: false },
     )) as {
@@ -58,32 +41,32 @@ describe('execa synthesize: failed resolution', () => {
   })
 
   test('legacy cassette (no failed field), exitCode !== 0: derives failed → throws', async () => {
-    await expect(replayWith({}, { exitCode: 1, signal: null, aborted: false })).rejects.toThrow(
+    await expect(replayExeca({}, { exitCode: 1, signal: null, aborted: false })).rejects.toThrow(
       /Command failed/,
     )
   })
 
   test('legacy cassette, signal kill (exitCode 0, signal SIGTERM): derives failed → throws', async () => {
     await expect(
-      replayWith({}, { exitCode: 0, signal: 'SIGTERM', aborted: false }),
+      replayExeca({}, { exitCode: 0, signal: 'SIGTERM', aborted: false }),
     ).rejects.toThrow(/Command failed/)
   })
 
   test('legacy cassette, aborted (exitCode 0, no signal, aborted true): derives failed → throws', async () => {
-    await expect(replayWith({}, { exitCode: 0, signal: null, aborted: true })).rejects.toThrow(
+    await expect(replayExeca({}, { exitCode: 0, signal: null, aborted: true })).rejects.toThrow(
       /Command failed/,
     )
   })
 
   test('legacy cassette, plain success (exitCode 0, no signal, not aborted): does not throw', async () => {
-    const r = (await replayWith({}, { exitCode: 0, signal: null, aborted: false })) as {
+    const r = (await replayExeca({}, { exitCode: 0, signal: null, aborted: false })) as {
       failed: boolean
     }
     expect(r.failed).toBe(false)
   })
 
   test('reject: false suppresses throw even when failed resolves true', async () => {
-    const r = (await replayWith(
+    const r = (await replayExeca(
       { reject: false },
       { exitCode: 1, signal: null, aborted: false, failed: true },
     )) as { failed: boolean; exitCode: number }

--- a/tests/unit/execa-synthesize-flags.test.ts
+++ b/tests/unit/execa-synthesize-flags.test.ts
@@ -1,0 +1,93 @@
+import type { Options } from 'execa'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { Result } from '../../src/types.js'
+import { restoreEnv } from '../helpers/env.js'
+import { makeRecording } from '../helpers/recording.js'
+import { makeSession } from '../helpers/session.js'
+
+vi.mock('execa', () => ({ execa: vi.fn() }))
+
+const { execa: realExecaMock } = await import('execa')
+const { execa } = await import('../../src/execa.js')
+
+const originalMode = process.env.SHELL_CASSETTE_MODE
+
+async function replayWith(options: Options, resultOverrides: Partial<Result>): Promise<unknown> {
+  const rec = makeRecording({
+    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
+    result: resultOverrides,
+  })
+  const session = makeSession({
+    loadedFile: { version: 2, recordedBy: null, recordings: [rec] },
+  })
+  setActiveCassette(session)
+  process.env.SHELL_CASSETTE_MODE = 'replay'
+  return await execa('cmd', [], { reject: false, ...options })
+}
+
+describe('execa synthesize: flag completeness', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    vi.mocked(realExecaMock).mockReset()
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+  })
+
+  test('plain success: all flags reachable as false', async () => {
+    const r = (await replayWith({}, {})) as Record<string, unknown>
+    expect(r.failed).toBe(false)
+    expect(r.timedOut).toBe(false)
+    expect(r.isCanceled).toBe(false)
+    expect(r.isMaxBuffer).toBe(false)
+    expect(r.isTerminated).toBe(false)
+    expect(r.isForcefullyTerminated).toBe(false)
+    expect(r.isGracefullyCanceled).toBe(false)
+    expect(r.killed).toBe(false)
+    expect(r.pipedFrom).toEqual([])
+    expect(r.ipcOutput).toEqual([])
+  })
+
+  test('signal-killed: isTerminated and killed are true; signal field set', async () => {
+    const r = (await replayWith({}, { signal: 'SIGKILL' })) as Record<string, unknown>
+    expect(r.signal).toBe('SIGKILL')
+    expect(r.killed).toBe(true)
+    expect(r.isTerminated).toBe(true)
+    expect(r.failed).toBe(true)
+  })
+
+  test('isMaxBuffer stored: surfaces on replay', async () => {
+    const r = (await replayWith({}, { isMaxBuffer: true, failed: true })) as Record<string, unknown>
+    expect(r.isMaxBuffer).toBe(true)
+    expect(r.failed).toBe(true)
+  })
+
+  test('isForcefullyTerminated and isGracefullyCanceled stored: surface on replay', async () => {
+    const r = (await replayWith(
+      {},
+      { isForcefullyTerminated: true, isGracefullyCanceled: true },
+    )) as Record<string, unknown>
+    expect(r.isForcefullyTerminated).toBe(true)
+    expect(r.isGracefullyCanceled).toBe(true)
+  })
+
+  test('timedOut stored: surfaces on replay', async () => {
+    const r = (await replayWith({}, { timedOut: true, signal: 'SIGTERM' })) as Record<
+      string,
+      unknown
+    >
+    expect(r.timedOut).toBe(true)
+  })
+
+  test('isCanceled mirrors aborted', async () => {
+    const r = (await replayWith({}, { aborted: true })) as Record<string, unknown>
+    expect(r.isCanceled).toBe(true)
+  })
+})

--- a/tests/unit/execa-synthesize-flags.test.ts
+++ b/tests/unit/execa-synthesize-flags.test.ts
@@ -1,30 +1,13 @@
-import type { Options } from 'execa'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { Result } from '../../src/types.js'
+import { _resetForTesting, clearActiveCassette } from '../../src/state.js'
 import { restoreEnv } from '../helpers/env.js'
-import { makeRecording } from '../helpers/recording.js'
-import { makeSession } from '../helpers/session.js'
+import { replayExeca } from '../helpers/execa-replay.js'
 
 vi.mock('execa', () => ({ execa: vi.fn() }))
 
 const { execa: realExecaMock } = await import('execa')
-const { execa } = await import('../../src/execa.js')
 
 const originalMode = process.env.SHELL_CASSETTE_MODE
-
-async function replayWith(options: Options, resultOverrides: Partial<Result>): Promise<unknown> {
-  const rec = makeRecording({
-    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
-    result: resultOverrides,
-  })
-  const session = makeSession({
-    loadedFile: { version: 2, recordedBy: null, recordings: [rec] },
-  })
-  setActiveCassette(session)
-  process.env.SHELL_CASSETTE_MODE = 'replay'
-  return await execa('cmd', [], { reject: false, ...options })
-}
 
 describe('execa synthesize: flag completeness', () => {
   beforeEach(() => {
@@ -42,7 +25,7 @@ describe('execa synthesize: flag completeness', () => {
   })
 
   test('plain success: all flags reachable as false', async () => {
-    const r = (await replayWith({}, {})) as Record<string, unknown>
+    const r = (await replayExeca({}, {}, { reject: false })) as Record<string, unknown>
     expect(r.failed).toBe(false)
     expect(r.timedOut).toBe(false)
     expect(r.isCanceled).toBe(false)
@@ -56,7 +39,10 @@ describe('execa synthesize: flag completeness', () => {
   })
 
   test('signal-killed: isTerminated and killed are true; signal field set', async () => {
-    const r = (await replayWith({}, { signal: 'SIGKILL' })) as Record<string, unknown>
+    const r = (await replayExeca({}, { signal: 'SIGKILL' }, { reject: false })) as Record<
+      string,
+      unknown
+    >
     expect(r.signal).toBe('SIGKILL')
     expect(r.killed).toBe(true)
     expect(r.isTerminated).toBe(true)
@@ -64,30 +50,39 @@ describe('execa synthesize: flag completeness', () => {
   })
 
   test('isMaxBuffer stored: surfaces on replay', async () => {
-    const r = (await replayWith({}, { isMaxBuffer: true, failed: true })) as Record<string, unknown>
+    const r = (await replayExeca(
+      {},
+      { isMaxBuffer: true, failed: true },
+      { reject: false },
+    )) as Record<string, unknown>
     expect(r.isMaxBuffer).toBe(true)
     expect(r.failed).toBe(true)
   })
 
   test('isForcefullyTerminated and isGracefullyCanceled stored: surface on replay', async () => {
-    const r = (await replayWith(
+    const r = (await replayExeca(
       {},
       { isForcefullyTerminated: true, isGracefullyCanceled: true },
+      { reject: false },
     )) as Record<string, unknown>
     expect(r.isForcefullyTerminated).toBe(true)
     expect(r.isGracefullyCanceled).toBe(true)
   })
 
   test('timedOut stored: surfaces on replay', async () => {
-    const r = (await replayWith({}, { timedOut: true, signal: 'SIGTERM' })) as Record<
-      string,
-      unknown
-    >
+    const r = (await replayExeca(
+      {},
+      { timedOut: true, signal: 'SIGTERM' },
+      { reject: false },
+    )) as Record<string, unknown>
     expect(r.timedOut).toBe(true)
   })
 
   test('isCanceled mirrors aborted', async () => {
-    const r = (await replayWith({}, { aborted: true })) as Record<string, unknown>
+    const r = (await replayExeca({}, { aborted: true }, { reject: false })) as Record<
+      string,
+      unknown
+    >
     expect(r.isCanceled).toBe(true)
   })
 })

--- a/tests/unit/execa-synthesize-stubs.test.ts
+++ b/tests/unit/execa-synthesize-stubs.test.ts
@@ -1,0 +1,91 @@
+import type { Options } from 'execa'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ShellCassetteError } from '../../src/errors.js'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { Result } from '../../src/types.js'
+import { restoreEnv } from '../helpers/env.js'
+import { makeRecording } from '../helpers/recording.js'
+import { makeSession } from '../helpers/session.js'
+
+vi.mock('execa', () => ({ execa: vi.fn() }))
+
+const { execa: realExecaMock } = await import('execa')
+const { execa } = await import('../../src/execa.js')
+
+const originalMode = process.env.SHELL_CASSETTE_MODE
+
+async function replayWith(
+  options: Options,
+  resultOverrides: Partial<Result> = {},
+): Promise<unknown> {
+  const rec = makeRecording({
+    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
+    result: resultOverrides,
+  })
+  const session = makeSession({
+    loadedFile: { version: 2, recordedBy: null, recordings: [rec] },
+  })
+  setActiveCassette(session)
+  process.env.SHELL_CASSETTE_MODE = 'replay'
+  return await execa('cmd', [], { reject: false, ...options })
+}
+
+describe('execa synthesize: subprocess-API stubs', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    vi.mocked(realExecaMock).mockReset()
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+  })
+
+  test('result.kill() returns false (no-op; no live subprocess to signal)', async () => {
+    const r = (await replayWith({}, {})) as { kill: () => boolean }
+    expect(typeof r.kill).toBe('function')
+    expect(r.kill()).toBe(false)
+  })
+
+  test('result.kill(signal) returns false and accepts signal arg without effect', async () => {
+    const r = (await replayWith({}, {})) as { kill: (sig?: string) => boolean }
+    expect(r.kill('SIGTERM')).toBe(false)
+  })
+
+  test('result.pipe() throws ShellCassetteError with passthrough hint', async () => {
+    const r = (await replayWith({}, {})) as { pipe: () => unknown }
+    expect(() => r.pipe()).toThrow(ShellCassetteError)
+    expect(() => r.pipe()).toThrow(/passthrough/i)
+  })
+
+  test('result[Symbol.asyncIterator]() throws ShellCassetteError with read-result hint', async () => {
+    const r = (await replayWith({}, {})) as Record<string | symbol, unknown> & {
+      [Symbol.asyncIterator]: () => unknown
+    }
+    expect(() => r[Symbol.asyncIterator]()).toThrow(ShellCassetteError)
+    expect(() => r[Symbol.asyncIterator]()).toThrow(/result\.stdout/i)
+  })
+
+  test('thrown error (failed cassette) carries kill/pipe/asyncIterator methods', async () => {
+    let caught: unknown
+    try {
+      await replayWith({ reject: true }, { exitCode: 1, failed: true })
+      throw new Error('should not reach')
+    } catch (e) {
+      caught = e
+    }
+    const err = caught as Record<string | symbol, unknown> & {
+      kill: () => boolean
+      pipe: () => unknown
+      [Symbol.asyncIterator]: () => unknown
+    }
+    expect(typeof err.kill).toBe('function')
+    expect(err.kill()).toBe(false)
+    expect(() => err.pipe()).toThrow(ShellCassetteError)
+    expect(() => err[Symbol.asyncIterator]()).toThrow(ShellCassetteError)
+  })
+})

--- a/tests/unit/execa-synthesize-stubs.test.ts
+++ b/tests/unit/execa-synthesize-stubs.test.ts
@@ -1,6 +1,6 @@
 import type { Options } from 'execa'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { ShellCassetteError } from '../../src/errors.js'
+import { UnsupportedOptionError } from '../../src/errors.js'
 import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
 import type { Result } from '../../src/types.js'
 import { restoreEnv } from '../helpers/env.js'
@@ -56,17 +56,17 @@ describe('execa synthesize: subprocess-API stubs', () => {
     expect(r.kill('SIGTERM')).toBe(false)
   })
 
-  test('result.pipe() throws ShellCassetteError with passthrough hint', async () => {
+  test('result.pipe() throws UnsupportedOptionError with passthrough hint', async () => {
     const r = (await replayWith({}, {})) as { pipe: () => unknown }
-    expect(() => r.pipe()).toThrow(ShellCassetteError)
+    expect(() => r.pipe()).toThrow(UnsupportedOptionError)
     expect(() => r.pipe()).toThrow(/passthrough/i)
   })
 
-  test('result[Symbol.asyncIterator]() throws ShellCassetteError with read-result hint', async () => {
+  test('result[Symbol.asyncIterator]() throws UnsupportedOptionError with read-result hint', async () => {
     const r = (await replayWith({}, {})) as Record<string | symbol, unknown> & {
       [Symbol.asyncIterator]: () => unknown
     }
-    expect(() => r[Symbol.asyncIterator]()).toThrow(ShellCassetteError)
+    expect(() => r[Symbol.asyncIterator]()).toThrow(UnsupportedOptionError)
     expect(() => r[Symbol.asyncIterator]()).toThrow(/result\.stdout/i)
   })
 
@@ -85,7 +85,7 @@ describe('execa synthesize: subprocess-API stubs', () => {
     }
     expect(typeof err.kill).toBe('function')
     expect(err.kill()).toBe(false)
-    expect(() => err.pipe()).toThrow(ShellCassetteError)
-    expect(() => err[Symbol.asyncIterator]()).toThrow(ShellCassetteError)
+    expect(() => err.pipe()).toThrow(UnsupportedOptionError)
+    expect(() => err[Symbol.asyncIterator]()).toThrow(UnsupportedOptionError)
   })
 })

--- a/tests/unit/execa-synthesize-stubs.test.ts
+++ b/tests/unit/execa-synthesize-stubs.test.ts
@@ -1,34 +1,14 @@
-import type { Options } from 'execa'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { UnsupportedOptionError } from '../../src/errors.js'
-import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
-import type { Result } from '../../src/types.js'
+import { _resetForTesting, clearActiveCassette } from '../../src/state.js'
 import { restoreEnv } from '../helpers/env.js'
-import { makeRecording } from '../helpers/recording.js'
-import { makeSession } from '../helpers/session.js'
+import { replayExeca } from '../helpers/execa-replay.js'
 
 vi.mock('execa', () => ({ execa: vi.fn() }))
 
 const { execa: realExecaMock } = await import('execa')
-const { execa } = await import('../../src/execa.js')
 
 const originalMode = process.env.SHELL_CASSETTE_MODE
-
-async function replayWith(
-  options: Options,
-  resultOverrides: Partial<Result> = {},
-): Promise<unknown> {
-  const rec = makeRecording({
-    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
-    result: resultOverrides,
-  })
-  const session = makeSession({
-    loadedFile: { version: 2, recordedBy: null, recordings: [rec] },
-  })
-  setActiveCassette(session)
-  process.env.SHELL_CASSETTE_MODE = 'replay'
-  return await execa('cmd', [], { reject: false, ...options })
-}
 
 describe('execa synthesize: subprocess-API stubs', () => {
   beforeEach(() => {
@@ -46,24 +26,24 @@ describe('execa synthesize: subprocess-API stubs', () => {
   })
 
   test('result.kill() returns false (no-op; no live subprocess to signal)', async () => {
-    const r = (await replayWith({}, {})) as { kill: () => boolean }
+    const r = (await replayExeca({}, {}, { reject: false })) as { kill: () => boolean }
     expect(typeof r.kill).toBe('function')
     expect(r.kill()).toBe(false)
   })
 
   test('result.kill(signal) returns false and accepts signal arg without effect', async () => {
-    const r = (await replayWith({}, {})) as { kill: (sig?: string) => boolean }
+    const r = (await replayExeca({}, {}, { reject: false })) as { kill: (sig?: string) => boolean }
     expect(r.kill('SIGTERM')).toBe(false)
   })
 
   test('result.pipe() throws UnsupportedOptionError with passthrough hint', async () => {
-    const r = (await replayWith({}, {})) as { pipe: () => unknown }
+    const r = (await replayExeca({}, {}, { reject: false })) as { pipe: () => unknown }
     expect(() => r.pipe()).toThrow(UnsupportedOptionError)
     expect(() => r.pipe()).toThrow(/passthrough/i)
   })
 
   test('result[Symbol.asyncIterator]() throws UnsupportedOptionError with read-result hint', async () => {
-    const r = (await replayWith({}, {})) as Record<string | symbol, unknown> & {
+    const r = (await replayExeca({}, {}, { reject: false })) as Record<string | symbol, unknown> & {
       [Symbol.asyncIterator]: () => unknown
     }
     expect(() => r[Symbol.asyncIterator]()).toThrow(UnsupportedOptionError)
@@ -73,7 +53,7 @@ describe('execa synthesize: subprocess-API stubs', () => {
   test('thrown error (failed cassette) carries kill/pipe/asyncIterator methods', async () => {
     let caught: unknown
     try {
-      await replayWith({ reject: true }, { exitCode: 1, failed: true })
+      await replayExeca({ reject: true }, { exitCode: 1, failed: true }, { reject: false })
       throw new Error('should not reach')
     } catch (e) {
       caught = e

--- a/tests/unit/serialize-result-flags.test.ts
+++ b/tests/unit/serialize-result-flags.test.ts
@@ -1,42 +1,21 @@
 import { describe, expect, test } from 'vitest'
 import { deserialize, serialize } from '../../src/serialize.js'
-import type { CassetteFile, Recording } from '../../src/types.js'
-
-const recording = (overrides: Partial<Recording['result']> = {}): Recording => ({
-  call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
-  result: {
-    stdoutLines: [''],
-    stderrLines: [''],
-    allLines: null,
-    exitCode: 0,
-    signal: null,
-    durationMs: 1,
-    aborted: false,
-    ...overrides,
-  },
-  redactions: [],
-  suppressed: [],
-})
-
-const wrap = (rec: Recording): CassetteFile => ({
-  version: 2,
-  recordedBy: null,
-  recordings: [rec],
-})
+import type { CassetteFile } from '../../src/types.js'
+import { makeRecording } from '../helpers/recording.js'
 
 describe('serialize: optional Result flag fields', () => {
   test('emits all five flag fields when defined', () => {
-    const json = serialize(
-      wrap(
-        recording({
-          failed: true,
-          timedOut: true,
-          isMaxBuffer: true,
-          isForcefullyTerminated: true,
-          isGracefullyCanceled: true,
-        }),
-      ),
-    )
+    const rec = makeRecording({
+      result: {
+        failed: true,
+        timedOut: true,
+        isMaxBuffer: true,
+        isForcefullyTerminated: true,
+        isGracefullyCanceled: true,
+      },
+    })
+    const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [rec] }
+    const json = serialize(cassette)
     const parsed = JSON.parse(json)
     const r = parsed.recordings[0].result
     expect(r.failed).toBe(true)
@@ -47,7 +26,9 @@ describe('serialize: optional Result flag fields', () => {
   })
 
   test('omits fields that are undefined on the in-memory recording', () => {
-    const json = serialize(wrap(recording()))
+    const rec = makeRecording()
+    const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [rec] }
+    const json = serialize(cassette)
     const parsed = JSON.parse(json)
     const r = parsed.recordings[0].result
     expect('failed' in r).toBe(false)
@@ -58,7 +39,8 @@ describe('serialize: optional Result flag fields', () => {
   })
 
   test('round-trips: serialize then deserialize preserves set fields', () => {
-    const original = wrap(recording({ failed: true, timedOut: false, isMaxBuffer: true }))
+    const rec = makeRecording({ result: { failed: true, timedOut: false, isMaxBuffer: true } })
+    const original: CassetteFile = { version: 2, recordedBy: null, recordings: [rec] }
     const round = deserialize(serialize(original))
     const r = round.recordings[0].result
     expect(r.failed).toBe(true)
@@ -69,7 +51,9 @@ describe('serialize: optional Result flag fields', () => {
   })
 
   test('canonical key order: flags appear after `aborted`', () => {
-    const json = serialize(wrap(recording({ failed: true, timedOut: true })))
+    const rec = makeRecording({ result: { failed: true, timedOut: true } })
+    const cassette: CassetteFile = { version: 2, recordedBy: null, recordings: [rec] }
+    const json = serialize(cassette)
     const resultText = json.slice(json.indexOf('"result"'), json.indexOf('"_redactions"'))
     expect(resultText.indexOf('"aborted"')).toBeLessThan(resultText.indexOf('"failed"'))
     expect(resultText.indexOf('"failed"')).toBeLessThan(resultText.indexOf('"timedOut"'))

--- a/tests/unit/serialize-result-flags.test.ts
+++ b/tests/unit/serialize-result-flags.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { deserialize, serialize } from '../../src/serialize.js'
+import type { CassetteFile, Recording } from '../../src/types.js'
+
+const recording = (overrides: Partial<Recording['result']> = {}): Recording => ({
+  call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
+  result: {
+    stdoutLines: [''],
+    stderrLines: [''],
+    allLines: null,
+    exitCode: 0,
+    signal: null,
+    durationMs: 1,
+    aborted: false,
+    ...overrides,
+  },
+  redactions: [],
+  suppressed: [],
+})
+
+const wrap = (rec: Recording): CassetteFile => ({
+  version: 2,
+  recordedBy: null,
+  recordings: [rec],
+})
+
+describe('serialize: optional Result flag fields', () => {
+  test('emits all five flag fields when defined', () => {
+    const json = serialize(
+      wrap(
+        recording({
+          failed: true,
+          timedOut: true,
+          isMaxBuffer: true,
+          isForcefullyTerminated: true,
+          isGracefullyCanceled: true,
+        }),
+      ),
+    )
+    const parsed = JSON.parse(json)
+    const r = parsed.recordings[0].result
+    expect(r.failed).toBe(true)
+    expect(r.timedOut).toBe(true)
+    expect(r.isMaxBuffer).toBe(true)
+    expect(r.isForcefullyTerminated).toBe(true)
+    expect(r.isGracefullyCanceled).toBe(true)
+  })
+
+  test('omits fields that are undefined on the in-memory recording', () => {
+    const json = serialize(wrap(recording()))
+    const parsed = JSON.parse(json)
+    const r = parsed.recordings[0].result
+    expect('failed' in r).toBe(false)
+    expect('timedOut' in r).toBe(false)
+    expect('isMaxBuffer' in r).toBe(false)
+    expect('isForcefullyTerminated' in r).toBe(false)
+    expect('isGracefullyCanceled' in r).toBe(false)
+  })
+
+  test('round-trips: serialize then deserialize preserves set fields', () => {
+    const original = wrap(recording({ failed: true, timedOut: false, isMaxBuffer: true }))
+    const round = deserialize(serialize(original))
+    const r = round.recordings[0].result
+    expect(r.failed).toBe(true)
+    expect(r.timedOut).toBe(false)
+    expect(r.isMaxBuffer).toBe(true)
+    expect(r.isForcefullyTerminated).toBeUndefined()
+    expect(r.isGracefullyCanceled).toBeUndefined()
+  })
+
+  test('canonical key order: flags appear after `aborted`', () => {
+    const json = serialize(wrap(recording({ failed: true, timedOut: true })))
+    const resultText = json.slice(json.indexOf('"result"'), json.indexOf('"_redactions"'))
+    expect(resultText.indexOf('"aborted"')).toBeLessThan(resultText.indexOf('"failed"'))
+    expect(resultText.indexOf('"failed"')).toBeLessThan(resultText.indexOf('"timedOut"'))
+  })
+})

--- a/tests/unit/tinyexec-capture-result.test.ts
+++ b/tests/unit/tinyexec-capture-result.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+
+import { _captureResultForTesting } from '../../src/tinyexec.js'
+
+describe('tinyexec captureResult: failed derivation', () => {
+  test('plain success (exitCode 0, no kill, no abort): failed false', () => {
+    const r = _captureResultForTesting(
+      { stdout: 'ok', stderr: '', exitCode: 0, killed: false, aborted: false },
+      1,
+    )
+    expect(r.failed).toBe(false)
+  })
+
+  test('non-zero exit: failed true', () => {
+    const r = _captureResultForTesting(
+      { stdout: '', stderr: 'oops', exitCode: 1, killed: false, aborted: false },
+      1,
+    )
+    expect(r.failed).toBe(true)
+  })
+
+  test('killed: failed true (signal kill collapses to SIGTERM in this adapter)', () => {
+    const r = _captureResultForTesting(
+      { stdout: '', stderr: '', exitCode: 0, killed: true, aborted: false },
+      1,
+    )
+    expect(r.failed).toBe(true)
+    expect(r.signal).toBe('SIGTERM')
+  })
+
+  test('aborted: failed true', () => {
+    const r = _captureResultForTesting(
+      { stdout: '', stderr: '', exitCode: 0, killed: false, aborted: true },
+      1,
+    )
+    expect(r.failed).toBe(true)
+    expect(r.aborted).toBe(true)
+  })
+
+  test('timedOut and isMaxBuffer not stored (tinyexec does not expose)', () => {
+    const r = _captureResultForTesting(
+      { stdout: '', stderr: '', exitCode: 0, killed: false, aborted: false },
+      1,
+    ) as Record<string, unknown>
+    expect(r.timedOut).toBeUndefined()
+    expect(r.isMaxBuffer).toBeUndefined()
+  })
+})

--- a/tests/unit/tinyexec-synthesize-failed.test.ts
+++ b/tests/unit/tinyexec-synthesize-failed.test.ts
@@ -1,0 +1,84 @@
+import type { Options } from 'tinyexec'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { Result } from '../../src/types.js'
+import { restoreEnv } from '../helpers/env.js'
+import { makeRecording } from '../helpers/recording.js'
+import { makeSession } from '../helpers/session.js'
+
+vi.mock('tinyexec', () => ({ x: vi.fn() }))
+
+const { x: realXMock } = await import('tinyexec')
+const { x } = await import('../../src/tinyexec.js')
+
+const originalMode = process.env.SHELL_CASSETTE_MODE
+
+async function replayWith(
+  options: Partial<Options>,
+  resultOverrides: Partial<Result>,
+): Promise<unknown> {
+  const rec = makeRecording({
+    call: { command: 'cmd', args: [], cwd: null, env: {}, stdin: null },
+    result: resultOverrides,
+  })
+  const session = makeSession({
+    loadedFile: { version: 2, recordedBy: null, recordings: [rec] },
+  })
+  setActiveCassette(session)
+  process.env.SHELL_CASSETTE_MODE = 'replay'
+  return await x('cmd', [], options)
+}
+
+describe('tinyexec synthesize: failed resolution', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    vi.mocked(realXMock).mockReset()
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.SHELL_CASSETTE_ACK_REDACTION
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+  })
+
+  test('throwOnError true, explicit failed: true throws', async () => {
+    await expect(
+      replayWith(
+        { throwOnError: true },
+        { exitCode: 0, signal: null, aborted: false, failed: true },
+      ),
+    ).rejects.toThrow(/Process exited with non-zero code/)
+  })
+
+  test('throwOnError true, legacy cassette signal kill (no failed field) throws via fallback', async () => {
+    await expect(
+      replayWith({ throwOnError: true }, { exitCode: 0, signal: 'SIGTERM', aborted: false }),
+    ).rejects.toThrow(/Process exited/)
+  })
+
+  test('throwOnError true, legacy cassette aborted (no failed field) throws via fallback', async () => {
+    await expect(
+      replayWith({ throwOnError: true }, { exitCode: 0, signal: null, aborted: true }),
+    ).rejects.toThrow(/Process exited/)
+  })
+
+  test('throwOnError true, plain success (exitCode 0, no signal, not aborted) does not throw', async () => {
+    const r = (await replayWith(
+      { throwOnError: true },
+      { exitCode: 0, signal: null, aborted: false },
+    )) as {
+      exitCode: number
+    }
+    expect(r.exitCode).toBe(0)
+  })
+
+  test('throwOnError omitted: legacy aborted cassette does not throw', async () => {
+    const r = (await replayWith({}, { exitCode: 0, signal: null, aborted: true })) as {
+      aborted: boolean
+    }
+    expect(r.aborted).toBe(true)
+  })
+})


### PR DESCRIPTION
## What Changed

- **Three replay-fidelity bug fixes.** `timedOut` is now captured and surfaced. Aborted, signal-killed, and `maxBuffer`-exceeded calls no longer replay as success — synth resolves `failed` via fallback derivation (`exitCode !== 0 || signal !== null || aborted`) and the reject branch keys on the resolved value. `result.kill()`, `result.pipe()`, and `for await (line of result)` on execa replay no longer raise `TypeError`.
- **Three new flag captures** for execa: `isMaxBuffer`, `isForcefullyTerminated`, `isGracefullyCanceled`. All five new optional flag fields added to the `Result` schema (additive; cassette schema stays at version 2).
- **Synth completeness.** Replay populates every documented execa `Result` boolean (`isTerminated`, `isMaxBuffer`, `isForcefullyTerminated`, `isGracefullyCanceled`, plus empty `pipedFrom`/`ipcOutput`) so user assertions reach reachable values.
- **Subprocess-API stubs on execa replay.** `kill()` (no-op returning `false`), `pipe()` (throws `UnsupportedOptionError`), `Symbol.asyncIterator` (throws `UnsupportedOptionError`). Mirrors tinyexec's existing pattern.
- **Tests.** 7 unit tests (capture + synthesize), 4 integration tests, 2 error-path tests, 2 e2e tests.
- **Docs.** `docs/execa.md` Replay-fidelity section expanded with the full flag table and stubs subsection. `docs/tinyexec.md` adds a "Failed flag" section explaining the derivation. `docs/troubleshooting.md` adds an execa-side counterpart to the existing tinyexec replay-method section. CHANGELOG `[Unreleased]` filled in.

## Why

Replay shape now matches real execa/tinyexec behavior on failure paths. Tests asserting on `result.timedOut === true`, `result.isMaxBuffer === true`, or `result.isForcefullyTerminated === true` after a recorded failure now work as expected. Tests that aborted a call no longer silently pass under replay because the cassette is treated as a success. Cassettes recorded before the new fields existed auto-upgrade their replay correctness without re-recording — the fallback derivation handles signal-kill and aborted cases the old `exitCode !== 0` check missed.

## Related Issues

Refs #126.

## Test Plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 762 passed, 2 skipped (POSIX-only test guards)
- [x] `npm run build` — clean

## Notes

- Tinyexec's record path drops `aborted`/`killed` from the awaited `Output` (those getters live on the pre-await `ExecProcess`). Cassettes recorded by tinyexec currently store `aborted: false` regardless of whether the call was canceled. Replay-side handling is correct. Tracked in #126; the wrapper restructure is out of scope for this PR.
- `_captureResultForTesting` is exported from `src/execa.ts` and `src/tinyexec.ts` (both public package entry points) to let unit tests exercise the pure capture function without spawning a subprocess. The underscore prefix marks the symbol as non-public by convention. A follow-up could move it behind a non-exported test-helpers module if the autocomplete leakage becomes a concern.
- Stream methods (`iterable()`, `readable()`, `writable()`, `duplex()`) and stream-property getters on execa replay are not stubbed; calls produce `TypeError`. Tests using these patterns must run with `SHELL_CASSETTE_MODE=passthrough`.