### PR TITLE
fix: capture killed/aborted on record; remove internal export leakage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## What Changed
 
-<!-- A short list of what landed in this PR. -->
+<!-- A short list of what changed in this PR. -->
 
 ## Why
 
@@ -12,10 +12,10 @@
 
 ## Test Plan
 
-- [ ] `npm run lint` — clean
-- [ ] `npm run typecheck` — clean
-- [ ] `npm test` — N passed, N skipped
-- [ ] `npm run build` — clean
+- [ ] `npm run lint`: clean
+- [ ] `npm run typecheck`: clean
+- [ ] `npm test`: N passed, N skipped
+- [ ] `npm run build`: clean
 
 ## Notes
 

--- a/docs/execa.md
+++ b/docs/execa.md
@@ -130,11 +130,11 @@ When the wrapper synthesizes a result on replay, it populates every documented `
 | `isTerminated` | Derived: `signal !== null` |
 | `isForcefullyTerminated` | Stored on capture; defaults to `false` when absent |
 | `isGracefullyCanceled` | Stored on capture; defaults to `false` when absent |
-| `killed` | Derived: `signal !== null` |
+| `killed` | Stored on capture from execa's `r.killed`; if absent (older cassettes), derived from `signal !== null` |
 | `pipedFrom` | Always `[]` (`.pipe()` is stubbed; see below) |
 | `ipcOutput` | Always `[]` (`ipc: true` is rejected at validation) |
 
-Other fields (`stdout`, `stderr`, `exitCode`, `signal`, `command`, `escapedCommand`, `durationMs`, optional `all`) round-trip as before. The reject branch throws synthesized `ExecaError` when the resolved `failed` is `true` and `reject !== false` (matching execa's default). The fallback derivation lets cassettes recorded before the `failed` field was added auto-upgrade their replay correctness — aborted and signal-killed calls now throw on replay even when the cassette was recorded before the flag existed.
+Other fields (`stdout`, `stderr`, `exitCode`, `signal`, `command`, `escapedCommand`, `durationMs`, optional `all`) round-trip as before. The reject branch throws synthesized `ExecaError` when the resolved `failed` is `true` and `reject !== false` (matching execa's default). The fallback derivations let cassettes recorded before the `failed` and `killed` fields were stored auto-upgrade their replay correctness; aborted and signal-killed calls throw on replay even when the cassette predates the flag.
 
 `durationMs` is wall-clock measured by shell-cassette's wrapper around the real subprocess.
 

--- a/docs/tinyexec.md
+++ b/docs/tinyexec.md
@@ -81,13 +81,11 @@ The cassette schema is narrower than tinyexec's runtime result. One mapping stil
 
 - **`signal` (string vs boolean)**: tinyexec exposes `killed: boolean` but not the actual signal name. We unconditionally store `'SIGTERM'` on kill. The real signal name is lost.
 
-`aborted` is preserved through record/replay (captured from tinyexec's `aborted: true` when AbortSignal triggered, synthesized back to `aborted` on replay).
+`aborted` and `killed` are preserved through record/replay. Both fields live as getters on the pre-await `ExecProcess`; the adapter's `realCall` snapshots them before the `await` resolves so the cassette captures real values rather than `undefined` reads from the awaited `Output`.
 
 ## Failed flag
 
 Tinyexec's `Output` does not expose a `failed` boolean. shell-cassette derives `failed` on capture from `exitCode !== 0 || killed || aborted` and stores it in the cassette. Replay surfaces the stored value; older cassettes recorded before the field was stored re-derive at replay time via the same formula. The `throwOnError` reject branch keys on the resolved value, so signal-killed and aborted replays throw under `throwOnError: true` even when the cassette predates the field.
-
-Tinyexec's awaited `Output` also drops the `aborted` and `killed` getters that live on the pre-await `ExecProcess`. As a result, tinyexec cassettes currently record `aborted: false` regardless of whether the original call was canceled. Tracked in [#126](https://github.com/slgoodrich/shell-cassette/issues/126); replay-side handling is correct.
 
 ## Supported tinyexec options
 

--- a/src/cli-review.ts
+++ b/src/cli-review.ts
@@ -54,7 +54,7 @@ export type Finding = {
   rule: string
   /** Raw match (always populated; review --json without --include-match strips it before emit). */
   match: string
-  /** `sha256:<64 hex>` — used for skip-set membership across runs. */
+  /** `sha256:<64 hex>`. Used for skip-set membership across runs. */
   matchHash: string
   matchLength: number
   /** First-4 + ellipsis + last-4 if length >= 12, else full match. */
@@ -78,7 +78,7 @@ const CONTEXT_RADIUS = 2
  *   1. Each finding includes context lines surrounding the match for
  *      terminal display.
  *   2. Matches whose hash appears in any recording's `suppressed` array
- *      are skipped — the user already chose to skip them.
+ *      are skipped (the user already chose to skip them).
  */
 export function preScan(cassette: CassetteFile, config: Readonly<RedactConfig>): Finding[] {
   const skipSet = collectSuppressedHashes(cassette)
@@ -273,7 +273,7 @@ export type ReviewState = {
   /**
    * Stack of cursors saved before each forward advance. `back` pops from
    * here so multi-step jumps (e.g. `delete`'s contiguous-recording skip)
-   * unwind to the actual prior decision point — not just `cursor - 1`.
+   * unwind to the actual prior decision point, not just `cursor - 1`.
    */
   readonly history: readonly number[]
   readonly decisions: ReadonlyMap<string, Decision>
@@ -303,7 +303,7 @@ export type ReviewAction =
  *   - back: pop the prior cursor from history and rewind to it, removing
  *     every decision recorded in the unwound range so the user must
  *     re-decide. Empty history is a no-op (start of review or already
- *     fully unwound). Allowed from 'confirming' too — pops back to
+ *     fully unwound). Allowed from 'confirming' too; pops back to
  *     'reviewing' at the last decided finding.
  *   - quit: transition to 'aborted' (decisions discarded by caller).
  *

--- a/src/execa-capture.ts
+++ b/src/execa-capture.ts
@@ -1,0 +1,45 @@
+import type { Result } from './types.js'
+
+/**
+ * Internal: maps an execa raw result (or thrown error shape) to the cassette
+ * `Result` type. Lives in a non-exported module so it stays out of the
+ * `shell-cassette/execa` public sub-path's `.d.ts` and IDE autocomplete.
+ * Tests import this module directly via `src/execa-capture.js`.
+ */
+export function captureResult(raw: unknown, durationMs: number): Result {
+  const r = raw as {
+    stdout?: string | string[]
+    stderr?: string | string[]
+    all?: string | string[]
+    exitCode?: number
+    signal?: string | null
+    isCanceled?: boolean
+    killed?: boolean
+    failed?: boolean
+    timedOut?: boolean
+    isMaxBuffer?: boolean
+    isForcefullyTerminated?: boolean
+    isGracefullyCanceled?: boolean
+  }
+  return {
+    stdoutLines: toLines(r.stdout),
+    stderrLines: toLines(r.stderr),
+    allLines: r.all === undefined ? null : toLines(r.all),
+    exitCode: r.exitCode ?? 0,
+    signal: r.signal ?? null,
+    durationMs,
+    aborted: r.isCanceled === true,
+    killed: r.killed === true,
+    failed: r.failed === true,
+    timedOut: r.timedOut === true,
+    isMaxBuffer: r.isMaxBuffer === true,
+    isForcefullyTerminated: r.isForcefullyTerminated === true,
+    isGracefullyCanceled: r.isGracefullyCanceled === true,
+  }
+}
+
+function toLines(input: string | string[] | undefined): string[] {
+  if (input === undefined) return ['']
+  if (Array.isArray(input)) return [...input, '']
+  return input.split('\n')
+}

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -1,8 +1,9 @@
 import type { Options, ResultPromise } from 'execa'
 import { MissingPeerDependencyError, UnsupportedOptionError } from './errors.js'
+import { captureResult } from './execa-capture.js'
 import { readInputFile } from './io.js'
 import { validateOptions } from './options-execa.js'
-import type { Call, Recording, Result } from './types.js'
+import type { Call, Recording } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
 
 // Reused across every synth call. `pipe` and async iteration always
@@ -69,9 +70,30 @@ export function execaNode(
 const execaHooks: RunnerHooks<Options, unknown> = {
   validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
   buildCall,
-  realCall: (file, args, options) => realExeca(file, args, options) as unknown as Promise<unknown>,
+  realCall,
   captureResult,
   synthesize,
+}
+
+// When buildCall already resolved `inputFile` into `Call.stdin`, swap the
+// option so real execa consumes the resolved string via `input` instead of
+// re-reading the file. The branch only fires on the record path
+// (passthrough/no-session pass `resolvedStdin: undefined`). buildCall's
+// contract: when inputFile is defined, stdin is always a string (possibly
+// empty), never null — so a string-typeof check covers the optimization
+// case without a redundant null branch. Closes #102.
+function realCall(
+  file: string,
+  args: readonly string[],
+  options: Options,
+  resolvedStdin: string | null | undefined,
+): Promise<unknown> {
+  let opts = options
+  if (typeof resolvedStdin === 'string' && options.inputFile !== undefined) {
+    const { inputFile: _, ...rest } = options as Options & { inputFile?: unknown }
+    opts = { ...rest, input: resolvedStdin } as Options
+  }
+  return realExeca(file, args, opts) as unknown as Promise<unknown>
 }
 
 async function buildCall(file: string, args: readonly string[], options: Options): Promise<Call> {
@@ -94,46 +116,6 @@ async function buildCall(file: string, args: readonly string[], options: Options
     env: (options.env as Record<string, string> | undefined) ?? {},
     stdin,
   }
-}
-
-function captureResult(raw: unknown, durationMs: number): Result {
-  const r = raw as {
-    stdout?: string | string[]
-    stderr?: string | string[]
-    all?: string | string[]
-    exitCode?: number
-    signal?: string | null
-    isCanceled?: boolean
-    failed?: boolean
-    timedOut?: boolean
-    isMaxBuffer?: boolean
-    isForcefullyTerminated?: boolean
-    isGracefullyCanceled?: boolean
-  }
-  return {
-    stdoutLines: toLines(r.stdout),
-    stderrLines: toLines(r.stderr),
-    allLines: r.all === undefined ? null : toLines(r.all),
-    exitCode: r.exitCode ?? 0,
-    signal: r.signal ?? null,
-    durationMs,
-    aborted: r.isCanceled === true,
-    failed: r.failed === true,
-    timedOut: r.timedOut === true,
-    isMaxBuffer: r.isMaxBuffer === true,
-    isForcefullyTerminated: r.isForcefullyTerminated === true,
-    isGracefullyCanceled: r.isGracefullyCanceled === true,
-  }
-}
-
-// Test-only export so unit tests can drive captureResult without spawning
-// a real subprocess. Underscore prefix marks it as non-public API.
-export const _captureResultForTesting = captureResult
-
-function toLines(input: string | string[] | undefined): string[] {
-  if (input === undefined) return ['']
-  if (Array.isArray(input)) return [...input, '']
-  return input.split('\n')
 }
 
 // Resolve execa's `lines` option to per-stream booleans. The object form lets
@@ -211,7 +193,9 @@ function synthesize(rec: Recording, options: Options): unknown {
     isTerminated,
     isForcefullyTerminated: rec.result.isForcefullyTerminated ?? false,
     isGracefullyCanceled: rec.result.isGracefullyCanceled ?? false,
-    killed: isTerminated, // NOTE: tracked as semantic bug in #129 — preserves current behavior
+    // Stored value when present; fall back to isTerminated for legacy
+    // cassettes recorded before `killed` was captured separately.
+    killed: rec.result.killed ?? isTerminated,
 
     // pipedFrom: no chained subprocess on replay. ipcOutput: ipc: true
     // is rejected at validation.

--- a/src/execa.ts
+++ b/src/execa.ts
@@ -80,8 +80,8 @@ const execaHooks: RunnerHooks<Options, unknown> = {
 // re-reading the file. The branch only fires on the record path
 // (passthrough/no-session pass `resolvedStdin: undefined`). buildCall's
 // contract: when inputFile is defined, stdin is always a string (possibly
-// empty), never null — so a string-typeof check covers the optimization
-// case without a redundant null branch. Closes #102.
+// empty), never null, so a string-typeof check covers the optimization
+// case without a redundant null branch.
 function realCall(
   file: string,
   args: readonly string[],

--- a/src/redact-pipeline.ts
+++ b/src/redact-pipeline.ts
@@ -269,7 +269,7 @@ export function seedCountersFromCassette(cassette: CassetteFile): Map<string, nu
 
   // Source 1: per-recording _redactions metadata. Each entry.count is the
   // number of placeholder occurrences within that single recording. The
-  // cassette-wide ceiling is the SUM across recordings — counters are
+  // cassette-wide ceiling is the SUM across recordings; counters are
   // monotonic and per-(source, rule) globally.
   for (const rec of cassette.recordings) {
     for (const entry of rec.redactions) {
@@ -326,7 +326,7 @@ function walkStringsForPlaceholders(
 /**
  * Synthetic rule name for the recorder's curated env-key-match path
  * (env values whose key name matches the CURATED_ENV_KEYS or user-supplied
- * envKeys list). Not in BUNDLED_PATTERNS — the env-key pathway bypasses the
+ * envKeys list). Not in BUNDLED_PATTERNS; the env-key pathway bypasses the
  * regex pipeline since the whole value is sensitive.
  */
 export const ENV_KEY_MATCH_RULE = 'env-key-match'

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -64,6 +64,7 @@ function orderRecording(rec: Recording) {
       ...(rec.result.isGracefullyCanceled !== undefined && {
         isGracefullyCanceled: rec.result.isGracefullyCanceled,
       }),
+      ...(rec.result.killed !== undefined && { killed: rec.result.killed }),
     },
     _redactions: rec.redactions,
     ...(rec.suppressed.length > 0 ? { _suppressed: rec.suppressed } : {}),

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -12,7 +12,7 @@ const REVIEW_WARNING =
 
 /**
  * Serialize a CassetteFile to JSON. Always emits SCHEMA_VERSION (currently 2)
- * regardless of `file.version` — serialize is upgrade-on-write. A v1 cassette
+ * regardless of `file.version`; serialize is upgrade-on-write. A v1 cassette
  * passed in is materialized as v2 on disk; deserialize handles the inverse
  * by accepting v1 input and normalizing missing fields.
  *
@@ -145,7 +145,7 @@ export function deserialize(text: string): CassetteFile {
   }
 }
 
-// Fields added after the v2 schema landed are optional on disk;
+// Fields added after v2 schema initial release are optional on disk;
 // normalizeRecording fills defaults.
 type LegacyRecording = {
   call: Recording['call']

--- a/src/tinyexec-capture.ts
+++ b/src/tinyexec-capture.ts
@@ -1,0 +1,43 @@
+import type { Result } from './types.js'
+
+/**
+ * Internal: maps a tinyexec raw result (with the OutputApi `aborted`/`killed`
+ * snapshot the wrapper takes pre-await) to the cassette `Result` type. Lives
+ * in a non-exported module so it stays out of the `shell-cassette/tinyexec`
+ * public sub-path's `.d.ts` and IDE autocomplete. Tests import this module
+ * directly via `src/tinyexec-capture.js`.
+ *
+ * tinyexec exposes only `killed: boolean` (not the actual signal name); we
+ * unconditionally record `signal: 'SIGTERM'` when killed. The real signal
+ * name is not recoverable from tinyexec's surface.
+ */
+export function captureResult(raw: unknown, durationMs: number): Result {
+  const r = raw as {
+    stdout?: string
+    stderr?: string
+    exitCode?: number
+    killed?: boolean
+    aborted?: boolean
+  }
+  // tinyexec.stdout/stderr is always a string per its type contract; the [''] fallback
+  // exists only for defensive narrowing on `unknown` raw input (e.g., a thrown error
+  // shape that happens to lack stdout/stderr fields).
+  const exitCode = r.exitCode ?? 0
+  const killed = r.killed === true
+  const aborted = r.aborted === true
+  return {
+    stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
+    stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],
+    allLines: null,
+    exitCode,
+    signal: killed ? 'SIGTERM' : null,
+    durationMs,
+    aborted,
+    killed,
+    // Derived because tinyexec does not expose a `failed` boolean. Covers
+    // the three known failure shapes (non-zero exit, signal kill, abort).
+    // timedOut and isMaxBuffer are intentionally not stored: tinyexec
+    // exposes neither; synth defaults each to false on replay.
+    failed: exitCode !== 0 || killed || aborted,
+  }
+}

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -46,12 +46,13 @@ const tinyexecHooks: RunnerHooks<Partial<Options>, TinyResult> = {
 // tinyexec's Result is `PromiseLike<Output> & OutputApi`. Awaiting it resolves
 // to Output (`{ stdout, stderr, exitCode }`) and drops the OutputApi getters
 // (`aborted`, `killed`). To capture those on the record path we snapshot them
-// from the ExecProcess BEFORE the await resolves, then return an enriched
-// plain object the cassette captureResult can read. Fixes #126.
+// from the ExecProcess before the await resolves, then return an enriched
+// plain object the cassette captureResult can read.
 //
-// `_resolvedStdin` is part of RunnerHooks.realCall's signature for the execa
-// adapter's #102 optimization; tinyexec has no `inputFile` option and ignores
-// it.
+// The fourth parameter is part of RunnerHooks.realCall's signature for the
+// execa adapter's inputFile optimization; tinyexec has no `inputFile`
+// option and ignores it (underscore prefix per biome's
+// noUnusedFunctionParameters).
 async function realCall(
   file: string,
   args: readonly string[],
@@ -88,7 +89,7 @@ function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
   // Stored value when present; fall back to signal-derived for legacy cassettes
-  // recorded before `killed` was captured separately. Closes #129.
+  // recorded before `killed` was captured separately.
   const killed = rec.result.killed ?? rec.result.signal !== null
 
   const result = {

--- a/src/tinyexec.ts
+++ b/src/tinyexec.ts
@@ -1,7 +1,8 @@
 import type { Options, Result as TinyResult } from 'tinyexec'
 import { MissingPeerDependencyError, ShellCassetteError, UnsupportedOptionError } from './errors.js'
 import { validateOptions } from './options-tinyexec.js'
-import type { Call, Result as CassetteResult, Recording } from './types.js'
+import { captureResult } from './tinyexec-capture.js'
+import type { Call, Recording } from './types.js'
 import { type RunnerHooks, runWrapped } from './wrapper.js'
 
 export type { Options, Result } from 'tinyexec'
@@ -37,12 +38,34 @@ export function x(
 const tinyexecHooks: RunnerHooks<Partial<Options>, TinyResult> = {
   validate: (opts) => validateOptions(opts as Record<string, unknown> | undefined),
   buildCall,
-  // tinyexec's Result is structurally a PromiseLike & OutputApi, not Promise<Result>;
-  // double-cast through unknown is needed to satisfy the hook's Promise<ResultShape> signature
-  realCall: (file, args, options) =>
-    realX(file, [...args], options) as unknown as Promise<TinyResult>,
+  realCall,
   captureResult,
   synthesize,
+}
+
+// tinyexec's Result is `PromiseLike<Output> & OutputApi`. Awaiting it resolves
+// to Output (`{ stdout, stderr, exitCode }`) and drops the OutputApi getters
+// (`aborted`, `killed`). To capture those on the record path we snapshot them
+// from the ExecProcess BEFORE the await resolves, then return an enriched
+// plain object the cassette captureResult can read. Fixes #126.
+//
+// `_resolvedStdin` is part of RunnerHooks.realCall's signature for the execa
+// adapter's #102 optimization; tinyexec has no `inputFile` option and ignores
+// it.
+async function realCall(
+  file: string,
+  args: readonly string[],
+  options: Partial<Options>,
+  _resolvedStdin: string | null | undefined,
+): Promise<TinyResult> {
+  const proc = realX(file, [...args], options)
+  const output = await proc
+  const enriched = { ...output, aborted: proc.aborted, killed: proc.killed }
+  // Cast: the enriched plain object lacks tinyexec's full Result shape (no
+  // OutputApi methods, no PromiseLike). The wrapper passes this to
+  // captureResult and (on record path) returns it to the user. Live ProcessApi
+  // calls post-await are a known replay limitation, see synthesize() comment.
+  return enriched as unknown as TinyResult
 }
 
 async function buildCall(
@@ -61,47 +84,12 @@ async function buildCall(
   }
 }
 
-function captureResult(raw: unknown, durationMs: number): CassetteResult {
-  const r = raw as {
-    stdout?: string
-    stderr?: string
-    exitCode?: number
-    killed?: boolean
-    aborted?: boolean
-  }
-  // tinyexec.stdout/stderr is always a string per its type contract; the [''] fallback
-  // exists only for defensive narrowing on `unknown` raw input (e.g., a thrown error
-  // shape that happens to lack stdout/stderr fields).
-  //
-  // tinyexec exposes only `killed: boolean`, not the actual signal name (SIGINT,
-  // SIGKILL, etc.). We unconditionally record SIGTERM on kill; the real signal is
-  // lost. Known limitation; tinyexec does not expose the signal name.
-  const exitCode = r.exitCode ?? 0
-  const killed = r.killed === true
-  const aborted = r.aborted === true
-  return {
-    stdoutLines: typeof r.stdout === 'string' ? r.stdout.split('\n') : [''],
-    stderrLines: typeof r.stderr === 'string' ? r.stderr.split('\n') : [''],
-    allLines: null,
-    exitCode,
-    signal: killed ? 'SIGTERM' : null,
-    durationMs,
-    aborted,
-    // Derived because tinyexec does not expose a `failed` boolean. Covers
-    // the three known failure shapes (non-zero exit, signal kill, abort).
-    // timedOut and isMaxBuffer are intentionally not stored: tinyexec
-    // exposes neither; synth defaults each to false on replay.
-    failed: exitCode !== 0 || killed || aborted,
-  }
-}
-
-// Test-only export. See execa.ts for the same pattern.
-export const _captureResultForTesting = captureResult
-
 function synthesize(rec: Recording, options: Partial<Options>): TinyResult {
   const stdout = rec.result.stdoutLines.join('\n')
   const stderr = rec.result.stderrLines.join('\n')
-  const killed = rec.result.signal !== null
+  // Stored value when present; fall back to signal-derived for legacy cassettes
+  // recorded before `killed` was captured separately. Closes #129.
+  const killed = rec.result.killed ?? rec.result.signal !== null
 
   const result = {
     stdout,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,8 @@ export type Result = {
    * True when `subprocess.kill()` was called (execa's `r.killed`, tinyexec's
    * `proc.killed`). Distinct from `signal !== null`: a process terminated by
    * an external signal has `signal !== null` but `killed === false`. Stored
-   * separately so synth doesn't have to derive (and get it wrong, as #129
-   * documented). Optional for backward compat with cassettes recorded before
+   * separately rather than derived because the two states are semantically
+   * different. Optional for backward compat with cassettes recorded before
    * the field existed.
    */
   killed?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,15 @@ export type Result = {
   isMaxBuffer?: boolean
   isForcefullyTerminated?: boolean
   isGracefullyCanceled?: boolean
+  /**
+   * True when `subprocess.kill()` was called (execa's `r.killed`, tinyexec's
+   * `proc.killed`). Distinct from `signal !== null`: a process terminated by
+   * an external signal has `signal !== null` but `killed === false`. Stored
+   * separately so synth doesn't have to derive (and get it wrong, as #129
+   * documented). Optional for backward compat with cassettes recorded before
+   * the field existed.
+   */
+  killed?: boolean
 }
 
 export type Recording = {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -21,7 +21,22 @@ CI=true forces replay mode by default; without a session shell-cassette refuses 
 export type RunnerHooks<Opts, ResultShape> = {
   validate: (options: Opts | undefined) => void
   buildCall: (file: string, args: readonly string[], options: Opts) => Promise<Call>
-  realCall: (file: string, args: readonly string[], options: Opts) => Promise<ResultShape>
+  /**
+   * Invokes the real runner. `resolvedStdin` carries `call.stdin` when
+   * `buildCall` already ran (record path); it is `undefined` on the
+   * passthrough/no-session paths where `buildCall` is skipped.
+   *
+   * Adapters use it to avoid duplicating side effects buildCall already
+   * performed. The execa adapter swaps `options.inputFile` for
+   * `input: resolvedStdin` when both are present, so real execa does not
+   * re-read the file (#102).
+   */
+  realCall: (
+    file: string,
+    args: readonly string[],
+    options: Opts,
+    resolvedStdin: string | null | undefined,
+  ) => Promise<ResultShape>
   // The wrapper measures elapsed time around realCall and passes it here.
   // Adapters use this value rather than reading runner-provided fields so
   // the measurement is uniform across runners (execa exposes durationMs;
@@ -53,7 +68,7 @@ export async function runWrapped<Opts, ResultShape>(
     if (mode === 'replay') {
       throw new NoActiveSessionError(NO_ACTIVE_SESSION_HELP)
     }
-    return hooks.realCall(file, args, options)
+    return hooks.realCall(file, args, options, undefined)
   }
 
   const loaded = await ensureSessionLoaded(session)
@@ -65,7 +80,7 @@ export async function runWrapped<Opts, ResultShape>(
   )
 
   if (mode === 'passthrough') {
-    return hooks.realCall(file, args, options)
+    return hooks.realCall(file, args, options, undefined)
   }
 
   const call = await hooks.buildCall(file, args, options)
@@ -111,7 +126,7 @@ export async function runWrapped<Opts, ResultShape>(
   }
   const start = performance.now()
   try {
-    const result = await hooks.realCall(file, args, options)
+    const result = await hooks.realCall(file, args, options, call.stdin)
     captureAndRecord(call, result, performance.now() - start, hooks, loaded)
     return result
   } catch (err) {

--- a/tests/helpers/paced-stdin.ts
+++ b/tests/helpers/paced-stdin.ts
@@ -5,9 +5,9 @@ import { Readable } from 'node:stream'
  * Required because Node's `readline.question` can drop a queued answer if
  * stdin EOFs before the next `question()` call is registered. The delay
  * gives the CLI time to render its prompt and re-register before the next
- * answer lands.
+ * answer arrives.
  *
- * Pacing is 250ms — 100ms was sufficient on Linux but flaky on Windows CI
+ * Pacing is 250ms; 100ms was sufficient on Linux but flaky on Windows CI
  * where readline event scheduling is slower. The added latency only affects
  * e2e tests (5 tests × 250ms × ~3 prompts each ≈ 4 seconds total), well
  * within the e2e budget.
@@ -22,7 +22,7 @@ export function pacedStdin(lines: readonly string[]): Readable {
   return new Readable({
     read() {
       if (i >= lines.length) {
-        // Delay EOF too so the final answer has time to land before stdin closes.
+        // Delay EOF too so the final answer has time to flush before stdin closes.
         setTimeout(() => this.push(null), PACE_MS)
         return
       }

--- a/tests/integration/record-replay-aborted.test.ts
+++ b/tests/integration/record-replay-aborted.test.ts
@@ -49,9 +49,9 @@ describe('record + replay: aborted (execa)', () => {
   })
 })
 
-// Closes #126: tinyexec's awaited Output drops the OutputApi getters
-// (aborted, killed) that live on the pre-await ExecProcess. The adapter's
-// realCall snapshots them before await so captureResult sees real values.
+// tinyexec's awaited Output drops the OutputApi getters (aborted, killed)
+// that live on the pre-await ExecProcess. The adapter's realCall snapshots
+// them before await so captureResult sees real values.
 describe('record + replay: aborted (tinyexec)', () => {
   const tmp = useTmpDir('sc-aborted-tinyexec-')
 

--- a/tests/integration/record-replay-aborted.test.ts
+++ b/tests/integration/record-replay-aborted.test.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { execa } from '../../src/execa.js'
+import { x } from '../../src/tinyexec.js'
 import { useCassette } from '../../src/use-cassette.js'
 import { restoreEnv } from '../helpers/env.js'
 import { useRecordingEnv } from '../helpers/recording-env.js'
@@ -9,12 +10,6 @@ import { SLEEP_5S } from '../helpers/subprocess-targets.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 useRecordingEnv()
-
-// Tinyexec coverage for aborted-call record/replay is tracked in #126.
-// tinyexec's awaited Output drops the OutputApi getters (aborted, killed)
-// that live on the pre-await ExecProcess, so the wrapper currently records
-// `aborted: false` even on cancelled tinyexec calls. Replay synth handles
-// the cassette field correctly; the gap is purely on the record path.
 
 describe('record + replay: aborted (execa)', () => {
   const tmp = useTmpDir('sc-aborted-execa-')
@@ -47,6 +42,40 @@ describe('record + replay: aborted (execa)', () => {
         await expect(execa('node', SLEEP_5S, { cancelSignal: ac.signal })).rejects.toThrow(
           /Command failed/,
         )
+      })
+    } finally {
+      restoreEnv('SHELL_CASSETTE_MODE', prevMode)
+    }
+  })
+})
+
+// Closes #126: tinyexec's awaited Output drops the OutputApi getters
+// (aborted, killed) that live on the pre-await ExecProcess. The adapter's
+// realCall snapshots them before await so captureResult sees real values.
+describe('record + replay: aborted (tinyexec)', () => {
+  const tmp = useTmpDir('sc-aborted-tinyexec-')
+
+  test('signal abort records aborted=true; replay surfaces aborted=true', async () => {
+    const cp = path.join(tmp.ref(), 'cassette.json')
+
+    await useCassette(cp, async () => {
+      const ac = new AbortController()
+      setTimeout(() => ac.abort(), 100)
+      const r = await x('node', [...SLEEP_5S], { signal: ac.signal })
+      expect(r.aborted).toBe(true)
+    })
+
+    const cassette = JSON.parse(await readFile(cp, 'utf8'))
+    expect(cassette.recordings[0].result.aborted).toBe(true)
+    expect(cassette.recordings[0].result.failed).toBe(true)
+
+    const prevMode = process.env.SHELL_CASSETTE_MODE
+    process.env.SHELL_CASSETTE_MODE = 'replay'
+    try {
+      await useCassette(cp, async () => {
+        const ac = new AbortController()
+        const r = await x('node', [...SLEEP_5S], { signal: ac.signal })
+        expect(r.aborted).toBe(true)
       })
     } finally {
       restoreEnv('SHELL_CASSETTE_MODE', prevMode)

--- a/tests/integration/wrapper.test.ts
+++ b/tests/integration/wrapper.test.ts
@@ -98,6 +98,85 @@ describe('wrapped execa', () => {
     }
   })
 
+  test('synth: legacy cassette without killed field falls back to signal-derived (#129)', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, 'cassette.json')
+      // Hand-crafted: signal is set, killed is absent. Pre-#129 behavior
+      // (signal-derived) is the only source of truth, so synth must report
+      // killed: true to keep legacy cassettes replaying as before.
+      const legacy = {
+        version: 2,
+        recordings: [
+          {
+            call: { command: 'node', args: ['-v'], cwd: null, env: {}, stdin: null },
+            result: {
+              stdoutLines: [''],
+              stderrLines: [''],
+              allLines: null,
+              exitCode: 0,
+              signal: 'SIGTERM',
+              durationMs: 1,
+              aborted: false,
+            },
+          },
+        ],
+      }
+      await writeFile(cassettePath, JSON.stringify(legacy), 'utf8')
+
+      const session = sessionAt(cassettePath)
+      setActiveCassette(session)
+      const replayed = (await wrappedExeca('node', ['-v'], { reject: false })) as {
+        killed: boolean
+        signal: string | null
+      }
+      expect(replayed.killed).toBe(true)
+      expect(replayed.signal).toBe('SIGTERM')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  test('synth: new cassette with killed:false, signal:SIGTERM reports killed:false (#129)', async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
+    try {
+      const cassettePath = path.join(tmp, 'cassette.json')
+      // External SIGTERM (not via subprocess.kill()): execa would surface
+      // signal !== null but killed === false. Pre-#129 synth conflated the
+      // two and reported killed:true; the fix preserves the distinction.
+      const cassette = {
+        version: 2,
+        recordings: [
+          {
+            call: { command: 'node', args: ['-v'], cwd: null, env: {}, stdin: null },
+            result: {
+              stdoutLines: [''],
+              stderrLines: [''],
+              allLines: null,
+              exitCode: 0,
+              signal: 'SIGTERM',
+              durationMs: 1,
+              aborted: false,
+              killed: false,
+            },
+          },
+        ],
+      }
+      await writeFile(cassettePath, JSON.stringify(cassette), 'utf8')
+
+      const session = sessionAt(cassettePath)
+      setActiveCassette(session)
+      const replayed = (await wrappedExeca('node', ['-v'], { reject: false })) as {
+        killed: boolean
+        signal: string | null
+      }
+      expect(replayed.killed).toBe(false)
+      expect(replayed.signal).toBe('SIGTERM')
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
   test('legacy cassette (no allLines) still replays all via stdout+stderr concat', async () => {
     const tmp = await mkdtemp(path.join(tmpdir(), 'sc-test-'))
     try {

--- a/tests/plugin/lifecycle.test.ts
+++ b/tests/plugin/lifecycle.test.ts
@@ -36,5 +36,5 @@ describe('vitest plugin lifecycle (subprocess-driven)', () => {
       recursive: true,
       force: true,
     })
-  }, 60000) // 60s timeout — vitest subprocess startup is slow on Windows
+  }, 60000) // 60s timeout because vitest subprocess startup is slow on Windows
 })

--- a/tests/property/canonicalize.property.test.ts
+++ b/tests/property/canonicalize.property.test.ts
@@ -5,7 +5,7 @@ import { defaultCanonicalize, MatcherState } from '../../src/matcher.js'
 import { normalizeTmpPath, TMP_TOKEN } from '../../src/normalize.js'
 import type { Call, Recording, Result } from '../../src/types.js'
 
-// Reuse generators (deliberate inline duplication — rule of three; two
+// Reuse generators (deliberate inline duplication; rule of three: two
 // property test files don't justify a shared helpers module yet)
 const genArg = fc.string({ minLength: 0, maxLength: 50 }).filter((s) => !s.includes('\n'))
 const genArgs = fc.array(genArg, { minLength: 0, maxLength: 5 })

--- a/tests/property/scan-record-symmetry.property.test.ts
+++ b/tests/property/scan-record-symmetry.property.test.ts
@@ -1,9 +1,9 @@
 /**
  * Property test: scan vs record symmetry.
  *
- * The load-bearing security guarantee: if record mode would have redacted a
- * value, scan must report that value as a finding. These tests verify the
- * forward direction of that guarantee for every bundled rule and for the
+ * Core security guarantee: if record mode would have redacted a value, scan
+ * must report that value as a finding. These tests verify the forward
+ * direction of that guarantee for every bundled rule and for the
  * env-key-match path.
  */
 import path from 'node:path'

--- a/tests/security/redact-stdin.test.ts
+++ b/tests/security/redact-stdin.test.ts
@@ -222,7 +222,7 @@ describe('e2e: stdin credential round-trips redacted in cassette JSON', () => {
       await useCassette(cp, async () => {
         // The replayed result is whatever the cassette stored (the redacted
         // stdout), but the assertion that matters is that the call matched
-        // at all — no ReplayMissError thrown.
+        // at all (no ReplayMissError thrown).
         const r = await execa('node', NODE_ECHO_STDIN, { input: SAMPLE_GITHUB_PAT_CLASSIC })
         expect(r.exitCode).toBe(0)
         expect(r.stdout).toBe('<redacted:stdout:github-pat-classic:1>')

--- a/tests/unit/cli-review.test.ts
+++ b/tests/unit/cli-review.test.ts
@@ -310,8 +310,8 @@ describe('applyAction', () => {
     state = applyAction(state, { kind: 'back' })
     // Cursor returns to 0 (where the user actually was when they pressed delete).
     expect(state.cursor).toBe(0)
-    // The delete decision is gone — user must re-decide. b never had a
-    // decision, but verifying both are clear ensures the unwound range is
+    // The delete decision is gone, so the user must re-decide. b never had
+    // a decision, but verifying both are clear ensures the unwound range is
     // correctly cleared.
     expect(state.decisions.has('a')).toBe(false)
     expect(state.decisions.has('b')).toBe(false)
@@ -564,9 +564,9 @@ describe('runReview interactive (driven via fake reader)', () => {
   beforeEach(async () => {
     tmp = await mkdtemp(path.join(tmpdir(), 'shell-cassette-review-int-'))
     outBuf = []
-    // renderFinding emits the match preview, hash, and surrounding context lines —
-    // for a fixture with a real-looking PAT, that means secrets land in the
-    // vitest reporter unless stdout is captured.
+    // renderFinding emits the match preview, hash, and surrounding context
+    // lines. For a fixture with a real-looking PAT that means secrets reach
+    // the vitest reporter unless stdout is captured.
     process.stdout.write = ((s: string) => {
       outBuf.push(s)
       return true

--- a/tests/unit/execa-capture-result.test.ts
+++ b/tests/unit/execa-capture-result.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-// captureResult is internal — its module is intentionally not in
+// captureResult is internal: its module is intentionally not in
 // package.json's exports map, so imports go through the source path
 // directly. Pure-function unit test bypasses the wrapper layer entirely.
 import { captureResult } from '../../src/execa-capture.js'
@@ -68,7 +68,7 @@ describe('execa captureResult: killed (#129)', () => {
   })
 
   test('signal !== null without killed records killed=false (external signal)', () => {
-    // External SIGTERM (not via subprocess.kill()) — execa exposes
+    // External SIGTERM (not via subprocess.kill()): execa exposes
     // signal !== null but killed === false. The capture must preserve
     // that distinction so synth does not report killed=true.
     const r = captureResult(

--- a/tests/unit/execa-capture-result.test.ts
+++ b/tests/unit/execa-capture-result.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'vitest'
 
-// captureResult is internal; expose a thin re-export by importing the
-// adapter and using a known shape. Pure-function unit test bypasses
-// the wrapper layer entirely.
-import { _captureResultForTesting } from '../../src/execa.js'
+// captureResult is internal — its module is intentionally not in
+// package.json's exports map, so imports go through the source path
+// directly. Pure-function unit test bypasses the wrapper layer entirely.
+import { captureResult } from '../../src/execa-capture.js'
 
 describe('execa captureResult: optional flag fields', () => {
   test('reads all five flags when present and true', () => {
-    const r = _captureResultForTesting(
+    const r = captureResult(
       {
         stdout: 'ok',
         stderr: '',
@@ -31,7 +31,7 @@ describe('execa captureResult: optional flag fields', () => {
   })
 
   test('absent flags default to false (not undefined)', () => {
-    const r = _captureResultForTesting({ stdout: '', stderr: '', exitCode: 0 }, 1)
+    const r = captureResult({ stdout: '', stderr: '', exitCode: 0 }, 1)
     expect(r.failed).toBe(false)
     expect(r.timedOut).toBe(false)
     expect(r.isMaxBuffer).toBe(false)
@@ -42,7 +42,7 @@ describe('execa captureResult: optional flag fields', () => {
   test('non-true truthy values (e.g. truthy strings) coerce to false', () => {
     // execa types these as boolean. The === true idiom guards against any
     // accidental string-leaks from real execa shape changes.
-    const r = _captureResultForTesting(
+    const r = captureResult(
       {
         stdout: '',
         stderr: '',
@@ -54,5 +54,33 @@ describe('execa captureResult: optional flag fields', () => {
     )
     expect(r.failed).toBe(false)
     expect(r.timedOut).toBe(false)
+  })
+})
+
+describe('execa captureResult: killed (#129)', () => {
+  test('killed=true on raw records killed=true', () => {
+    const r = captureResult(
+      { stdout: '', stderr: '', exitCode: 0, signal: 'SIGTERM', killed: true },
+      1,
+    )
+    expect(r.killed).toBe(true)
+    expect(r.signal).toBe('SIGTERM')
+  })
+
+  test('signal !== null without killed records killed=false (external signal)', () => {
+    // External SIGTERM (not via subprocess.kill()) — execa exposes
+    // signal !== null but killed === false. The capture must preserve
+    // that distinction so synth does not report killed=true.
+    const r = captureResult(
+      { stdout: '', stderr: '', exitCode: 0, signal: 'SIGTERM', killed: false },
+      1,
+    )
+    expect(r.killed).toBe(false)
+    expect(r.signal).toBe('SIGTERM')
+  })
+
+  test('absent killed defaults to false', () => {
+    const r = captureResult({ stdout: '', stderr: '', exitCode: 0 }, 1)
+    expect(r.killed).toBe(false)
   })
 })

--- a/tests/unit/execa-input-file-swap.test.ts
+++ b/tests/unit/execa-input-file-swap.test.ts
@@ -1,0 +1,80 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('execa', () => ({ execa: vi.fn() }))
+
+const { execa: realExecaMock } = await import('execa')
+const { execa: wrappedExeca } = await import('../../src/execa.js')
+const { _resetForTesting, clearActiveCassette, setActiveCassette } = await import(
+  '../../src/state.js'
+)
+const { restoreEnv } = await import('../helpers/env.js')
+const { makeSession } = await import('../helpers/session.js')
+const { useTmpDir } = await import('../helpers/tmp-dir.js')
+
+const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+
+describe('execa adapter: realCall swaps inputFile -> input on record path (#102)', () => {
+  const tmp = useTmpDir('sc-input-swap-')
+
+  beforeEach(() => {
+    _resetForTesting()
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.CI
+    vi.mocked(realExecaMock).mockReset()
+    // Resolve to a minimal execa-shaped result so captureResult is happy.
+    vi.mocked(realExecaMock).mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      signal: null,
+      isCanceled: false,
+      failed: false,
+    } as never)
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+    restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+  })
+
+  test('record path: real execa receives `input: <bytes>`, no `inputFile`', async () => {
+    const fixture = path.join(tmp.ref(), 'in.txt')
+    await writeFile(fixture, 'hello-from-file', 'utf8')
+
+    const session = makeSession({
+      name: 't',
+      path: path.join(tmp.ref(), 'cassette.json'),
+      loadedFile: null,
+      matcher: null,
+    })
+    setActiveCassette(session)
+
+    await wrappedExeca('node', ['-v'], { inputFile: fixture })
+
+    expect(realExecaMock).toHaveBeenCalledTimes(1)
+    const passedOptions = vi.mocked(realExecaMock).mock.calls[0]?.[2] as Record<string, unknown>
+    expect(passedOptions.input).toBe('hello-from-file')
+    expect(passedOptions.inputFile).toBeUndefined()
+  })
+
+  test('record path with explicit `input` string: forwarded as-is, no swap needed', async () => {
+    const session = makeSession({
+      name: 't',
+      path: path.join(tmp.ref(), 'cassette.json'),
+      loadedFile: null,
+      matcher: null,
+    })
+    setActiveCassette(session)
+
+    await wrappedExeca('node', ['-v'], { input: 'literal' })
+
+    expect(realExecaMock).toHaveBeenCalledTimes(1)
+    const passedOptions = vi.mocked(realExecaMock).mock.calls[0]?.[2] as Record<string, unknown>
+    expect(passedOptions.input).toBe('literal')
+    expect(passedOptions.inputFile).toBeUndefined()
+  })
+})

--- a/tests/unit/matcher.test.ts
+++ b/tests/unit/matcher.test.ts
@@ -58,7 +58,7 @@ describe('defaultCanonicalize', () => {
     expect(canonical.args).toEqual(['remote', 'set-url', 'origin', '<tmp>/remote.git'])
   })
 
-  test('is deterministic — same input produces same output', () => {
+  test('is deterministic: same input produces same output', () => {
     const c = callOf('git', ['log'])
     expect(defaultCanonicalize(c, DEFAULT_CONFIG.redact)).toEqual(
       defaultCanonicalize(c, DEFAULT_CONFIG.redact),
@@ -105,7 +105,7 @@ describe('defaultCanonicalize', () => {
   })
 })
 
-describe('MatcherState — basic matching', () => {
+describe('MatcherState: basic matching', () => {
   test('returns null when no recordings', () => {
     const m = new MatcherState([], defaultCanonicalize, DEFAULT_CONFIG.redact)
     expect(m.findMatch(callOf('git', []))).toBeNull()
@@ -147,7 +147,7 @@ describe('MatcherState — basic matching', () => {
   })
 })
 
-describe('MatcherState — sequential consumption', () => {
+describe('MatcherState: sequential consumption', () => {
   test('first call gets first match, second call gets second match', () => {
     const recs = [recordingOf('git', ['status'], 'first'), recordingOf('git', ['status'], 'second')]
     const m = new MatcherState(recs, defaultCanonicalize, DEFAULT_CONFIG.redact)
@@ -175,7 +175,7 @@ describe('MatcherState — sequential consumption', () => {
   })
 })
 
-describe('MatcherState — ambiguity warning', () => {
+describe('MatcherState: ambiguity warning', () => {
   test('logs warning when multiple unconsumed recordings could match', () => {
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     try {
@@ -192,7 +192,7 @@ describe('MatcherState — ambiguity warning', () => {
   })
 })
 
-describe('MatcherState — custom canonicalize', () => {
+describe('MatcherState: custom canonicalize', () => {
   test('uses provided canonicalize fn (e.g., command-only matching)', () => {
     const commandOnly: Canonicalize = (call) => ({ command: call.command })
     const recs = [recordingOf('git', ['status'])]

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -14,7 +14,7 @@ const baseConfig: RedactConfig = {
 }
 
 describe('public redact() wraps pipeline', () => {
-  test('bundledPatterns: false — input unchanged for credential-shaped value', () => {
+  test('bundledPatterns: false leaves input unchanged for credential-shaped value', () => {
     const r = redact({ source: 'env', value: SAMPLE_GITHUB_PAT_CLASSIC }, baseConfig, {
       counted: false,
     })
@@ -23,7 +23,7 @@ describe('public redact() wraps pipeline', () => {
     expect(r.warnings).toEqual([])
   })
 
-  test('counted: false — emits placeholder without counter', () => {
+  test('counted: false emits placeholder without counter', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const r = redact({ source: 'env', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
       counted: false,
@@ -31,7 +31,7 @@ describe('public redact() wraps pipeline', () => {
     expect(r.output).toBe('<redacted:env:github-pat-classic>')
   })
 
-  test('counted: true — increments counter and returns counted placeholder', () => {
+  test('counted: true increments counter and returns counted placeholder', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const counters = new Map<string, number>()
     const r = redact({ source: 'env', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
@@ -58,7 +58,7 @@ describe('public redact() wraps pipeline', () => {
     expect(r.output).toBe('<redacted:stdin:github-pat-classic>')
   })
 
-  test('source: "stdin", counted: true — counter is per (stdin, rule)', () => {
+  test('source: "stdin", counted: true uses per-(stdin, rule) counter', () => {
     const config: RedactConfig = { ...baseConfig, bundledPatterns: true }
     const counters = new Map<string, number>()
     const r = redact({ source: 'stdin', value: SAMPLE_GITHUB_PAT_CLASSIC }, config, {
@@ -69,7 +69,7 @@ describe('public redact() wraps pipeline', () => {
     expect(counters.get('stdin:github-pat-classic')).toBe(1)
   })
 
-  test('source: "stdin" — custom regex rule fires', () => {
+  test('source: "stdin" custom regex rule fires', () => {
     const config: RedactConfig = {
       ...baseConfig,
       customPatterns: [{ name: 'my-secret', pattern: /SECRET-[A-Z0-9]+/ }],

--- a/tests/unit/tinyexec-adapter.test.ts
+++ b/tests/unit/tinyexec-adapter.test.ts
@@ -102,14 +102,16 @@ describe('tinyexec adapter', () => {
     const session = makeSession({ loadedFile: null })
     setActiveCassette(session)
 
-    vi.mocked(realXMock).mockResolvedValueOnce({
-      stdout: '',
-      stderr: '',
-      exitCode: 1,
-      pid: 1,
-      aborted: true,
-      killed: true,
-    } as never)
+    // Real tinyexec exposes aborted/killed as OutputApi getters on the
+    // pre-await ExecProcess, not on the resolved Output. The wrapper
+    // snapshots them via `proc.aborted` / `proc.killed` before await
+    // resolves (#126). Mock that shape: a Promise carrying the OutputApi
+    // fields as own properties.
+    const fakeProc = Object.assign(
+      Promise.resolve({ stdout: '', stderr: '', exitCode: 1, pid: 1 }),
+      { aborted: true, killed: true },
+    )
+    vi.mocked(realXMock).mockReturnValueOnce(fakeProc as never)
 
     await x('sleep', ['10'])
     expect(session.newRecordings[0]?.result.aborted).toBe(true)
@@ -139,14 +141,12 @@ describe('tinyexec adapter', () => {
     const session = makeSession({ loadedFile: null })
     setActiveCassette(session)
 
-    vi.mocked(realXMock).mockResolvedValueOnce({
-      stdout: '',
-      stderr: '',
-      exitCode: 143,
-      pid: 1,
-      aborted: false,
-      killed: true,
-    } as never)
+    // Same pre-await snapshot contract as the aborted test above.
+    const fakeProc = Object.assign(
+      Promise.resolve({ stdout: '', stderr: '', exitCode: 143, pid: 1 }),
+      { aborted: false, killed: true },
+    )
+    vi.mocked(realXMock).mockReturnValueOnce(fakeProc as never)
 
     await x('sleep', ['10'])
     expect(session.newRecordings[0]?.result.signal).toBe('SIGTERM')

--- a/tests/unit/tinyexec-capture-result.test.ts
+++ b/tests/unit/tinyexec-capture-result.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
-import { _captureResultForTesting } from '../../src/tinyexec.js'
+import { captureResult } from '../../src/tinyexec-capture.js'
 
 describe('tinyexec captureResult: failed derivation', () => {
   test('plain success (exitCode 0, no kill, no abort): failed false', () => {
-    const r = _captureResultForTesting(
+    const r = captureResult(
       { stdout: 'ok', stderr: '', exitCode: 0, killed: false, aborted: false },
       1,
     )
@@ -12,7 +12,7 @@ describe('tinyexec captureResult: failed derivation', () => {
   })
 
   test('non-zero exit: failed true', () => {
-    const r = _captureResultForTesting(
+    const r = captureResult(
       { stdout: '', stderr: 'oops', exitCode: 1, killed: false, aborted: false },
       1,
     )
@@ -20,7 +20,7 @@ describe('tinyexec captureResult: failed derivation', () => {
   })
 
   test('killed: failed true (signal kill collapses to SIGTERM in this adapter)', () => {
-    const r = _captureResultForTesting(
+    const r = captureResult(
       { stdout: '', stderr: '', exitCode: 0, killed: true, aborted: false },
       1,
     )
@@ -29,7 +29,7 @@ describe('tinyexec captureResult: failed derivation', () => {
   })
 
   test('aborted: failed true', () => {
-    const r = _captureResultForTesting(
+    const r = captureResult(
       { stdout: '', stderr: '', exitCode: 0, killed: false, aborted: true },
       1,
     )
@@ -38,11 +38,29 @@ describe('tinyexec captureResult: failed derivation', () => {
   })
 
   test('timedOut and isMaxBuffer not stored (tinyexec does not expose)', () => {
-    const r = _captureResultForTesting(
+    const r = captureResult(
       { stdout: '', stderr: '', exitCode: 0, killed: false, aborted: false },
       1,
     ) as Record<string, unknown>
     expect(r.timedOut).toBeUndefined()
     expect(r.isMaxBuffer).toBeUndefined()
+  })
+
+  test('killed=true on raw records killed=true (#129)', () => {
+    const r = captureResult(
+      { stdout: '', stderr: '', exitCode: 0, killed: true, aborted: false },
+      1,
+    )
+    expect(r.killed).toBe(true)
+    expect(r.signal).toBe('SIGTERM')
+  })
+
+  test('killed=false records killed=false even when signal would be derived elsewhere', () => {
+    const r = captureResult(
+      { stdout: '', stderr: '', exitCode: 0, killed: false, aborted: false },
+      1,
+    )
+    expect(r.killed).toBe(false)
+    expect(r.signal).toBeNull()
   })
 })

--- a/tests/unit/wrapper-resolved-stdin.test.ts
+++ b/tests/unit/wrapper-resolved-stdin.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { _resetForTesting, clearActiveCassette, setActiveCassette } from '../../src/state.js'
+import type { Recording, Result } from '../../src/types.js'
+import { type RunnerHooks, runWrapped } from '../../src/wrapper.js'
+import { restoreEnv } from '../helpers/env.js'
+import { makeSession } from '../helpers/session.js'
+
+const originalMode = process.env.SHELL_CASSETTE_MODE
+const originalAck = process.env.SHELL_CASSETTE_ACK_REDACTION
+
+type Opts = { input?: string; inputFile?: string }
+
+function makeHooks(): {
+  hooks: RunnerHooks<Opts, { stdout: string }>
+  realCall: ReturnType<typeof vi.fn>
+} {
+  const realCall = vi.fn(
+    async (
+      _file: string,
+      _args: readonly string[],
+      _opts: Opts,
+      _resolvedStdin: string | null | undefined,
+    ) => ({ stdout: 'ok' }),
+  )
+  const hooks: RunnerHooks<Opts, { stdout: string }> = {
+    validate: () => undefined,
+    buildCall: async (file, args, opts) => ({
+      command: file,
+      args: [...args],
+      cwd: null,
+      env: {},
+      stdin: opts.input ?? (opts.inputFile !== undefined ? '<file:bytes>' : null),
+    }),
+    realCall,
+    captureResult: (raw): Result => {
+      const r = raw as { stdout: string }
+      return {
+        stdoutLines: r.stdout.split('\n'),
+        stderrLines: [''],
+        allLines: null,
+        exitCode: 0,
+        signal: null,
+        durationMs: 0,
+        aborted: false,
+      }
+    },
+    synthesize: (rec: Recording): { stdout: string } => ({
+      stdout: rec.result.stdoutLines.join('\n'),
+    }),
+  }
+  return { hooks, realCall }
+}
+
+describe('wrapper.realCall: resolvedStdin threading (#102)', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    process.env.SHELL_CASSETTE_ACK_REDACTION = 'true'
+    delete process.env.SHELL_CASSETTE_MODE
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearActiveCassette()
+    restoreEnv('SHELL_CASSETTE_MODE', originalMode)
+    restoreEnv('SHELL_CASSETTE_ACK_REDACTION', originalAck)
+  })
+
+  test('passes resolvedStdin = call.stdin on record path with `input`', async () => {
+    const session = makeSession({
+      name: 't',
+      path: '/tmp/test.json',
+      loadedFile: null,
+      matcher: null,
+    })
+    setActiveCassette(session)
+
+    const { hooks, realCall } = makeHooks()
+    await runWrapped('node', ['-v'], { input: 'literal-stdin' } satisfies Opts, hooks)
+
+    expect(realCall).toHaveBeenCalledTimes(1)
+    expect(realCall.mock.calls[0]?.[3]).toBe('literal-stdin')
+  })
+
+  test('passes resolvedStdin = call.stdin on record path with `inputFile` resolved by buildCall', async () => {
+    const session = makeSession({
+      name: 't',
+      path: '/tmp/test.json',
+      loadedFile: null,
+      matcher: null,
+    })
+    setActiveCassette(session)
+
+    const { hooks, realCall } = makeHooks()
+    await runWrapped('node', ['-v'], { inputFile: '/some/path' } satisfies Opts, hooks)
+
+    expect(realCall).toHaveBeenCalledTimes(1)
+    // makeHooks's buildCall returns '<file:bytes>' as a stand-in for the
+    // resolved stdin; the wrapper must thread that through to realCall.
+    expect(realCall.mock.calls[0]?.[3]).toBe('<file:bytes>')
+  })
+
+  test('passes resolvedStdin = null on record path when neither input nor inputFile is set', async () => {
+    const session = makeSession({
+      name: 't',
+      path: '/tmp/test.json',
+      loadedFile: null,
+      matcher: null,
+    })
+    setActiveCassette(session)
+
+    const { hooks, realCall } = makeHooks()
+    await runWrapped('node', ['-v'], {} satisfies Opts, hooks)
+
+    expect(realCall).toHaveBeenCalledTimes(1)
+    expect(realCall.mock.calls[0]?.[3]).toBeNull()
+  })
+
+  test('passes resolvedStdin = undefined on passthrough mode (buildCall skipped)', async () => {
+    const session = makeSession({
+      name: 't',
+      path: '/tmp/test.json',
+      loadedFile: null,
+      matcher: null,
+      scopeDefault: 'passthrough',
+    })
+    setActiveCassette(session)
+
+    const { hooks, realCall } = makeHooks()
+    await runWrapped('node', ['-v'], { input: 'irrelevant' } satisfies Opts, hooks)
+
+    expect(realCall).toHaveBeenCalledTimes(1)
+    expect(realCall.mock.calls[0]?.[3]).toBeUndefined()
+  })
+
+  test('passes resolvedStdin = undefined on no-active-session passthrough', async () => {
+    // No setActiveCassette() — wrapper falls through to realCall after the
+    // mode check (resolveMode defaults to passthrough when CI=false).
+    const { hooks, realCall } = makeHooks()
+    await runWrapped('node', ['-v'], { input: 'irrelevant' } satisfies Opts, hooks)
+
+    expect(realCall).toHaveBeenCalledTimes(1)
+    expect(realCall.mock.calls[0]?.[3]).toBeUndefined()
+  })
+})

--- a/tests/unit/wrapper-resolved-stdin.test.ts
+++ b/tests/unit/wrapper-resolved-stdin.test.ts
@@ -134,7 +134,7 @@ describe('wrapper.realCall: resolvedStdin threading (#102)', () => {
   })
 
   test('passes resolvedStdin = undefined on no-active-session passthrough', async () => {
-    // No setActiveCassette() — wrapper falls through to realCall after the
+    // No setActiveCassette(): wrapper falls through to realCall after the
     // mode check (resolveMode defaults to passthrough when CI=false).
     const { hooks, realCall } = makeHooks()
     await runWrapped('node', ['-v'], { input: 'irrelevant' } satisfies Opts, hooks)


### PR DESCRIPTION
## Summary

Bundles four open issues into one PR (#72 and #81 deferred as features).

- **#129** — capture `killed` separately from `signal`
- **#126** — tinyexec record path: snapshot `aborted`/`killed` from `ExecProcess` pre-await
- **#102** — skip the `inputFile` double-read by threading `Call.stdin` through `realCall`
- **#128** — move `captureResult` into non-exported modules so `_captureResultForTesting` no longer leaks into the published `.d.ts`

## Why

### #129: replay synth conflated `killed` with `signal !== null`

execa's `killed` is true only when `subprocess.kill()` was called. A process terminated by an external signal has `signal !== null` but `killed === false` on the real result. Replay synth derived `killed: signal !== null`, so cassettes recorded for externally-signaled processes replayed with the wrong `killed` value. Both adapters now store `r.killed === true` on capture; `serialize` emits `killed` when defined; synth uses `rec.result.killed ?? signal !== null` so cassettes recorded before this change still replay correctly.

### #126: tinyexec recorded `aborted: false` / `killed: false` on every call

tinyexec's `Result = PromiseLike<Output> & OutputApi`. Awaiting it drops the OutputApi getters (`aborted`, `killed`) that live on the `ExecProcess`. The adapter previously read those on the awaited Output and got `undefined`, so every cassette stored `aborted: false`/`killed: false` regardless of the call's outcome. The adapter's `realCall` now grabs the `ExecProcess` synchronously, awaits it for the Output, then enriches the resolved value with `proc.aborted` / `proc.killed` before `captureResult` runs.

### #102: `inputFile` was read twice on the record path

`buildCall` reads `inputFile` to populate `Call.stdin` (for canonical matching). Real execa then re-reads the same file because we forwarded the original options. `RunnerHooks.realCall` gains a fourth parameter `resolvedStdin`: `call.stdin` on the record path, `undefined` on passthrough/no-session paths. The execa adapter swaps `options.inputFile` for `input: resolvedStdin` when both are present, so real execa consumes the resolved bytes instead of re-reading the file.

### #128: `_captureResultForTesting` leaked into public sub-paths

The underscore-prefixed test export appeared in the published `.d.ts` for `shell-cassette/execa` and `shell-cassette/tinyexec`. Each adapter now imports `captureResult` from a sibling internal module (`src/execa-capture.ts`, `src/tinyexec-capture.ts`) that is not in `package.json`'s `exports` map. Tests import the same path.

## Schema and API

Schema stays additive. Cassettes without the `killed` field load and replay correctly via the synth fallback. Format stays at version 2.

`RunnerHooks` lives in `src/wrapper.ts`, which is not in the package's `exports` map, so the signature change (4th param) is internal.

## Related Issues

Closes #126
Closes #128
Closes #129
Closes #102

## Test Plan

- [x] ` npm run lint`
- [x] ` npm run typecheck`
- [x] ` npm test` (777 passing, 2 skipped)
- [x] ` npm run build`
- [x] ` tests/integration/record-replay-aborted.test.ts` extended to cover tinyexec
- [x] ` tests/unit/execa-capture-result.test.ts` and `tinyexec-capture-result.test.ts` cover the new `killed` field
- [x] ` tests/integration/wrapper.test.ts` covers synth fallback (legacy cassette without `killed`, new cassette with `killed: false` and `signal: 'SIGTERM'`)
- [x] ` tests/unit/wrapper-resolved-stdin.test.ts` covers `resolvedStdin` threading on all five wrapper paths
- [x] ` tests/unit/execa-input-file-swap.test.ts` covers the execa adapter's `inputFile` -> `input` swap
- [x] ` tests/unit/tinyexec-adapter.test.ts` updated for the pre-await snapshot contract

## Notes

`tests/integration/record-replay-aborted.test.ts` previously had a banner deferring tinyexec coverage to #126. That banner is removed; the file now covers both adapters.

The two tests in `tests/unit/tinyexec-adapter.test.ts` that asserted on `aborted: true` / `killed: true` were rewritten to mock the realistic shape: a `Promise` carrying the OutputApi fields as own properties, mirroring how real tinyexec exposes them. The previous mocks (flat object on `mockResolvedValueOnce`) implicitly tested the buggy path.