### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to shell-cassette are documented here. The format is based o
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-03
+
+Metadata-only refresh: the npm package description now reads "Snapshot testing for subprocess output", matching the repo description on GitHub. The previous Polly.js-comparison tagline was changed on the GitHub side via the web UI but never synced into `package.json`, so the npm-published description stayed stale through v0.6.0 and v0.6.1. No code, schema, or behavior changes.
+
+### Changed
+
+- **`package.json` description**: now `Snapshot testing for subprocess output`. Aligns the npm metadata with the repo description for downstream package scanners and registry consumers.
+
 ## [0.6.1] - 2026-05-03
 
 Replay shape now matches real execa/tinyexec behavior on failure paths, plus a record-side perf cleanup that retires the `inputFile` double-read deferral noted in v0.6.0. Cassette schema stays at version 2; new `Result` fields are JSON-additive.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-cassette",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Snapshot testing for subprocess output",
   "keywords": [
     "subprocess",


### PR DESCRIPTION
## Summary

Metadata-only release. Republishes v0.6.1's package contents under v0.6.2 so the npm registry picks up the description change merged in #132 (`Snapshot testing for subprocess output`, matching the GitHub repo description).

## Why a release for one metadata field

npm locks `description` (and other metadata) per published version. The only way to update what Socket and similar scanners read is to publish a new version. Without this bump, v0.6.1 keeps showing the old Polly.js tagline indefinitely.

## What's not in this release

No code changes. No schema changes. No test changes. Diff is `package.json` version field + a CHANGELOG entry.

## Related Issues

Refs #132.

## Test Plan

- [x] `npm run lint`: clean
- [x] `npm run typecheck`: clean
- [x] `npm test`: 777 passed, 2 skipped
- [ ] `npm run build && npm publish`: deferred to manual run after merge

## Notes

Post-merge: tag from `main` (`git tag -a v0.6.2 -m "v0.6.2"`), push the tag, `npm run build && npm publish`, verify with `npm view shell-cassette description`, then create a draft release using the v0.6.2 CHANGELOG section.