### PR TITLE
chore: align package description with repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shell-cassette",
   "version": "0.6.1",
-  "description": "Polly.js, but for shell commands. Record subprocess calls once, replay them deterministically forever.",
+  "description": "Snapshot testing for subprocess output",
   "keywords": [
     "subprocess",
     "spawn",


### PR DESCRIPTION
## Summary

Updates `package.json` description from the original Polly.js-comparison tagline to "Snapshot testing for subprocess output", matching the GitHub repo description.

## Why

The repo description on GitHub was changed via the web UI (no commit), so the npm-published description was never refreshed. npm metadata is locked per published version, so downstream scanners (Socket, etc.) keep showing the old line until a new version publishes with the new field.

This PR is the first half: get the change into the repo. The npm side updates whenever the next version (v0.6.2 or v0.7) publishes.

## Test Plan

- [x] `npm run lint`: clean
- [x] `npm run typecheck`: clean
- [x] `npm test`: 777 passed, 2 skipped
- [x] description string verified: `Snapshot testing for subprocess output`

## Notes

No code or schema changes. README and docs were already free of the old tagline; only `package.json` carried it.